### PR TITLE
Use hotfixed wasmfx-tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "toml",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime-types",
  "wat",
 ]
@@ -836,7 +836,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime-types",
  "wat",
 ]
@@ -2625,7 +2625,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
- "wit-component 0.14.2 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wit-component 0.14.2 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
@@ -2907,7 +2907,7 @@ name = "verify-component-adapter"
 version = "14.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wat",
 ]
 
@@ -3008,7 +3008,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wit-bindgen",
 ]
 
@@ -3113,7 +3113,7 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.33.1"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "leb128",
 ]
@@ -3136,41 +3136,41 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.10.5"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "anyhow",
  "indexmap 2.0.0",
  "serde",
  "serde_json",
  "spdx",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
 name = "wasm-mutate"
 version = "0.2.34"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
 name = "wasm-smith"
 version = "0.12.17"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "arbitrary",
  "flagset",
  "indexmap 2.0.0",
  "leb128",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.113.1"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "indexmap 2.0.0",
  "semver",
@@ -3242,10 +3242,10 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.2.66"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "anyhow",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
@@ -3273,8 +3273,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-cap-std-sync",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -3389,8 +3389,8 @@ dependencies = [
  "test-programs",
  "tokio",
  "walkdir",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3435,7 +3435,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.11.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wit-parser 0.11.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
@@ -3459,7 +3459,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "wasmtime-runtime",
@@ -3497,8 +3497,8 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "thiserror",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3513,7 +3513,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger 0.10.0",
  "libfuzzer-sys",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3581,7 +3581,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3601,12 +3601,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3676,7 +3676,7 @@ dependencies = [
  "rand",
  "rustix",
  "sptr",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -3695,7 +3695,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
@@ -3808,7 +3808,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",
@@ -3821,7 +3821,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.0.0",
- "wit-parser 0.11.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wit-parser 0.11.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
@@ -3840,18 +3840,18 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "65.0.1"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
 name = "wat"
 version = "1.0.73"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "wast 65.0.1",
 ]
@@ -3979,7 +3979,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime-environ",
 ]
 
@@ -4024,7 +4024,7 @@ dependencies = [
  "similar",
  "target-lexicon",
  "toml",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
  "wasmtime-environ",
  "wat",
  "winch-codegen",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.14.2"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
@@ -4263,10 +4263,10 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
- "wasm-metadata 0.10.5 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
- "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
- "wit-parser 0.11.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix)",
+ "wasm-encoder 0.33.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
+ "wasm-metadata 0.10.5 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
+ "wasmparser 0.113.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
+ "wit-parser 0.11.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1)",
 ]
 
 [[package]]
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.11.1"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.hotfix#1e57203382cf57530e4c92817e50609a9baf8fd1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.42.rev+1#9a01dae1ec7d2020ef8994f38bc37d5d49be0158"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,15 +210,15 @@ is-terminal = "0.4.0"
 wit-bindgen = { version = "0.11.0", default-features = false }
 
 # wasm-tools family:
-wasmparser    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.hotfix" }
-wat           = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.hotfix" }
-wast          = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.hotfix" }
-wasmprinter   = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.hotfix" }
-wasm-encoder  = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.hotfix" }
-wasm-smith    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.hotfix" }
-wasm-mutate   = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.hotfix" }
-wit-parser    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.hotfix" }
-wit-component = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.hotfix" }
+wasmparser    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.rev+1" }
+wat           = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.rev+1" }
+wast          = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.rev+1" }
+wasmprinter   = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.rev+1" }
+wasm-encoder  = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.rev+1" }
+wasm-smith    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.rev+1" }
+wasm-mutate   = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.rev+1" }
+wit-parser    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.rev+1" }
+wit-component = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "wasmfx-tools-1.0.42.rev+1" }
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -95,8 +95,11 @@ impl<'data> ModuleEnvironment<'data> for ModuleEnv {
         self.inner.declare_type_func(wasm_func_type)
     }
 
-    fn declare_type_cont(&mut self, type_index: u32) -> cranelift_wasm::WasmResult<()> {
-        self.inner.declare_type_cont(type_index)
+    fn declare_type_cont(
+        &mut self,
+        ct: cranelift_wasm::WasmContType,
+    ) -> cranelift_wasm::WasmResult<()> {
+        self.inner.declare_type_cont(ct)
     }
 
     fn declare_func_import(

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -12,7 +12,7 @@ use crate::WasmType;
 use crate::{
     DataIndex, DefinedFuncIndex, ElemIndex, FuncIndex, Global, GlobalIndex, GlobalInit, Heap,
     HeapData, HeapStyle, Memory, MemoryIndex, Table, TableIndex, TypeConvert, TypeIndex,
-    WasmFuncType, WasmHeapType, WasmResult,
+    WasmContType, WasmFuncType, WasmHeapType, WasmResult,
 };
 use core::convert::TryFrom;
 use cranelift_codegen::cursor::FuncCursor;
@@ -895,7 +895,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         Ok(())
     }
 
-    fn declare_type_cont(&mut self, _type_index: u32) -> WasmResult<()> {
+    fn declare_type_cont(&mut self, _wasm_cont_type: WasmContType) -> WasmResult<()> {
         unimplemented!()
     }
 

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -10,7 +10,7 @@ use crate::state::FuncTranslationState;
 use crate::{
     DataIndex, ElemIndex, FuncIndex, Global, GlobalIndex, GlobalInit, Heap, HeapData, Memory,
     MemoryIndex, SignatureIndex, Table, TableIndex, Tag, TagIndex, TypeConvert, TypeIndex,
-    WasmError, WasmFuncType, WasmHeapType, WasmResult,
+    WasmContType, WasmError, WasmFuncType, WasmHeapType, WasmResult,
 };
 use core::convert::From;
 use cranelift_codegen::cursor::FuncCursor;
@@ -841,7 +841,7 @@ pub trait ModuleEnvironment<'data>: TypeConvert {
     fn declare_type_func(&mut self, wasm_func_type: WasmFuncType) -> WasmResult<()>;
 
     /// Declares a continuation signature to the environment.
-    fn declare_type_cont(&mut self, type_index: u32) -> WasmResult<()>;
+    fn declare_type_cont(&mut self, wasm_cont_type: WasmContType) -> WasmResult<()>;
 
     /// Translates a type index to its signature index, only called for type
     /// indices which point to functions.

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -56,6 +56,7 @@ pub fn parse_type_section<'a>(
                 environ.declare_type_func(ty)?;
             }
             wasmparser::FuncOrContType::Cont(ty) => {
+                let ty = environ.convert_cont_type(&ty);
                 environ.declare_type_cont(ty)?;
             }
         }

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -5,8 +5,8 @@ use crate::module::{
 use crate::{
     DataIndex, DefinedFuncIndex, ElemIndex, EntityIndex, EntityType, FuncIndex, GlobalIndex,
     GlobalInit, MemoryIndex, ModuleTypesBuilder, PrimaryMap, SignatureIndex, TableIndex,
-    TableInitialValue, Tunables, TypeConvert, TypeIndex, WasmError, WasmFuncType, WasmHeapType,
-    WasmResult, WasmType,
+    TableInitialValue, Tunables, TypeConvert, TypeIndex, WasmContType, WasmError, WasmFuncType,
+    WasmHeapType, WasmResult, WasmType,
 };
 use cranelift_entity::packed_option::ReservedValue;
 use std::borrow::Cow;
@@ -244,6 +244,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             self.declare_type_func(ty)?;
                         }
                         wasmparser::FuncOrContType::Cont(ty) => {
+                            let ty = self.convert_cont_type(&ty);
                             self.declare_type_cont(ty)?;
                         }
                     }
@@ -817,8 +818,8 @@ and for re-adding support for interface types you can see this issue:
         Ok(())
     }
 
-    fn declare_type_cont(&mut self, index: u32) -> WasmResult<()> {
-        let sig_index = self.result.module.types[TypeIndex::from_u32(index)].unwrap_function();
+    fn declare_type_cont(&mut self, wasm: WasmContType) -> WasmResult<()> {
+        let sig_index = self.result.module.types[WasmContType::type_index(wasm)].unwrap_function();
         self.result
             .module
             .types

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -161,6 +161,20 @@ impl WasmFuncType {
     }
 }
 
+/// WebAssembly continuation type -- equivalent of `wasmparser`'s ContType.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct WasmContType(TypeIndex);
+
+impl WasmContType {
+    pub fn new(idx: TypeIndex) -> Self {
+        WasmContType(idx)
+    }
+
+    pub fn type_index(self) -> TypeIndex {
+        self.0
+    }
+}
+
 /// Index type of a function (imported or defined) inside the WebAssembly module.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 pub struct FuncIndex(u32);
@@ -456,6 +470,11 @@ pub trait TypeConvert {
             .map(|t| self.convert_valtype(*t))
             .collect();
         WasmFuncType::new(params, results)
+    }
+
+    /// Converts a wasmparser continuation type to a wasmtime type
+    fn convert_cont_type(&self, ty: &wasmparser::ContType) -> WasmContType {
+        WasmContType(TypeIndex::from_u32(ty.0))
     }
 
     /// Converts a wasmparser value type to a wasmtime type


### PR DESCRIPTION
This patch uses release `wasmfx-tools-1.0.42.rev+1`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
