### PR TITLE
Silence unused variable warning in release mode.

### DIFF
--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -371,11 +371,11 @@ pub fn resume(
     let fiber = unsafe { (*contobj).fiber };
 
     if ENABLE_DEBUG_PRINTING {
-        let running_contobj = instance.typed_continuations_store();
+        let _running_contobj = instance.typed_continuations_store();
         debug_println!(
             "Resuming contobj @ {:p}, previously running contobj is {:p}",
             contobj,
-            running_contobj
+            _running_contobj
         );
     }
 


### PR DESCRIPTION
This patch fixes an unused variable warning triggered in `continuation.rs` when compiling in release mode.

```
warning: unused variable: `running_contobj`
   --> crates/runtime/src/continuation.rs:374:13
    |
374 |         let running_contobj = instance.typed_continuations_store();
    |             ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_running_contobj`
    |
    = note: `#[warn(unused_variables)]` on by default
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
