### PR TITLE
Consolidate translation of resume instructions in FuncEnvironment

### DIFF
--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -698,18 +698,17 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
             .translate_cont_new(builder, state, func, arg_types, return_types)
     }
 
-    /// Translates a resume instruction and returns a triple (vmctx,
-    /// signal, tag), where vmctx is the base address of the VM
-    /// context, signal is high bit of the resume result, and tag is
-    /// the index of the control tag supplied to suspend (if the
-    /// signal is 1).
+    /// TODO(dhil): write documentatio.n
     fn translate_resume(
         &mut self,
         builder: &mut cranelift_frontend::FunctionBuilder,
-        state: &cranelift_wasm::FuncTranslationState,
-        cont: ir::Value,
-    ) -> cranelift_wasm::WasmResult<(ir::Value, ir::Value, ir::Value)> {
-        self.inner.translate_resume(builder, state, cont)
+        type_index: u32,
+        contref: ir::Value,
+        resume_args: &[ir::Value],
+        resumetable: &[(u32, ir::Block)],
+    ) -> Vec<ir::Value> {
+        self.inner
+            .translate_resume(builder, type_index, contref, resume_args, resumetable)
     }
 
     /// TODO(dhil): write documentation.
@@ -728,10 +727,9 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
     fn translate_suspend(
         &mut self,
         builder: &mut cranelift_frontend::FunctionBuilder,
-        state: &cranelift_wasm::FuncTranslationState,
         tag_index: ir::Value,
     ) -> ir::Value {
-        return self.inner.translate_suspend(builder, state, tag_index);
+        return self.inner.translate_suspend(builder, tag_index);
     }
 
     /// TODO

--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -698,7 +698,7 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
             .translate_cont_new(builder, state, func, arg_types, return_types)
     }
 
-    /// TODO(dhil): write documentatio.n
+    /// TODO(frank-emrich): write documentation.
     fn translate_resume(
         &mut self,
         builder: &mut cranelift_frontend::FunctionBuilder,

--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -729,7 +729,7 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         builder: &mut cranelift_frontend::FunctionBuilder,
         tag_index: ir::Value,
     ) -> ir::Value {
-        return self.inner.translate_suspend(builder, tag_index);
+        self.inner.translate_suspend(builder, tag_index)
     }
 
     /// TODO

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -709,9 +709,11 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
     fn translate_resume(
         &mut self,
         _builder: &mut FunctionBuilder,
-        _state: &FuncTranslationState,
-        _cont: ir::Value,
-    ) -> WasmResult<(ir::Value, ir::Value, ir::Value)> {
+        _type_index: u32,
+        _contref: ir::Value,
+        _resume_args: &[ir::Value],
+        _resumetable: &[(u32, ir::Block)],
+    ) -> Vec<ir::Value> {
         todo!()
     }
 
@@ -728,7 +730,6 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
     fn translate_suspend(
         &mut self,
         _builder: &mut FunctionBuilder,
-        _state: &FuncTranslationState,
         _tag_index: ir::Value,
     ) -> ir::Value {
         todo!()

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -21,6 +21,7 @@ use cranelift_entity::PrimaryMap;
 use cranelift_frontend::FunctionBuilder;
 use std::boxed::Box;
 use std::string::ToString;
+use std::vec::Vec;
 use wasmparser::{FuncValidator, FunctionBody, Operator, ValidatorResources, WasmFeatures};
 
 /// The value of a WebAssembly global variable.
@@ -629,17 +630,17 @@ pub trait FuncEnvironment: TargetEnvironment {
         return_types: &[wasmtime_types::WasmType],
     ) -> WasmResult<ir::Value>;
 
-    /// Translates a resume instruction and returns a triple (vmctx,
-    /// signal, tag), where vmctx is the base address of the VM
-    /// context, signal is high bit of the resume result, and tag is
-    /// the index of the control tag supplied to suspend (if the
-    /// signal is 1).
+    /// Translates resume instructions.
+    /// Returns the values returned by the instruction (i.e., the values
+    /// returned by the resumed continuation once it returns normally)
     fn translate_resume(
         &mut self,
         builder: &mut FunctionBuilder,
-        state: &FuncTranslationState,
-        cont: ir::Value,
-    ) -> WasmResult<(ir::Value, ir::Value, ir::Value)>;
+        type_index: u32,
+        contref: ir::Value,
+        resume_args: &[ir::Value],
+        resumetable: &[(u32, ir::Block)],
+    ) -> Vec<ir::Value>;
 
     /// TODO(dhil): write documentation.
     fn translate_resume_throw(
@@ -654,7 +655,6 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn translate_suspend(
         &mut self,
         builder: &mut FunctionBuilder,
-        state: &FuncTranslationState,
         tag_index: ir::Value,
     ) -> ir::Value;
 

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -129,45 +129,6 @@ pub fn block_with_params_wasmtype<PE: TargetEnvironment + ?Sized>(
     Ok(block)
 }
 
-/// Create a synthetic suspend block (used to wrap a resume table).
-pub fn suspend_block<PE: TargetEnvironment + ?Sized>(
-    builder: &mut FunctionBuilder,
-    _environ: &PE,
-) -> WasmResult<ir::Block> {
-    let block = builder.create_block();
-    Ok(block)
-}
-
-/// Create a synthetic resume table entry block.
-pub fn resumetable_entry_block<PE: TargetEnvironment + ?Sized>(
-    builder: &mut FunctionBuilder,
-    _environ: &PE,
-) -> WasmResult<ir::Block> {
-    let block = builder.create_block();
-    Ok(block)
-}
-
-/// Create a synthetic resume table forwarding block.
-pub fn resumetable_forwarding_block<PE: TargetEnvironment + ?Sized>(
-    builder: &mut FunctionBuilder,
-    _environ: &PE,
-) -> WasmResult<ir::Block> {
-    let block = builder.create_block();
-
-    Ok(block)
-}
-
-/// Create a synthetic return block (used to wrap the return
-/// continuation of resume).
-pub fn return_block<PE: TargetEnvironment + ?Sized>(
-    builder: &mut FunctionBuilder,
-    _environ: &PE,
-) -> WasmResult<ir::Block> {
-    let block = builder.create_block();
-
-    Ok(block)
-}
-
 /// Compute the maximum number of arguments that a suspension may
 /// supply.
 pub fn resumetable_max_num_tag_payloads<PE: crate::FuncEnvironment + ?Sized>(


### PR DESCRIPTION
Currently, the translation of `resume` instructions is somewhat arbitrarily split between `translate_operator` in `code_translator.rs` and `func_environ.rs`. The low-level nature of translating `resume` requires a lot of functionality found only in the latter, which required us to add many helper functions to the `FuncEnvironment` trait (i.e., `spec.rs`). As a result, every change to the translation requires a lot of unnecessary busywork (updating `spec.rs`, `dummy.rs` and `env.rs`).

This particularly obstructs my subsequent optimisation work.

This PR consolidates all of the logic for translating `resume` in `func_environ.rs`. The only work left to do inside  `translate_operator` is very minor, specifically the interaction with the stack and interpreting the resume table. The `FuncTranslationState` is not even handed to the logic inside `func_environ.rs` anymore.

This is purely a refactoring, there are no changes to the actual translation logic.

