### PR TITLE
Remove libcall cont_obj_has_state_invoked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,6 +1830,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2024,16 @@ checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
 dependencies = [
  "env_logger 0.10.0",
  "log",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2742,6 +2773,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.0.1",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3671,6 +3719,7 @@ dependencies = [
  "mach",
  "memfd",
  "memoffset",
+ "num_enum",
  "once_cell",
  "paste",
  "proptest",
@@ -4164,6 +4213,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winx"

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -67,8 +67,6 @@ macro_rules! foreach_builtin_function {
             /// pointing at the next free slot. Marks the next `arg_count`
             /// entries in that buffer as used.
             cont_obj_occupy_next_args_slots(vmctx: vmctx, contobj: pointer, arg_count: i32) -> pointer;
-            /// Returns a boolean indicating whether the state of the continutation object is `Invoked`
-            cont_obj_has_state_invoked(vmctx: vmctx, contobj: pointer) -> i32;
             /// Returns the continuation object corresponding to the given continuation reference.
             cont_ref_get_cont_obj(vmctx: vmctx, contref: pointer) -> pointer;
             /// Drops the given continuation object. Currently unused.

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -30,6 +30,7 @@ paste = "1.0.3"
 encoding_rs = { version = "0.8.31", optional = true }
 sptr = "0.3.2"
 wasm-encoder = { workspace = true }
+num_enum = "0.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3.2"

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -2,6 +2,7 @@
 
 use crate::vmcontext::{VMArrayCallFunction, VMFuncRef, VMOpaqueContext, ValRaw};
 use crate::{Instance, TrapReason};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::cmp;
 use std::mem;
 use std::ptr;
@@ -55,7 +56,8 @@ impl Payloads {
 }
 
 /// Encodes the life cycle of a `ContinuationObject`.
-#[derive(PartialEq)]
+#[derive(PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(i32)]
 enum State {
     /// The `ContinuationObject` has been created, but `resume` has never been
     /// called on it. During this stage, we may add arguments using `cont.bind`.
@@ -104,8 +106,13 @@ pub mod offsets {
 
     /// Offsets of fields in `ContinuationObject`
     pub mod continuation_object {
+        use crate::continuation::ContinuationObject;
+        use memoffset::offset_of;
+
         /// Offset of `parent` field
-        pub const PARENT: i32 = 0;
+        pub const PARENT: i32 = offset_of!(ContinuationObject, parent) as i32;
+        /// Offset of `state` field
+        pub const STATE: i32 = offset_of!(ContinuationObject, state) as i32;
     }
 }
 

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -58,7 +58,7 @@ impl Payloads {
 /// Encodes the life cycle of a `ContinuationObject`.
 #[derive(PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(i32)]
-enum State {
+pub enum State {
     /// The `ContinuationObject` has been created, but `resume` has never been
     /// called on it. During this stage, we may add arguments using `cont.bind`.
     Allocated,
@@ -215,18 +215,6 @@ pub fn cont_obj_deallocate_tag_return_values_buffer(obj: *mut ContinuationObject
     let _: Vec<u128> =
         unsafe { Vec::from_raw_parts((*payloads).data, (*payloads).length, (*payloads).capacity) };
     obj.tag_return_values = None;
-}
-
-/// TODO
-#[inline(always)]
-pub fn cont_obj_has_state_invoked(obj: *mut ContinuationObject) -> bool {
-    // We use this function to determine whether a contination object is in initialisation mode or
-    // not.
-    // FIXME(frank-emrich) Rename this function to make it clearer that we shouldn't call
-    // it in `Returned` state.
-    assert!(unsafe { (*obj).state != State::Returned });
-
-    return unsafe { (*obj).state == State::Invoked };
 }
 
 /// TODO

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -828,15 +828,6 @@ fn cont_ref_get_cont_obj(
     )? as *mut u8)
 }
 
-fn cont_obj_has_state_invoked(
-    _instance: &mut Instance,
-    contobj: *mut u8,
-) -> Result<u32, TrapReason> {
-    Ok(crate::continuation::cont_obj_has_state_invoked(
-        contobj as *mut crate::continuation::ContinuationObject,
-    ) as u32)
-}
-
 fn cont_obj_occupy_next_tag_returns_slots(
     _instance: &mut Instance,
     contobj: *mut u8,


### PR DESCRIPTION
This PR removes the libcall `cont_obj_has_state_invoked` and replaces it with a direct implementation.

To this end, we derive `IntoPrimitive` and `TryFromPrimitive` for the `State` enum, using the `num_enum` crate (already used elsewhere within wasmtime), to convert between `State` and integers.