### PR TITLE
Enable compilation of `ref.null` with `cont`/`nocont` heap type.

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1988,7 +1988,9 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             WasmHeapType::Func | WasmHeapType::TypedFunc(_) => {
                 pos.ins().iconst(self.pointer_type(), 0)
             }
-            WasmHeapType::Cont | WasmHeapType::NoCont => todo!(), // TODO(dhil): revisit this later.
+            WasmHeapType::Cont | WasmHeapType::NoCont => {
+                pos.ins().iconst(self.pointer_type(), 0) // TODO(dhil): I haven't really thought this through.
+            }
             WasmHeapType::Extern => pos.ins().null(self.reference_type(ht)),
         })
     }


### PR DESCRIPTION
This patch translate `ref.null cont` and `ref.null nocont` to the constant `0` with `pointer_type` given by the compilation environment. I haven't thought this through deeply, but I think they should be treated the same as `func` and typed function references.