### PR TITLE
Implement `AssertSuspension`

### DIFF
--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -266,7 +266,7 @@ pub fn suspend(instance: &mut Instance, tag_index: u32) {
     let running = unsafe {
         running
             .as_ref()
-            .expect("Calling suspend outside of a continuation")
+            .expect("Calling suspend outside of a continuation") // TODO(dhil): we should emit the trap UnhandledTag here.
     };
 
     let stack_ptr = unsafe { (*running.fiber).stack().top().unwrap() };

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -501,7 +501,7 @@ where
             AssertSuspension {
                 span: _,
                 exec,
-                message
+                message,
             } => {
                 let err = match self.perform_execute(exec) {
                     Ok(_) => bail!("expected tag to be unhandled"),

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -363,7 +363,11 @@ where
         {
             Ok(())
         } else {
-            bail!("assert_suspension: expected '{}', got '{}'", expected, actual)
+            bail!(
+                "assert_suspension: expected '{}', got '{}'",
+                expected,
+                actual
+            )
         }
     }
 

--- a/tests/misc_testsuite/typed-continuations/unhandled.wast
+++ b/tests/misc_testsuite/typed-continuations/unhandled.wast
@@ -1,10 +1,23 @@
 ;; Test unhandled suspension
 
 (module
+  (type $ft (func))
+  (type $ct (cont $ft))
   (tag $t)
 
-  (func $main
+  (func $suspend
     (suspend $t))
+  (elem declare func $suspend)
+
+  (func $unhandled-0 (export "unhandled-0")
+    (call $suspend))
+
+  (func $unhandled-1 (export "unhandled-1")
+    (resume $ct (cont.new $ct (ref.func $suspend))))
 )
 
-(assert_suspension (invoke "main") "unhandled")
+;; TODO(dhil): Suspending on the main thread currently causes an
+;; unrecoverable panic. Instead we should emit the UnhandledTrap trap
+;; code; once this has been implemented the below test should pass.
+;;(assert_suspension (invoke "unhandled-0") "unhandled")
+(assert_suspension (invoke "unhandled-1") "unhandled")

--- a/tests/misc_testsuite/typed-continuations/unhandled.wast
+++ b/tests/misc_testsuite/typed-continuations/unhandled.wast
@@ -1,0 +1,10 @@
+;; Test unhandled suspension
+
+(module
+  (tag $t)
+
+  (func $main
+    (suspend $t))
+)
+
+(assert_suspension (invoke "main") "unhandled")


### PR DESCRIPTION
This patch provides an implementation for the Wast `assert_suspension` directive, enabling us to run test cases that tests for unhandled suspensions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
