### PR TITLE
Move continuation related types into own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,6 +3439,7 @@ dependencies = [
  "wasmtime-cache",
  "wasmtime-cli-flags",
  "wasmtime-component-util",
+ "wasmtime-continuations",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-explorer",
@@ -3487,6 +3488,15 @@ name = "wasmtime-component-util"
 version = "15.0.0"
 
 [[package]]
+name = "wasmtime-continuations"
+version = "15.0.0"
+dependencies = [
+ "memoffset",
+ "num_enum",
+ "wasmtime-fibre",
+]
+
+[[package]]
 name = "wasmtime-cranelift"
 version = "15.0.0"
 dependencies = [
@@ -3504,9 +3514,9 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmparser 0.116.0 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.50)",
+ "wasmtime-continuations",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
- "wasmtime-runtime",
  "wasmtime-versioned-export-macros",
 ]
 
@@ -3715,7 +3725,6 @@ dependencies = [
  "mach",
  "memfd",
  "memoffset",
- "num_enum",
  "once_cell",
  "paste",
  "proptest",
@@ -3724,6 +3733,7 @@ dependencies = [
  "sptr",
  "wasm-encoder 0.36.1 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.50)",
  "wasmtime-asm-macros",
+ "wasmtime-continuations",
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-fibre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ wasmtime-wasi-nn = { workspace = true, optional = true }
 wasmtime-wasi-threads = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
 wasmtime-runtime = { workspace = true }
+wasmtime-continuations = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 target-lexicon = { workspace = true }
@@ -67,6 +68,7 @@ log = { workspace = true }
 filecheck = { workspace = true }
 tempfile = { workspace = true }
 wasmtime-runtime = { workspace = true }
+wasmtime-continuations = { workspace = true }
 tokio = { workspace = true, features = ["rt", "time", "macros", "rt-multi-thread"] }
 wast = { workspace = true }
 criterion = "0.5.0"
@@ -146,6 +148,7 @@ wasmtime-types = { path = "crates/types", version = "15.0.0" }
 wasmtime-jit = { path = "crates/jit", version = "=15.0.0" }
 wasmtime-jit-debug = { path = "crates/jit-debug", version = "=15.0.0" }
 wasmtime-runtime = { path = "crates/runtime", version = "=15.0.0" }
+wasmtime-continuations = { path = "crates/continuations", version = "=15.0.0" }
 wasmtime-wast = { path = "crates/wast", version = "=15.0.0" }
 wasmtime-wasi = { path = "crates/wasi", version = "15.0.0", default-features = false }
 wasmtime-wasi-http = { path = "crates/wasi-http", version = "=15.0.0", default-features = false }

--- a/crates/continuations/Cargo.toml
+++ b/crates/continuations/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wasmtime-continuations"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wasmtime-fibre = { workspace = true }
+num_enum = "0.5"
+memoffset = "0.9.0"

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -1,0 +1,137 @@
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use std::ptr;
+use wasmtime_fibre::Fiber;
+
+/// TODO
+#[allow(dead_code)]
+pub const ENABLE_DEBUG_PRINTING: bool = false;
+
+#[macro_export]
+macro_rules! debug_println {
+    ($( $args:expr ),+ ) => {
+        #[cfg(debug_assertions)]
+        if ENABLE_DEBUG_PRINTING {
+            println!($($args),*);
+        }
+    }
+}
+
+/// Makes the types available that we use for various fields.
+pub mod types {
+    /// Types used by `Payloads` struct
+    pub mod payloads {
+        /// type of length
+        pub type Length = usize;
+        /// type of capacity
+        pub type Capacity = usize;
+        /// Type of the entries in the actual buffer
+        pub type DataEntries = u128;
+    }
+}
+
+pub type ContinuationFiber = Fiber<'static, (), u32, ()>;
+
+pub struct Payloads {
+    /// Number of currently occupied slots.
+    pub length: types::payloads::Length,
+    /// Number of slots in the data buffer. Note that this is *not* the size of
+    /// the buffer in bytes!
+    pub capacity: types::payloads::Capacity,
+    /// This is null if and only if capacity (and thus also `length`) are 0.
+    pub data: *mut u128,
+}
+
+impl Payloads {
+    pub fn new(capacity: usize) -> Payloads {
+        let data = if capacity == 0 {
+            ptr::null_mut()
+        } else {
+            let mut args = Vec::with_capacity(capacity);
+            let args_ptr = args.as_mut_ptr();
+            args.leak();
+            args_ptr
+        };
+        return Payloads {
+            length: 0,
+            capacity,
+            data,
+        };
+    }
+}
+
+/// Encodes the life cycle of a `ContinuationObject`.
+#[derive(PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(i32)]
+pub enum State {
+    /// The `ContinuationObject` has been created, but `resume` has never been
+    /// called on it. During this stage, we may add arguments using `cont.bind`.
+    Allocated,
+    /// `resume` has been invoked at least once on the `ContinuationObject`,
+    /// meaning that the function passed to `cont.new` has started executing.
+    /// Note that this state does not indicate whether the execution of this
+    /// function is currently suspended or not.
+    Invoked,
+    /// The function originally passed to `cont.new` has returned normally.
+    /// Note that there is no guarantee that a ContinuationObject will ever
+    /// reach this status, as it may stay suspended until being dropped.
+    Returned,
+}
+
+/// TODO
+#[repr(C)]
+pub struct ContinuationObject {
+    pub parent: *mut ContinuationObject,
+
+    pub fiber: *mut ContinuationFiber,
+
+    /// Used to store
+    /// 1. The arguments to the function passed to cont.new
+    /// 2. The return values of that function
+    /// Note that this is *not* used for tag payloads.
+    pub args: Payloads,
+
+    // Once a continuation is suspended, this buffer is used to hold payloads
+    // provided by cont.bind and resume and received at the suspend site.
+    // In particular, this may only be Some when `state` is `Invoked`.
+    pub tag_return_values: Payloads,
+
+    pub state: State,
+}
+
+/// M:1 Many-to-one mapping. A single ContinuationObject may be
+/// referenced by multiple ContinuationReference, though, only one
+/// ContinuationReference may hold a non-null reference to the object
+/// at a given time.
+#[repr(C)]
+pub struct ContinuationReference(pub Option<*mut ContinuationObject>);
+
+/// Defines offsets of the fields in the types defined earlier
+pub mod offsets {
+    /// Offsets of fields in `Payloads`
+    pub mod payloads {
+        use crate::Payloads;
+        use memoffset::offset_of;
+
+        /// Offset of `capacity` field
+        pub const CAPACITY: i32 = offset_of!(Payloads, capacity) as i32;
+        /// Offset of `data` field
+        pub const DATA: i32 = offset_of!(Payloads, data) as i32;
+        /// Offset of `length` field
+        pub const LENGTH: i32 = offset_of!(Payloads, length) as i32;
+    }
+
+    /// Offsets of fields in `ContinuationObject`
+    pub mod continuation_object {
+        use crate::ContinuationObject;
+        use memoffset::offset_of;
+
+        /// Offset of `args` field
+        pub const ARGS: i32 = offset_of!(ContinuationObject, args) as i32;
+        /// Offset of `parent` field
+        pub const PARENT: i32 = offset_of!(ContinuationObject, parent) as i32;
+        /// Offset of `state` field
+        pub const STATE: i32 = offset_of!(ContinuationObject, state) as i32;
+        /// Offset of `tag_return_values` field
+        pub const TAG_RETURN_VALUES: i32 = offset_of!(ContinuationObject, tag_return_values) as i32;
+    }
+}

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -21,7 +21,7 @@ cranelift-entity = { workspace = true }
 cranelift-native = { workspace = true }
 cranelift-control = { workspace = true }
 wasmtime-cranelift-shared = { workspace = true }
-wasmtime-runtime = { workspace = true }
+wasmtime-continuations = { workspace = true }
 wasmparser = { workspace = true }
 target-lexicon = { workspace = true }
 gimli = { workspace = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -16,6 +16,7 @@ wasmtime-asm-macros = { workspace = true }
 wasmtime-environ = { workspace = true }
 wasmtime-fiber = { workspace = true, optional = true }
 wasmtime-fibre = { workspace = true }
+wasmtime-continuations = { workspace = true }
 wasmtime-jit-debug = { workspace = true, features = ["gdb_jit_int"] }
 wasmtime-versioned-export-macros = { workspace = true }
 libc = { version = "0.2.112", default-features = false }
@@ -30,7 +31,6 @@ paste = "1.0.3"
 encoding_rs = { version = "0.8.31", optional = true }
 sptr = "0.3.2"
 wasm-encoder = { workspace = true }
-num_enum = "0.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3.2"

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -2,144 +2,17 @@
 
 use crate::vmcontext::{VMArrayCallFunction, VMFuncRef, VMOpaqueContext, ValRaw};
 use crate::{Instance, TrapReason};
-use num_enum::{IntoPrimitive, TryFromPrimitive};
+//use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::cmp;
 use std::mem;
 use std::ptr;
+use wasmtime_continuations::{debug_println, ENABLE_DEBUG_PRINTING};
+pub use wasmtime_continuations::{
+    ContinuationFiber, ContinuationObject, ContinuationReference, Payloads, State,
+};
 use wasmtime_fibre::{Fiber, FiberStack, Suspend};
 
-type ContinuationFiber = Fiber<'static, (), u32, ()>;
 type Yield = Suspend<(), u32, ()>;
-
-#[allow(dead_code)]
-const ENABLE_DEBUG_PRINTING: bool = false;
-
-macro_rules! debug_println {
-    ($( $args:expr ),+ ) => {
-        #[cfg(debug_assertions)]
-        if ENABLE_DEBUG_PRINTING {
-            println!($($args),*);
-        }
-    }
-}
-
-/// Makes the types available that we use for various fields.
-pub mod types {
-    /// Types used by `Payloads` struct
-    pub mod payloads {
-        /// type of length
-        pub type Length = usize;
-        /// type of capacity
-        pub type Capacity = usize;
-        /// Type of the entries in the actual buffer
-        pub type DataEntries = u128;
-    }
-}
-
-struct Payloads {
-    /// Number of currently occupied slots.
-    length: types::payloads::Length,
-    /// Number of slots in the data buffer. Note that this is *not* the size of
-    /// the buffer in bytes!
-    capacity: types::payloads::Capacity,
-    /// This is null if and only if capacity (and thus also `length`) are 0.
-    data: *mut u128,
-}
-
-impl Payloads {
-    fn new(capacity: usize) -> Payloads {
-        let data = if capacity == 0 {
-            ptr::null_mut()
-        } else {
-            let mut args = Vec::with_capacity(capacity);
-            let args_ptr = args.as_mut_ptr();
-            args.leak();
-            args_ptr
-        };
-        return Payloads {
-            length: 0,
-            capacity,
-            data,
-        };
-    }
-}
-
-/// Encodes the life cycle of a `ContinuationObject`.
-#[derive(PartialEq, IntoPrimitive, TryFromPrimitive)]
-#[repr(i32)]
-pub enum State {
-    /// The `ContinuationObject` has been created, but `resume` has never been
-    /// called on it. During this stage, we may add arguments using `cont.bind`.
-    Allocated,
-    /// `resume` has been invoked at least once on the `ContinuationObject`,
-    /// meaning that the function passed to `cont.new` has started executing.
-    /// Note that this state does not indicate whether the execution of this
-    /// function is currently suspended or not.
-    Invoked,
-    /// The function originally passed to `cont.new` has returned normally.
-    /// Note that there is no guarantee that a ContinuationObject will ever
-    /// reach this status, as it may stay suspended until being dropped.
-    Returned,
-}
-
-/// TODO
-#[repr(C)]
-pub struct ContinuationObject {
-    parent: *mut ContinuationObject,
-
-    fiber: *mut ContinuationFiber,
-
-    /// Used to store
-    /// 1. The arguments to the function passed to cont.new
-    /// 2. The return values of that function
-    /// Note that this is *not* used for tag payloads.
-    args: Payloads,
-
-    // Once a continuation is suspended, this buffer is used to hold payloads
-    // provided by cont.bind and resume and received at the suspend site.
-    // In particular, this may only be Some when `state` is `Invoked`.
-    tag_return_values: Payloads,
-
-    state: State,
-}
-
-/// M:1 Many-to-one mapping. A single ContinuationObject may be
-/// referenced by multiple ContinuationReference, though, only one
-/// ContinuationReference may hold a non-null reference to the object
-/// at a given time.
-#[repr(C)]
-pub struct ContinuationReference(Option<*mut ContinuationObject>);
-
-/// Defines offsets of the fields in the types defined earlier
-pub mod offsets {
-    /// Offsets of fields in `Payloads`
-    pub mod payloads {
-        use crate::continuation::Payloads;
-        use memoffset::offset_of;
-
-        /// Offset of `capacity` field
-        pub const CAPACITY: i32 = offset_of!(Payloads, capacity) as i32;
-        /// Offset of `data` field
-        pub const DATA: i32 = offset_of!(Payloads, data) as i32;
-        /// Offset of `length` field
-        pub const LENGTH: i32 = offset_of!(Payloads, length) as i32;
-    }
-
-    /// Offsets of fields in `ContinuationObject`
-    pub mod continuation_object {
-        use crate::continuation::ContinuationObject;
-        use memoffset::offset_of;
-
-        /// Offset of `args` field
-        pub const ARGS: i32 = offset_of!(ContinuationObject, args) as i32;
-        /// Offset of `parent` field
-        pub const PARENT: i32 = offset_of!(ContinuationObject, parent) as i32;
-        /// Offset of `state` field
-        pub const STATE: i32 = offset_of!(ContinuationObject, state) as i32;
-        /// Offset of `tag_return_values` field
-        pub const TAG_RETURN_VALUES: i32 = offset_of!(ContinuationObject, tag_return_values) as i32;
-    }
-}
 
 /// TODO
 #[inline(always)]


### PR DESCRIPTION
We currently have a situation where types such as `ContinuationObject` and related constants are defined in the crate `wasmtime-runtime`. This means that we cannot access any of our definitions from crates that must not depend on the `runtime` crate (for example, if it causes cyclic dependencies).

This PR remedies this situation by moving the definitions of types and constant from `continuation.rs` in the runtime crate into a new crate, `wasmtime-continuations`. As this crate has no (non-trivial) dependencies, we can use it from everywhere. Note that the runtime crate continues to contain the definitions of the continuation-related libcalls.