### PR TITLE
Reliably construct backtraces when stack switching is enabled.

### DIFF
--- a/crates/runtime/src/traphandlers/backtrace.rs
+++ b/crates/runtime/src/traphandlers/backtrace.rs
@@ -280,7 +280,9 @@ impl Backtrace {
 
             // Because the stack always grows down, the older FP must be greater
             // than the current FP.
-            assert!(next_older_fp > fp, "{next_older_fp:#x} > {fp:#x}");
+            // TODO(dhil): The following assertion is not always true
+            // in the presence of stack switching.
+            //assert!(next_older_fp > fp, "{next_older_fp:#x} > {fp:#x}");
             fp = next_older_fp;
         }
     }


### PR DESCRIPTION
This patch is a follow up on PR #35. It partially addresses issue presence of stack switching as older frame pointers are not guaranteed to be greater than the current frame pointer (e.g. tracing across stack boundaries).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
