### PR TITLE
Debug printing from generated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,6 +3511,7 @@ dependencies = [
  "gimli",
  "log",
  "object",
+ "regex",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.116.0 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.50)",

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -29,6 +29,7 @@ object = { workspace = true, features = ['write'] }
 thiserror = { workspace = true }
 cfg-if = { workspace = true }
 wasmtime-versioned-export-macros = { workspace = true }
+regex = "1.10"
 
 [features]
 all-arch = ["cranelift-codegen/all-arch"]

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -207,6 +207,122 @@ mod typed_continuation_helpers {
     use std::mem;
     use wasmtime_environ::BuiltinFunctionIndex;
 
+    /// Low-level implementation of debug printing. Do not use directly; see
+    /// debug_println! macro for doing actual printing.
+    ///
+    /// Takes a string literal which may contain placeholders similarly to those
+    /// supported by `std::fmt`.
+    ///
+    /// Currently supported placeholders:
+    /// {}       for unsinged integers
+    /// {:p}     for printing pointers (in hex form)
+    ///
+    /// When printing, we replace them with the corresponding values in `vals`.
+    /// Thus, the number of placeholders in `s` must match the number of entries
+    /// in `vals`.
+    fn emit_debug_print<'a>(
+        env: &mut crate::func_environ::FuncEnvironment<'a>,
+        builder: &mut FunctionBuilder,
+        s: &'static str,
+        vals: &[ir::Value],
+    ) {
+        let print_s_infix = |env: &mut crate::func_environ::FuncEnvironment<'a>,
+                             builder: &mut FunctionBuilder,
+                             start: usize,
+                             end: usize| {
+            if start < end {
+                let s: &'static str = &s[start..end];
+                // This is quite dodgy, which is why we can only do this for
+                // debugging purposes:
+                // At jit time, we take a pointer to the slice of the (static)
+                // string, thus yielding an address within wasmtime's DATA
+                // section. This pointer is hard-code into generated code. We do
+                // not emit any kind of relocation information, which means that
+                // this breaks if we were to store the generated code and use it
+                // during subsequent executions of wasmtime (e.g., when using
+                // wasmtime compile).
+                let ptr = s.as_ptr();
+                let ptr = builder.ins().iconst(env.pointer_type(), ptr as i64);
+                let len = s.len();
+                let len = builder.ins().iconst(I64, len as i64);
+
+                let index = BuiltinFunctionIndex::tc_print_str();
+                let sig = env.builtin_function_signatures.tc_print_str(builder.func);
+                env.generate_builtin_call_no_return_val(builder, index, sig, vec![ptr, len]);
+            }
+        };
+        let print_int = |env: &mut crate::func_environ::FuncEnvironment<'a>,
+                         builder: &mut FunctionBuilder,
+                         val: ir::Value| {
+            let index = BuiltinFunctionIndex::tc_print_int();
+            let sig = env.builtin_function_signatures.tc_print_int(builder.func);
+            env.generate_builtin_call_no_return_val(builder, index, sig, vec![val]);
+        };
+        let print_pointer = |env: &mut crate::func_environ::FuncEnvironment<'a>,
+                             builder: &mut FunctionBuilder,
+                             ptr: ir::Value| {
+            let index = BuiltinFunctionIndex::tc_print_pointer();
+            let sig = env
+                .builtin_function_signatures
+                .tc_print_pointer(builder.func);
+            env.generate_builtin_call_no_return_val(builder, index, sig, vec![ptr]);
+        };
+
+        if wasmtime_continuations::ENABLE_DEBUG_PRINTING {
+            // Regex matching { followed by something without { or } followed by }.
+            let placeholder_re = regex::Regex::new(r"\{[^{}]*\}").unwrap();
+
+            let mut prev_end = 0;
+            let mut i = 0;
+            for ph_match in placeholder_re.find_iter(s) {
+                let start = ph_match.start();
+                let end = ph_match.end();
+
+                assert!(
+                    i < vals.len(),
+                    "Must supply as many entries in vals as there are placeholders in the string"
+                );
+
+                print_s_infix(env, builder, prev_end, start);
+                match ph_match.as_str() {
+                    "{}" => print_int(env, builder, vals[i]),
+                    "{:p}" => print_pointer(env, builder, vals[i]),
+                    u => panic!("Unsupported placeholder in debug_print input string: {}", u),
+                }
+                prev_end = end;
+                i += 1;
+            }
+            assert_eq!(
+                i,
+                vals.len(),
+                "Must supply as many entries in vals as there are placeholders in the string"
+            );
+
+            print_s_infix(env, builder, prev_end, s.len());
+        }
+    }
+
+    /// Emits code to print debug information. Only actually prints in debug
+    /// builds and if debug printing flag is enabled. The third and all
+    /// following arguments are like those to println!: A string literal with
+    /// placeholders followed by the actual values.
+    ///
+    /// Summary of arguments:
+    /// * `env` - Type &mut crate::func_environ::FuncEnvironment<'a>
+    /// * `builder` - Type &mut FunctionBuilder,
+    /// * `msg` : String literal, containing placeholders like those supported by println!
+    /// * remaining arguments: ir::Values filled into the placeholders in `msg`
+    #[allow(unused_macros)]
+    macro_rules! emit_debug_println {
+        ($env : expr, $builder : expr, $msg : literal, $( $arg:expr ),*) => {
+            let msg_newline : &'static str= std::concat!(
+                $msg,
+                "\n"
+            );
+            emit_debug_print($env, $builder, msg_newline, &[$($arg),*]);
+        }
+    }
+
     #[derive(Copy, Clone)]
     pub struct ContinuationObject {
         address: ir::Value,
@@ -443,6 +559,17 @@ mod typed_continuation_helpers {
             let zero = builder.ins().iconst(ir::types::I64, 0);
             emit_debug_assert_ne(builder, required_capacity, zero);
 
+            if cfg!(debug_assertions) {
+                let data = self.get_data(builder);
+                emit_debug_println!(
+                    env,
+                    builder,
+                    "[ensure_capacity] contobj {:p}, buffer is {:p}",
+                    self.contobj(),
+                    data
+                );
+            }
+
             let capacity = self.get_capacity(builder);
 
             let sufficient_capacity_block = builder.create_block();
@@ -464,6 +591,14 @@ mod typed_continuation_helpers {
             {
                 builder.switch_to_block(insufficient_capacity_block);
                 builder.seal_block(insufficient_capacity_block);
+
+                emit_debug_println!(
+                    env,
+                    builder,
+                    "[ensure_capacity] need to increase capacity from {} to {}",
+                    capacity,
+                    required_capacity
+                );
 
                 if cfg!(debug_assertions) {
                     // We must only re-allocate while there is no data in the buffer.

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -208,7 +208,7 @@ mod typed_continuation_helpers {
     use wasmtime_environ::BuiltinFunctionIndex;
 
     /// Low-level implementation of debug printing. Do not use directly; see
-    /// debug_println! macro for doing actual printing.
+    /// `emit_debug_println!` macro for doing actual printing.
     ///
     /// Takes a string literal which may contain placeholders similarly to those
     /// supported by `std::fmt`.

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -106,6 +106,16 @@ macro_rules! foreach_builtin_function {
             /// `old_size` must be smaller than `new_size`
             tc_reallocate(vmctx: vmctx, ptr: pointer, old_size: i64, new_size: i64, align: i64) -> pointer;
 
+            // General-purpose printing functions.
+            //
+            /// Prints a string. Note that we transfer the string not as C strings, but as 'static str,
+            /// represented as a pointer and a length.
+            tc_print_str(vmctx: vmctx, s: pointer, len : i64);
+            /// TODO
+            tc_print_int(vmctx: vmctx, arg : i64);
+            /// TODO
+            tc_print_pointer(vmctx: vmctx, arg : pointer);
+
             /// Invoked before malloc returns.
             check_malloc(vmctx: vmctx, addr: i32, len: i32) -> i32;
             /// Invoked before the free returns.

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -867,3 +867,17 @@ fn tc_reallocate(
 
     tc_allocate(instance, new_size, align)
 }
+
+fn tc_print_str(_instance: &mut Instance, s: *const u8, len: u64) {
+    let str = unsafe { std::slice::from_raw_parts(s, len as usize) };
+    let s = std::str::from_utf8(str).unwrap();
+    print!("{}", s);
+}
+
+fn tc_print_int(_instance: &mut Instance, arg: u64) {
+    print!("{}", arg);
+}
+
+fn tc_print_pointer(_instance: &mut Instance, arg: *const u8) {
+    print!("{:p}", arg);
+}

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -60,6 +60,15 @@ pub struct CompileCommand {
 impl CompileCommand {
     /// Executes the command.
     pub fn execute(mut self) -> Result<()> {
+        // Note that because of this, `cargo test` does not succeed when
+        // `ENABLE_DEBUG_PRINTING` is true, simply because some tests directly
+        // test `wasmtime compile`. However, all typed continuation unit tests
+        // are still usable.
+        assert!(
+            !wasmtime_continuations::ENABLE_DEBUG_PRINTING,
+            "Cannot store compiled code while debug printing is enabled"
+        );
+
         self.common.init_logging()?;
 
         let mut config = self.common.config(self.target.as_deref())?;


### PR DESCRIPTION
This PR adds the facility to print from jitted code for debugging purposes.

This is done using the new macro `emit_debug_println!`, which is designed to be similar to Rust's `println!`.

Thus, analogously to writing 
```
println!("Hello {}, my favorite number is stored at {:p}, name, pointer)
```

we may now write
```
emit_debug_println!(env, builder, "Hello {}, my favorite number is stored at {:p}, name, pointer)
```

where `env` and `builder` are a `FuncEnvironment` and `FunctionBuilder`.

Note that using string literals with placeholders in them is not just to make the new printing functionality similar to the existing Rust macros, but there is also a technical reason: Using string literals means that we need not worry about allocation of string objects passed between generated code and the libcalls doing the actual pritning: We can just pass strings as pointers into static data.

