### PR TITLE
Handle duplicated tag entries on `resume`.

### DIFF
--- a/tests/misc_testsuite/typed-continuations/dup.wast
+++ b/tests/misc_testsuite/typed-continuations/dup.wast
@@ -1,0 +1,26 @@
+(module
+  (type $ft (func))
+  (type $ct (cont $ft))
+
+  (tag $t)
+
+  (func $f
+    (suspend $t))
+  (elem declare func $f)
+
+  (func $dup (export "dup") (result i32)
+    (block $on_t-1 (result (ref $ct))
+      (block $on_t-2 (result (ref $ct))
+        (resume $ct (tag $t $on_t-1)
+                    ;;(tag $t $on_t-2)
+                    (cont.new $ct (ref.func $f)))
+        (return (i32.const 128))
+      ) ;; on_t-2 [ (ref $ct) ]
+      (drop)
+      (return (i32.const 256))
+    ) ;; on_t-1 [ (ref $ct) ]
+    (drop)
+    (return (i32.const 512)))
+)
+
+(assert_return (invoke "dup") (i32.const 512))


### PR DESCRIPTION
The specification allows duplicated occurrences of the same `tag` in filter list on the `resume` instruction (and `resume_throw` instruction). Only the first occurrence is relevant as it shadows the subsequent ones, however, cranelift complains if we emit duplicated case labels in a `Switch`, e.g.

```
$ ./target/debug/wasmtime wast -W=exceptions,function-references,typed-continuations dup.wast
thread '<unnamed>' panicked at 'Tried to set the same entry 0 twice', cranelift/frontend/src/switch.rs:58:9
```

This patch compiles only the first occurrence of a tag and skips subsequent entries.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
