### PR TITLE
Assertions in generated code print source location

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -297,6 +297,12 @@ mod typed_continuation_helpers {
         }
     }
 
+    
+    /// Low-level implementation of assertion mechanism. Use emit_debug_* macros
+    /// instead.
+    ///
+    /// If `ENABLE_DEBUG_PRINTING` is enabled, `error_str` is printed before
+    /// trapping in case of an assertion violation.
     fn emit_debug_assert_generic<'a>(
         env: &mut crate::func_environ::FuncEnvironment<'a>,
         builder: &mut FunctionBuilder,
@@ -329,6 +335,13 @@ mod typed_continuation_helpers {
         }
     }
 
+    /// Low-level implementation of assertion mechanism. Use emit_debug_* macros
+    /// instead.
+    ///
+    /// If `ENABLE_DEBUG_PRINTING` is enabled, `error_str` is printed before
+    /// trapping in case of an assertion violation. Here, `error_str` is expected
+    /// to contain two placeholders, such as {} or {:p}, which are replaced with
+    /// `v1` and `v2` when printing.
     fn emit_debug_assert_icmp<'a>(
         env: &mut crate::func_environ::FuncEnvironment<'a>,
         builder: &mut FunctionBuilder,
@@ -365,6 +378,7 @@ mod typed_continuation_helpers {
         }
     }
 
+    /// Used to implement other macros, do not use directly.
     macro_rules! emit_debug_assert_icmp {
         ( $env : expr,
             $builder: expr,


### PR DESCRIPTION
Currently, assertion violations cause programs to unceremoniously crash.

This PR uses the new printing facilitities added in #43 and combines it with the assertion mechanism, to make assertion violations more informative. The new macros `emit_debug_assert*` are analogous to the corresponding Rust `debug_assert*` macros, replacing already existing functions that we already had for emitting assertions.

What is new is that when `ENABLE_DEBUG_PRINTING` is set, these new assertion macros can now print the source location in the Rust code where they where defined when assertions are violated, making it much easier to identify which assertion was actually violated.

Those macros that assert that a certain relation holds (e.g., `emit_debug_assert_eq`) also print a description of the violation, including the offending values.
