### PR TITLE
Store Payloads object in VMContext and manage with generated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
  "wasmparser 0.116.0 (git+https://github.com/wasmfx/wasmfx-tools?tag=wasmfx-tools-1.0.50)",
  "wasmprinter",
  "wasmtime-component-util",
+ "wasmtime-continuations",
  "wasmtime-types",
  "wat",
 ]

--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -756,7 +756,7 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
     fn typed_continuations_load_payloads(
         &mut self,
         builder: &mut cranelift_frontend::FunctionBuilder,
-        valtypes: &[WasmType],
+        valtypes: &[ir::Type],
     ) -> std::vec::Vec<ir::Value> {
         self.inner
             .typed_continuations_load_payloads(builder, valtypes)

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -761,7 +761,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
     fn typed_continuations_load_payloads(
         &mut self,
         _builder: &mut FunctionBuilder,
-        _valtypes: &[WasmType],
+        _valtypes: &[ir::Type],
     ) -> Vec<ir::Value> {
         todo!()
     }

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -679,7 +679,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn typed_continuations_load_payloads(
         &mut self,
         builder: &mut FunctionBuilder,
-        valtypes: &[wasmtime_types::WasmType],
+        valtypes: &[ir::Type],
     ) -> std::vec::Vec<ir::Value>;
 
     /// TODO

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -746,6 +746,9 @@ mod typed_continuation_helpers {
             builder.seal_block(sufficient_capacity_block);
         }
 
+        /// Loads n entries from this Payloads object, where n is the length of
+        /// `load_types`, which also gives the types of the values to load.
+        /// Loading starts at index 0 of the Payloads object.
         pub fn load_data_entries<'a>(
             &self,
             env: &mut crate::func_environ::FuncEnvironment<'a>,
@@ -775,6 +778,10 @@ mod typed_continuation_helpers {
             values
         }
 
+        /// Stores the given `values` in this Payloads object, beginning at
+        /// index 0. This expects the Payloads object to be empty (i.e., current
+        /// length is 0), and to be of sufficient capacity to store |`values`|
+        /// entries.
         pub fn store_data_entries<'a>(
             &self,
             env: &mut crate::func_environ::FuncEnvironment<'a>,
@@ -785,7 +792,10 @@ mod typed_continuation_helpers {
 
             if cfg!(debug_assertions) {
                 let capacity = self.get_capacity(builder);
+                let length = self.get_length(builder);
+                let zero = builder.ins().iconst(I64, 0);
                 emit_debug_assert_ule!(env, builder, store_count, capacity);
+                emit_debug_assert_eq!(env, builder, length, zero);
             }
 
             let memflags = ir::MemFlags::trusted();

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -14,6 +14,7 @@ edition.workspace = true
 anyhow = { workspace = true }
 cranelift-entity = { workspace = true }
 wasmtime-types = { workspace = true }
+wasmtime-continuations = { workspace = true }
 wasmparser = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -66,24 +66,6 @@ macro_rules! foreach_builtin_function {
             tc_new_cont_ref(vmctx: vmctx, contobj: pointer) -> pointer;
 
 
-            /// Allocates a buffer large enough for storing `element_count` tag
-            /// payloads and stores it in the `VMContext` in such a way that
-            /// subsequent calls to `get_payload_buffer` will return the same
-            /// buffer.
-            /// Returns a pointer to that buffer.
-            /// Such a payload buffer is only used to store payloads provided
-            /// at a suspend site and read in a corresponding handler.
-            tc_allocate_payload_buffer(vmctx: vmctx, element_count: i32) -> pointer;
-            /// Counterpart to `alllocate_payload_buffer`, deallocating the
-            /// buffer. For debugging purposes, `expected_element_capacity`
-            /// should be the same value passed when allocating.
-            tc_deallocate_payload_buffer(vmctx: vmctx, expected_element_capacity: i32);
-            /// Returns pointer to the payload buffer, whose function was described earlier.
-            /// `expected_element_capacity` should be the same value passed when
-            /// allocating.
-            tc_get_payload_buffer(vmctx: vmctx, expected_element_capacity: i32) -> pointer;
-
-
             /// Sets the tag return values of `child_contobj` to those of `parent_contobj`.
             /// This is implemented by exchanging the pointers to the underlying buffers.
             /// `child_contobj` must not currently have a tag return value buffer.

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -95,7 +95,7 @@ pub struct VMOffsets<P> {
     // NOTE(dhil): The following field is used as "global" to store
     // the arguments of continuations and payloads of suspensions.
     typed_continuations_store: u32,
-    typed_continuations_payloads_ptr: u32,
+    typed_continuations_payloads: u32,
 }
 
 /// Trait used for the `ptr` representation of the field of `VMOffsets`
@@ -357,7 +357,7 @@ impl<P: PtrSize> VMOffsets<P> {
         }
 
         calculate_sizes! {
-            typed_continuations_payloads_ptr: "typed continuations payloads",
+            typed_continuations_payloads: "typed continuations payloads object",
             typed_continuations_store: "typed continuations store",
             defined_func_refs: "module functions",
             defined_globals: "defined globals",
@@ -412,7 +412,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             defined_func_refs: 0,
             size: 0,
             typed_continuations_store: 0,
-            typed_continuations_payloads_ptr: 0,
+            typed_continuations_payloads: 0,
         };
 
         // Convenience functions for checked addition and multiplication.
@@ -477,7 +477,10 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             ),
             size(typed_continuations_store)
                 = ret.ptr.size(),
-            size(typed_continuations_payloads_ptr) = ret.ptr.size(),
+             align(std::mem::align_of::<wasmtime_continuations::Payloads>() as u32),
+            //align(u32::from(ret.ptr.size())),
+            size(typed_continuations_payloads) = std::mem::size_of::<wasmtime_continuations::Payloads>() as u32,
+            //size(typed_continuations_payloads) = ret.ptr.size() * 3,
             align(16), // TODO(dhil): This could probably be done more
                        // efficiently by packing the pointer into the above 16 byte
                        // alignment
@@ -736,10 +739,10 @@ impl<P: PtrSize> VMOffsets<P> {
         self.typed_continuations_store
     }
 
-    /// The offset of the typed continuations payloads pointer.
+    /// The offset of the typed continuations Payloads object.
     #[inline]
-    pub fn vmctx_typed_continuations_payloads_ptr(&self) -> u32 {
-        self.typed_continuations_payloads_ptr
+    pub fn vmctx_typed_continuations_payloads(&self) -> u32 {
+        self.typed_continuations_payloads
     }
 
     /// Return the size of the `VMContext` allocation.

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -477,10 +477,11 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             ),
             size(typed_continuations_store)
                 = ret.ptr.size(),
-             align(std::mem::align_of::<wasmtime_continuations::Payloads>() as u32),
-            //align(u32::from(ret.ptr.size())),
-            size(typed_continuations_payloads) = std::mem::size_of::<wasmtime_continuations::Payloads>() as u32,
-            //size(typed_continuations_payloads) = ret.ptr.size() * 3,
+
+            align(std::mem::align_of::<wasmtime_continuations::Payloads>() as u32),
+            size(typed_continuations_payloads) =
+                std::mem::size_of::<wasmtime_continuations::Payloads>() as u32,
+
             align(16), // TODO(dhil): This could probably be done more
                        // efficiently by packing the pointer into the above 16 byte
                        // alignment
@@ -733,13 +734,18 @@ impl<P: PtrSize> VMOffsets<P> {
         self.builtin_functions
     }
 
-    /// The offset of the typed continuations store.
+    /// The offset of the typed continuations store, where we save the currently
+    /// running continuation (as a pointer to a
+    /// wasmtime_comtinuations::ContinuationObject, or null if running on main
+    /// stack).
     #[inline]
     pub fn vmctx_typed_continuations_store(&self) -> u32 {
         self.typed_continuations_store
     }
 
-    /// The offset of the typed continuations Payloads object.
+    /// The offset of the typed continuations payloads object, stored as a as a
+    /// wasmtime_comtinuations::Payloads object. Used to transfer payloads from
+    /// suspend calls to the corresponding handler/resume instructions.
     #[inline]
     pub fn vmctx_typed_continuations_payloads(&self) -> u32 {
         self.typed_continuations_payloads

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -88,61 +88,61 @@ pub fn drop_cont_obj(contobj: *mut ContinuationObject) {
         unsafe { Vec::from_raw_parts(payloads.data, payloads.length, payloads.capacity) };
 }
 
-/// TODO
-pub fn allocate_payload_buffer(instance: &mut Instance, element_count: usize) -> *mut u128 {
-    // In the current design, we allocate a `Vec<u128>` and store a pointer to
-    // it in the `VMContext` payloads pointer slot. We then return the pointer
-    // to the `Vec`'s data, not to the `Vec` itself.
-    // This is mostly for debugging purposes, since the `Vec` stores its size.
-    // Alternatively, we may allocate the buffer ourselves here and store the
-    // pointer directly in the `VMContext`. This would avoid one level of
-    // pointer indirection.
+// /// TODO
+// pub fn allocate_payload_buffer(instance: &mut Instance, element_count: usize) -> *mut u128 {
+//     // In the current design, we allocate a `Vec<u128>` and store a pointer to
+//     // it in the `VMContext` payloads pointer slot. We then return the pointer
+//     // to the `Vec`'s data, not to the `Vec` itself.
+//     // This is mostly for debugging purposes, since the `Vec` stores its size.
+//     // Alternatively, we may allocate the buffer ourselves here and store the
+//     // pointer directly in the `VMContext`. This would avoid one level of
+//     // pointer indirection.
 
-    let payload_ptr =
-        unsafe { instance.get_typed_continuations_payloads_ptr_mut() as *mut *mut Vec<u128> };
+//     let payload_ptr =
+//         unsafe { instance.get_typed_continuations_payloads_ptr_mut() as *mut *mut Vec<u128> };
 
-    // FIXME(frank-emrich) This doesn't work, yet, because we don't zero-initialize the
-    // payload pointer field in the VMContext, meaning that it may initially contain garbage.
-    // Ensure that there isn't an active payload buffer. If there was, we didn't clean up propertly
-    // assert!(unsafe { (*payload_ptr).is_null() });
+//     // FIXME(frank-emrich) This doesn't work, yet, because we don't zero-initialize the
+//     // payload pointer field in the VMContext, meaning that it may initially contain garbage.
+//     // Ensure that there isn't an active payload buffer. If there was, we didn't clean up propertly
+//     // assert!(unsafe { (*payload_ptr).is_null() });
 
-    let mut vec = Box::new(Vec::<u128>::with_capacity(element_count));
+//     let mut vec = Box::new(Vec::<u128>::with_capacity(element_count));
 
-    let vec_data = (*vec).as_mut_ptr();
-    unsafe {
-        *payload_ptr = Box::into_raw(vec);
-    }
-    return vec_data;
-}
+//     let vec_data = (*vec).as_mut_ptr();
+//     unsafe {
+//         *payload_ptr = Box::into_raw(vec);
+//     }
+//     return vec_data;
+// }
 
-/// TODO
-pub fn deallocate_payload_buffer(instance: &mut Instance, element_count: usize) {
-    let payload_ptr =
-        unsafe { instance.get_typed_continuations_payloads_ptr_mut() as *mut *mut Vec<u128> };
+// /// TODO
+// pub fn deallocate_payload_buffer(instance: &mut Instance, element_count: usize) {
+//     let payload_ptr =
+//         unsafe { instance.get_typed_continuations_payloads_ptr_mut() as *mut *mut Vec<u128> };
 
-    let vec = unsafe { Box::from_raw(*payload_ptr) };
+//     let vec = unsafe { Box::from_raw(*payload_ptr) };
 
-    // If these don't match something went wrong.
-    assert_eq!(vec.capacity(), element_count);
+//     // If these don't match something went wrong.
+//     assert_eq!(vec.capacity(), element_count);
 
-    unsafe { *payload_ptr = ptr::null_mut() };
+//     unsafe { *payload_ptr = ptr::null_mut() };
 
-    // payload buffer destroyed when `vec` goes out of scope
-}
+//     // payload buffer destroyed when `vec` goes out of scope
+// }
 
-/// TODO
-pub fn get_payload_buffer(instance: &mut Instance, element_count: usize) -> *mut u128 {
-    let payload_ptr =
-        unsafe { instance.get_typed_continuations_payloads_ptr_mut() as *mut *mut Vec<u128> };
+// /// TODO
+// pub fn get_payload_buffer(instance: &mut Instance, element_count: usize) -> *mut u128 {
+//     let payload_ptr =
+//         unsafe { instance.get_typed_continuations_payloads_ptr_mut() as *mut *mut Vec<u128> };
 
-    let vec = unsafe { (*payload_ptr).as_mut().unwrap() };
+//     let vec = unsafe { (*payload_ptr).as_mut().unwrap() };
 
-    // If these don't match something went wrong.
-    assert_eq!(vec.capacity(), element_count);
+//     // If these don't match something went wrong.
+//     assert_eq!(vec.capacity(), element_count);
 
-    let vec_data = vec.as_mut_ptr();
-    return vec_data;
-}
+//     let vec_data = vec.as_mut_ptr();
+//     return vec_data;
+// }
 
 /// TODO
 #[inline(always)]

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -88,62 +88,6 @@ pub fn drop_cont_obj(contobj: *mut ContinuationObject) {
         unsafe { Vec::from_raw_parts(payloads.data, payloads.length, payloads.capacity) };
 }
 
-// /// TODO
-// pub fn allocate_payload_buffer(instance: &mut Instance, element_count: usize) -> *mut u128 {
-//     // In the current design, we allocate a `Vec<u128>` and store a pointer to
-//     // it in the `VMContext` payloads pointer slot. We then return the pointer
-//     // to the `Vec`'s data, not to the `Vec` itself.
-//     // This is mostly for debugging purposes, since the `Vec` stores its size.
-//     // Alternatively, we may allocate the buffer ourselves here and store the
-//     // pointer directly in the `VMContext`. This would avoid one level of
-//     // pointer indirection.
-
-//     let payload_ptr =
-//         unsafe { instance.get_typed_continuations_payloads_ptr_mut() as *mut *mut Vec<u128> };
-
-//     // FIXME(frank-emrich) This doesn't work, yet, because we don't zero-initialize the
-//     // payload pointer field in the VMContext, meaning that it may initially contain garbage.
-//     // Ensure that there isn't an active payload buffer. If there was, we didn't clean up propertly
-//     // assert!(unsafe { (*payload_ptr).is_null() });
-
-//     let mut vec = Box::new(Vec::<u128>::with_capacity(element_count));
-
-//     let vec_data = (*vec).as_mut_ptr();
-//     unsafe {
-//         *payload_ptr = Box::into_raw(vec);
-//     }
-//     return vec_data;
-// }
-
-// /// TODO
-// pub fn deallocate_payload_buffer(instance: &mut Instance, element_count: usize) {
-//     let payload_ptr =
-//         unsafe { instance.get_typed_continuations_payloads_ptr_mut() as *mut *mut Vec<u128> };
-
-//     let vec = unsafe { Box::from_raw(*payload_ptr) };
-
-//     // If these don't match something went wrong.
-//     assert_eq!(vec.capacity(), element_count);
-
-//     unsafe { *payload_ptr = ptr::null_mut() };
-
-//     // payload buffer destroyed when `vec` goes out of scope
-// }
-
-// /// TODO
-// pub fn get_payload_buffer(instance: &mut Instance, element_count: usize) -> *mut u128 {
-//     let payload_ptr =
-//         unsafe { instance.get_typed_continuations_payloads_ptr_mut() as *mut *mut Vec<u128> };
-
-//     let vec = unsafe { (*payload_ptr).as_mut().unwrap() };
-
-//     // If these don't match something went wrong.
-//     assert_eq!(vec.capacity(), element_count);
-
-//     let vec_data = vec.as_mut_ptr();
-//     return vec_data;
-// }
-
 /// TODO
 #[inline(always)]
 pub fn cont_new(

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -1130,6 +1130,11 @@ impl Instance {
         *self.vmctx_plus_offset_mut(offsets.vmctx_typed_continuations_store()) =
             std::ptr::null_mut::<crate::continuation::ContinuationObject>();
 
+        // Initialize the Payloads object to be empty
+        let vmctx_payloads: *mut wasmtime_continuations::Payloads =
+            self.vmctx_plus_offset_mut(offsets.vmctx_typed_continuations_payloads());
+        *vmctx_payloads = wasmtime_continuations::Payloads::new(0);
+
         // Initialize the imports
         debug_assert_eq!(imports.functions.len(), module.num_imported_funcs);
         ptr::copy_nonoverlapping(
@@ -1286,7 +1291,7 @@ impl Instance {
 
     /// TODO
     pub unsafe fn get_typed_continuations_payloads_ptr_mut(&mut self) -> *mut u32 {
-        self.vmctx_plus_offset_mut(self.offsets().vmctx_typed_continuations_payloads_ptr())
+        self.vmctx_plus_offset_mut(self.offsets().vmctx_typed_continuations_payloads())
     }
 }
 

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -822,18 +822,6 @@ fn tc_cont_obj_forward_tag_return_values_buffer(
     );
 }
 
-fn tc_allocate_payload_buffer(instance: &mut Instance, element_count: u32) -> *mut u8 {
-    crate::continuation::allocate_payload_buffer(instance, element_count as usize) as *mut u8
-}
-
-fn tc_deallocate_payload_buffer(instance: &mut Instance, expected_element_capacity: u32) {
-    crate::continuation::deallocate_payload_buffer(instance, expected_element_capacity as usize);
-}
-
-fn tc_get_payload_buffer(instance: &mut Instance, expected_element_capacity: u32) -> *mut u8 {
-    crate::continuation::get_payload_buffer(instance, expected_element_capacity as usize) as *mut u8
-}
-
 fn tc_drop_cont_obj(_instance: &mut Instance, contobj: *mut u8) {
     crate::continuation::drop_cont_obj(contobj as *mut crate::continuation::ContinuationObject)
 }

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -653,11 +653,12 @@ fn instance_too_large() -> Result<()> {
 
     let engine = Engine::new(&config)?;
     let expected = "\
-instance allocation for this module requires 256 bytes which exceeds the \
+instance allocation for this module requires 272 bytes which exceeds the \
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
- * 62.50% - 160 bytes - instance state management
- * 6.25% - 16 bytes - jit store state
+ * 58.82% - 160 bytes - instance state management
+ * 8.82% - 24 bytes - typed continuations payloads object
+ * 5.88% - 16 bytes - jit store state
 ";
     match Module::new(&engine, "(module)") {
         Ok(_) => panic!("should have failed to compile"),
@@ -671,11 +672,11 @@ configured maximum of 16 bytes; breakdown of allocation requirement:
     lots_of_globals.push_str(")");
 
     let expected = "\
-instance allocation for this module requires 1856 bytes which exceeds the \
+instance allocation for this module requires 1872 bytes which exceeds the \
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
- * 8.62% - 160 bytes - instance state management
- * 86.21% - 1600 bytes - defined globals
+ * 8.55% - 160 bytes - instance state management
+ * 85.47% - 1600 bytes - defined globals
 ";
     match Module::new(&engine, &lots_of_globals) {
         Ok(_) => panic!("should have failed to compile"),


### PR DESCRIPTION
Currently, the `VMContext` contains a pointer to a "payloads" object, which is used to store the values provided to a `suspend` invocation and makes them available in the handler. This object is opaque in the sense that we only manage it through libcalls, in particular using a libcall to extract a pointer to and underlying buffer with the actual data.

This PR changes that, instead putting a `wasmtime_continuations::Payloads` (basically a vector) object directly into the `VMContext`, which we then manipulate using generated code. We already have plenty of infrastructure for generating such code, as such `Payloads` objects are also used in `ContinuationObject`s. 
