### PR TITLE
Re-use Payloads object buffers

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -631,6 +631,7 @@ mod typed_continuation_helpers {
             builder.ins().iadd(data, byte_offset)
         }
 
+        #[allow(dead_code)]
         pub fn deallocate_buffer<'a>(
             &self,
             env: &mut crate::func_environ::FuncEnvironment<'a>,

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -815,6 +815,11 @@ mod typed_continuation_helpers {
             self.set_length(builder, store_count);
         }
 
+        pub fn clear(&self, builder: &mut FunctionBuilder) {
+            let zero = builder.ins().iconst(I64, 0);
+            self.set_length(builder, zero);
+        }
+
         /// Silences some unused function warnings
         #[allow(dead_code)]
         pub fn dummy<'a>(
@@ -823,6 +828,8 @@ mod typed_continuation_helpers {
         ) {
             let _index = BuiltinFunctionIndex::tc_allocate();
             let _sig = env.builtin_function_signatures.tc_allocate(builder.func);
+            let _index = BuiltinFunctionIndex::tc_deallocate();
+            let _sig = env.builtin_function_signatures.tc_deallocate(builder.func);
         }
     }
 }
@@ -3597,7 +3604,10 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
             values = vmctx_payloads.load_data_entries(self, builder, valtypes);
 
-            vmctx_payloads.deallocate_buffer(self, builder);
+            // In theory, we way want to deallocate the buffer instead of just
+            // clearing it if its size is above a certain threshold. That would
+            // avoid keeping a large object unnecessarily long.
+            vmctx_payloads.clear(builder);
         }
         values
     }
@@ -3629,7 +3639,10 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 offset += self.offsets.ptr.maximum_value_size() as i32;
             }
 
-            tag_return_values.deallocate_buffer(self, builder);
+            // In theory, we way want to deallocate the buffer instead of just
+            // clearing it if its size is above a certain threshold. That would
+            // avoid keeping a large object unnecessarily long.
+            tag_return_values.clear(builder);
         }
         values
     }

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -51,7 +51,7 @@ pub fn cont_obj_forward_tag_return_values_buffer(
     assert!(parent.state == State::Invoked);
     assert!(child.state == State::Invoked);
 
-    assert!(child.tag_return_values.capacity == 0);
+    assert!(child.tag_return_values.length == 0);
 
     mem::swap(&mut child.tag_return_values, &mut parent.tag_return_values);
 }


### PR DESCRIPTION
Currently, we use `Payloads` objects for example to
- Propagate payloads from `suspend` calls to handlers
- From `resume` calls back to the `suspend` sites

In both cases, we proceed as follows:
1. Allocate a sufficiently sized data buffer within the `Payloads` object first
2. Write the payload data to it
3. Read the payload data on the receiving side
4. Deallocate the buffer within the `Payloads` object.

This PR changes this behavior: Instead of deallocating the buffer in step 4, we simply mark it as empty, but keep the buffer. Thus, we may change step 1 so that we first check if the `Payloads` object under consideration already has a sufficiently sized buffer. If so, we reuse it, and only need to allocate a new one otherwise.