### PR TITLE
Move operations from resume libcall to generated code

### DIFF
--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -77,6 +77,13 @@ pub enum State {
     Returned,
 }
 
+impl State {
+    pub fn discriminant(&self) -> i32 {
+        // This is well-defined for an enum with repr(i32).
+        unsafe { *(self as *const Self as *const i32) }
+    }
+}
+
 /// TODO
 #[repr(C)]
 pub struct ContinuationObject {

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -462,7 +462,7 @@ mod typed_continuation_helpers {
     }
 
     #[derive(Copy, Clone)]
-    pub struct Vmctx {
+    pub struct VMContext {
         address: ir::Value,
         pointer_type: ir::Type,
     }
@@ -864,9 +864,9 @@ mod typed_continuation_helpers {
         }
     }
 
-    impl Vmctx {
-        pub fn new(address: ir::Value, pointer_type: ir::Type) -> Vmctx {
-            Vmctx {
+    impl VMContext {
+        pub fn new(address: ir::Value, pointer_type: ir::Type) -> VMContext {
+            VMContext {
                 address,
                 pointer_type,
             }
@@ -3513,7 +3513,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             let vmctx = builder.ins().global_value(self.pointer_type(), vmctx);
 
             // We mark `resume_contobj` as the currently running one
-            let vmctx = tc::Vmctx::new(vmctx, self.pointer_type());
+            let vmctx = tc::VMContext::new(vmctx, self.pointer_type());
             vmctx.set_active_continuation(self, builder, resume_contobj);
 
             // We mark `resume_contobj` to be invoked
@@ -3921,7 +3921,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         let vmctx = self.vmctx(builder.cursor().func);
         let base_addr = builder.ins().global_value(pointer_type, vmctx);
 
-        let vmctx = tc::Vmctx::new(base_addr, pointer_type);
+        let vmctx = tc::VMContext::new(base_addr, pointer_type);
 
         vmctx.get_active_continuation(self, builder)
     }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -1279,6 +1279,7 @@ impl Instance {
         unsafe { *self.vmctx_plus_offset_mut(self.offsets().vmctx_typed_continuations_store()) }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn set_typed_continuations_store(
         &mut self,
         contobj: *mut crate::continuation::ContinuationObject,


### PR DESCRIPTION
This PR refactors the `resume` libcall and its call sites (in generated code). The idea is that afterwards, the `resume` libcall should only be a slim wrapper around `wasmtime_fibre::Fiber::resume`. The only additional logic remaining in the libcall function is the encoding of the result as a u64. (ordinary return vs. suspend + tag information).

Thus, the following is moved out of the libcall, and now done by code generated in `translate_resume`:
1. Setting the active continuation within the `VMContext`.
2. Setting the `State` flags of the `ContinuationObject`.

Note that this PR is supposed to result in exactly the same actions being taken as before, just from generated code instead of the libcall.