### PR TITLE
Additional documentation of assembly functions in wasmtime-fibre

### DIFF
--- a/crates/fibre/src/unix/x86_64.rs
+++ b/crates/fibre/src/unix/x86_64.rs
@@ -90,7 +90,7 @@ asm_func!(
         // `wasmtime_fibre_switch` function consumes 6 registers plus a return
         // pointer, and the top 16 bytes are reserved, so that's:
         //
-        //	(6 + 1) * 16 + 16 = 0x48
+        //	(6 + 1) * 8 + 16 = 0x48
         lea rax, -0x48[rdi]
         mov -0x10[rdi], rax
         ret

--- a/crates/fibre/src/unix/x86_64.rs
+++ b/crates/fibre/src/unix/x86_64.rs
@@ -54,8 +54,9 @@ asm_func!(
 //
 // This function is only every called such that `entry_point` is a pointer to
 // (an instantiation of) the `fiber_start` function in unix.rs and `entry_arg0`
-// is a a Box<*mut u8>, containing the function to actually run as the
-// continuation as a FnOnce(A, &super::Suspend<A, B, C>) -> C, for some A,B,C.
+// is a `Box<*mut u8>`, containing the function to actually run as the
+// continuation as a `FnOnce(A, &super::Suspend<A, B, C>) -> C`, for some `A`,
+// `B`, `C`.
 //
 // The layout of the FiberStack near the top of stack (TOS) *after* running this
 // function is as follows:

--- a/crates/fibre/src/unix/x86_64.rs
+++ b/crates/fibre/src/unix/x86_64.rs
@@ -52,11 +52,10 @@ asm_func!(
 // such that invoking wasmtime_fibre_switch on the stack actually runs the
 // desired computation.
 //
-// This function is only every called such that `entry_point` is a pointer to
-// (an instantiation of) the `fiber_start` function in unix.rs and `entry_arg0`
-// is a `Box<*mut u8>`, containing the function to actually run as the
-// continuation as a `FnOnce(A, &super::Suspend<A, B, C>) -> C`, for some `A`,
-// `B`, `C`.
+// This function is only ever called such that `entry_point` is a pointer to (an
+// instantiation of) the `fiber_start` function in unix.rs and `entry_arg0` is a
+// `Box<*mut u8>`, containing the function to actually run as the continuation
+// as a `FnOnce(A, &super::Suspend<A, B, C>) -> C`, for some `A`, `B`, `C`.
 //
 // The layout of the FiberStack near the top of stack (TOS) *after* running this
 // function is as follows:

--- a/crates/fibre/src/unix/x86_64.rs
+++ b/crates/fibre/src/unix/x86_64.rs
@@ -48,6 +48,10 @@ asm_func!(
 //    entry_arg0(rdx): *mut u8,
 // )
 //
+// This function installs the launchpad for the computation to run on the fiber,
+// such that invoking wasmtime_fibre_switch on the stack actually runs the
+// desired computation.
+//
 // This function is only every called such that `entry_point` is a pointer to
 // (an instantiation of) the `fiber_start` function in unix.rs and `entry_arg0`
 // is a a Box<*mut u8>, containing the function to actually run as the
@@ -119,6 +123,7 @@ asm_func!(
 // comment on wasmtime_fibre_init leads to the following values in various
 // registers at the right before the RET instruction of the latter is executed:
 //
+// RBP: frame pointer of *caller* of wasmtime_fibre_switch
 // RSP: TOS - 0x18
 // RDI: irrelevant  (not read by wasmtime_fibre_start)
 // RSI: irrelevant  (not read by wasmtime_fibre_start)


### PR DESCRIPTION
This PR adds some additional documentation to the `wasmtime_fibre_init` and `wasmtime_fibre_start` handwritten assembly functions. Due to how special these functions behave, the documentation shows the produced or expected stack layouts, as well as values of key registers.

Currently, these functions are identical to their counterparts in the original `fiber` crate. This documentation will become increasingly important as we optimise these functions further specificly for our needs and diverge from the original `fiber` crate.
