### PR TITLE
Safer continuations-related libcall implementations

### DIFF
--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -1,6 +1,6 @@
 //! Continuations TODO
 
-use crate::vmcontext::{VMArrayCallFunction, VMFuncRef, VMOpaqueContext, ValRaw};
+use crate::vmcontext::{VMFuncRef, VMOpaqueContext, ValRaw};
 use crate::{Instance, TrapReason};
 use std::cmp;
 use std::mem;

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -95,9 +95,13 @@ pub fn cont_new(
     param_count: usize,
     result_count: usize,
 ) -> Result<*mut ContinuationObject, TrapReason> {
-    let func_ref = unsafe { (func as *mut VMFuncRef).as_ref().ok_or_else(|| {
-        TrapReason::user_without_backtrace(anyhow::anyhow!("Attempt to dereference null VMFuncRef"))
-    })? };
+    let func_ref = unsafe {
+        (func as *mut VMFuncRef).as_ref().ok_or_else(|| {
+            TrapReason::user_without_backtrace(anyhow::anyhow!(
+                "Attempt to dereference null VMFuncRef"
+            ))
+        })?
+    };
     let callee_ctx = func_ref.vmctx;
     let caller_ctx = VMOpaqueContext::from_vmcontext(instance.vmctx());
 
@@ -105,7 +109,8 @@ pub fn cont_new(
     let payload = Payloads::new(capacity);
 
     let fiber = {
-        let stack = FiberStack::malloc(4096).map_err(|error| TrapReason::user_without_backtrace(error.into()))?;
+        let stack = FiberStack::malloc(4096)
+            .map_err(|error| TrapReason::user_without_backtrace(error.into()))?;
         let args_ptr = payload.data;
         let fiber = Fiber::new(stack, move |_first_val: (), _suspend: &Yield| unsafe {
             (func_ref.array_call)(callee_ctx, caller_ctx, args_ptr as *mut ValRaw, capacity)

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -13,7 +13,7 @@ use wasmtime_fibre::{Fiber, FiberStack, Suspend};
 
 type Yield = Suspend<(), u32, ()>;
 
-const DEFAULT_FIBER_SIZE: usize = 2000000; // 2MB
+const DEFAULT_FIBER_SIZE: usize = 2097152; // 2MB = 512 pages of 4k
 
 /// TODO
 #[inline(always)]

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -783,7 +783,8 @@ fn tc_cont_new(
     param_count: u64,
     result_count: u64,
 ) -> *mut u8 {
-    match crate::continuation::cont_new(instance, func, param_count as usize, result_count as usize) {
+    match crate::continuation::cont_new(instance, func, param_count as usize, result_count as usize)
+    {
         Ok(ptr) => ptr as *mut u8,
         Err(_) => panic!("cont_new failed!"),
         // TODO(dhil): I see sporadic crashes if I change the return

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -783,8 +783,12 @@ fn tc_cont_new(
     param_count: u64,
     result_count: u64,
 ) -> *mut u8 {
-    crate::continuation::cont_new(instance, func, param_count as usize, result_count as usize)
-        as *mut u8
+    match crate::continuation::cont_new(instance, func, param_count as usize, result_count as usize) {
+        Ok(ptr) => ptr as *mut u8,
+        Err(_) => panic!("cont_new failed!"),
+        // TODO(dhil): I see sporadic crashes if I change the return
+        // type to be Result<*mut u8, TrapReason>.
+    }
 }
 
 fn tc_resume(instance: &mut Instance, contobj: *mut u8) -> Result<u32, TrapReason> {
@@ -798,6 +802,8 @@ fn tc_suspend(instance: &mut Instance, tag_index: u32) {
     crate::continuation::suspend(instance, tag_index)
 }
 
+// TODO(dhil): This function can trap, so the return type ought to be
+// Result<*mut u8, TrapReason>.
 fn tc_new_cont_ref(_instance: &mut Instance, contobj: *mut u8) -> *mut u8 {
     crate::continuation::new_cont_ref(contobj as *mut crate::continuation::ContinuationObject)
         as *mut u8
@@ -827,6 +833,8 @@ fn tc_drop_cont_obj(_instance: &mut Instance, contobj: *mut u8) {
     crate::continuation::drop_cont_obj(contobj as *mut crate::continuation::ContinuationObject)
 }
 
+// TODO(dhil): This function can trap, so the return type ought to be
+// Result<*mut u8, TrapReason>.
 fn tc_allocate(_instance: &mut Instance, size: u64, align: u64) -> *mut u8 {
     debug_assert!(size > 0);
     let layout =
@@ -834,6 +842,7 @@ fn tc_allocate(_instance: &mut Instance, size: u64, align: u64) -> *mut u8 {
     unsafe { std::alloc::alloc(layout) }
 }
 
+// TODO(dhil): Similar as above.
 fn tc_deallocate(_instance: &mut Instance, ptr: *mut u8, size: u64, align: u64) {
     debug_assert!(size > 0);
     let layout =
@@ -841,6 +850,7 @@ fn tc_deallocate(_instance: &mut Instance, ptr: *mut u8, size: u64, align: u64) 
     unsafe { std::alloc::dealloc(ptr, layout) };
 }
 
+// TODO(dhil): Similar as above.
 fn tc_reallocate(
     instance: &mut Instance,
     ptr: *mut u8,

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -845,7 +845,6 @@ fn tc_allocate(_instance: &mut Instance, size: u64, align: u64) -> Result<*mut u
     }
 }
 
-// TODO(dhil): Similar as above.
 fn tc_deallocate(
     _instance: &mut Instance,
     ptr: *mut u8,
@@ -858,7 +857,6 @@ fn tc_deallocate(
     Ok(unsafe { std::alloc::dealloc(ptr, layout) })
 }
 
-// TODO(dhil): Similar as above.
 fn tc_reallocate(
     instance: &mut Instance,
     ptr: *mut u8,


### PR DESCRIPTION
This patch makes the interfaces and implementations of continuation-related libcalls safer as they now handle traps/failures.

In addition, this patch increases the default fiber stack size to 2MB.