### PR TITLE
Backtrace support, part 2: Shadow VMRuntimeLimits for each stack

### DIFF
--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -1321,6 +1321,10 @@ pub(crate) fn translate_resume<'a>(
         //
         // 2. Copy `stack_limit` and `last_wasm_entry_sp` in the
         // `StackLimits` of `resume_contobj` into the `VMRuntimeLimits`.
+        //
+        // See the comment on `wasmtime_continuations::StackChain` for a
+        // description of the invariants that we maintain for the various stack
+        // limits.
         let parent_stacks_limit_pointer = parent_stack_chain.get_stack_limits_ptr(env, builder);
 
         // We mark `resume_contobj` to be invoked

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -55,7 +55,7 @@ macro_rules! foreach_builtin_function {
             /// Creates a new continuation from a funcref.
             tc_cont_new(vmctx: vmctx, r: pointer, param_count: i64, result_count: i64) -> pointer;
             /// Resumes a continuation.
-            tc_resume(vmctx: vmctx, contobj: pointer) -> i32;
+            tc_resume(vmctx: vmctx, contobj: pointer, parent_stack_limits: pointer) -> i32;
             /// Suspends a continuation.
             tc_suspend(vmctx: vmctx, tag: i32);
             /// Returns the continuation object corresponding to the given continuation reference.

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -208,6 +208,8 @@ pub fn resume(
         }
     }
 
+    // See the comment on `wasmtime_continuations::StackChain` for a description
+    // of the invariants that we maintain for the various stack limits.
     unsafe {
         let runtime_limits = &**instance.runtime_limits();
 

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -788,10 +788,15 @@ fn tc_cont_new(
     Ok(ans.cast::<u8>())
 }
 
-fn tc_resume(instance: &mut Instance, contobj: *mut u8) -> Result<u32, TrapReason> {
+fn tc_resume(
+    instance: &mut Instance,
+    contobj: *mut u8,
+    parent_stack_limits: *mut u8,
+) -> Result<u32, TrapReason> {
     crate::continuation::resume(
         instance,
         contobj.cast::<crate::continuation::ContinuationObject>(),
+        parent_stack_limits.cast::<crate::continuation::StackLimits>(),
     )
 }
 


### PR DESCRIPTION
As of PR #98, each `ContinuationObject` contains an object of type `StackLimits`. In addition, there exists such an object for the main stack, it is stored in the `VMContext` and the `StackChain::MainStack` variant at the list of currently active continuations points to it. These `StackLimits` objects contain counterparts  of the stack-related fields in `VMRuntimeLimits`, namely `stack_limit` and the various `last_wasm_*` fields.

As of PR #98, the actual contents of these `StackLimits` are unused (and not updated). This changes in this PR:

While the `VMRuntimeLimits` continue to contain the stack-related information for the currently executing stack (either the main stack or a continuation), we ensure that for stacks that are *not* currently running, their corresponding `StackLimits` object now contains accurate values about their stack limits. The doc comment on `wasmtime_continuations::StackChain` describes the exact invariants that we maintain.

To ensure that these invariants hold, we need to copy some fields between the `VMRuntimeLimits` and  `StackLimits` objects when stack switching occurs. In particular, the `tc_resume` libcall now takes an additional argument: A pointer to the `StackLimits` object of the *parent* of the continuation that is about to be resume. Note that this needs to happen in the libcall itself, in order to obtain accurate values for the `last_wasm_exit_*` values in the `VMRuntimeLimits`.