### PR TITLE
C API option to enable the WasmFX instruction set

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -221,6 +221,30 @@ WASMTIME_CONFIG_PROP(void, wasm_multi_memory, bool)
 WASMTIME_CONFIG_PROP(void, wasm_memory64, bool)
 
 /**
+ * \brief Configures whether the WebAssembly exception-handling
+ * proposal is enabled.
+ *
+ * This setting is `false` by default.
+ */
+WASMTIME_CONFIG_PROP(void, wasm_exceptions, bool)
+
+/**
+ * \brief Configures whether the WebAssembly function references
+ * proposal is enabled.
+ *
+ * This setting is `false` by default.
+ */
+WASMTIME_CONFIG_PROP(void, wasm_function_references, bool)
+
+/**
+ * \brief Configures whether the WebAssembly typed continuations
+ * proposal is enabled.
+ *
+ * This setting is `false` by default.
+ */
+WASMTIME_CONFIG_PROP(void, wasm_typed_continuations, bool)
+
+/**
  * \brief Configures how JIT code will be compiled.
  *
  * This setting is #WASMTIME_STRATEGY_AUTO by default.

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -124,6 +124,21 @@ pub extern "C" fn wasmtime_config_wasm_memory64_set(c: &mut wasm_config_t, enabl
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_config_wasm_exceptions_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.wasm_exceptions(enable);
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_config_wasm_function_references_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.wasm_function_references(enable);
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_config_wasm_typed_continuations_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.wasm_typed_continuations(enable);
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_config_strategy_set(
     c: &mut wasm_config_t,
     strategy: wasmtime_strategy_t,

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -129,12 +129,18 @@ pub extern "C" fn wasmtime_config_wasm_exceptions_set(c: &mut wasm_config_t, ena
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_config_wasm_function_references_set(c: &mut wasm_config_t, enable: bool) {
+pub extern "C" fn wasmtime_config_wasm_function_references_set(
+    c: &mut wasm_config_t,
+    enable: bool,
+) {
     c.config.wasm_function_references(enable);
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_config_wasm_typed_continuations_set(c: &mut wasm_config_t, enable: bool) {
+pub extern "C" fn wasmtime_config_wasm_typed_continuations_set(
+    c: &mut wasm_config_t,
+    enable: bool,
+) {
     c.config.wasm_typed_continuations(enable);
 }
 


### PR DESCRIPTION
This patch adds options to enable the exception-handling, function references, and typed continuations proposals in C API.