### PR TITLE
Store length and capacity of Payloads object as u32

### DIFF
--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2593,7 +2593,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let contobj =
                 environ.typed_continuations_cont_ref_get_cont_obj(builder, *original_contref);
 
-            let src_arity_value = builder.ins().iconst(I64, src_arity as i64);
+            let src_arity_value = builder.ins().iconst(I32, src_arity as i64);
             environ.typed_continuations_store_resume_args(builder, args, src_arity_value, contobj);
 
             let new_contref = environ.typed_continuations_new_cont_ref(builder, contobj);

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -76,6 +76,7 @@ impl StackLimits {
 unsafe impl Send for StackLimits {}
 unsafe impl Sync for StackLimits {}
 
+#[repr(C)]
 pub struct Payloads {
     /// Number of currently occupied slots.
     pub length: types::payloads::Length,

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -22,9 +22,9 @@ pub mod types {
     /// Types used by `Payloads` struct
     pub mod payloads {
         /// type of length
-        pub type Length = usize;
+        pub type Length = u32;
         /// type of capacity
-        pub type Capacity = usize;
+        pub type Capacity = u32;
         /// Type of the entries in the actual buffer
         pub type DataEntries = u128;
     }
@@ -87,11 +87,11 @@ pub struct Payloads {
 }
 
 impl Payloads {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new(capacity: u32) -> Self {
         let data = if capacity == 0 {
             ptr::null_mut()
         } else {
-            let mut args = Vec::with_capacity(capacity);
+            let mut args = Vec::with_capacity(capacity as usize);
             let args_ptr = args.as_mut_ptr();
             args.leak();
             args_ptr

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -40,7 +40,7 @@ macro_rules! foreach_builtin_function {
             new_epoch(vmctx: vmctx) -> i64;
 
             /// Creates a new continuation from a funcref.
-            tc_cont_new(vmctx: vmctx, r: pointer, param_count: i64, result_count: i64) -> pointer;
+            tc_cont_new(vmctx: vmctx, r: pointer, param_count: i32, result_count: i32) -> pointer;
             /// Resumes a continuation. The result value is of type
             /// wasmtime_continuations::SwitchDirection.
             tc_resume(vmctx: vmctx, contobj: pointer, parent_stack_limits: pointer) -> i64;

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -279,13 +279,18 @@ pub fn drop_cont_obj(contobj: *mut ContinuationObject) {
     unsafe {
         let _: Vec<u128> = Vec::from_raw_parts(
             contobj.args.data,
-            contobj.args.length,
-            contobj.args.capacity,
+            contobj.args.length as usize,
+            contobj.args.capacity as usize,
         );
     };
     let payloads = &contobj.tag_return_values;
-    let _: Vec<u128> =
-        unsafe { Vec::from_raw_parts(payloads.data, payloads.length, payloads.capacity) };
+    let _: Vec<u128> = unsafe {
+        Vec::from_raw_parts(
+            payloads.data,
+            payloads.length as usize,
+            payloads.capacity as usize,
+        )
+    };
 }
 
 /// TODO
@@ -293,8 +298,8 @@ pub fn drop_cont_obj(contobj: *mut ContinuationObject) {
 pub fn cont_new(
     instance: &mut Instance,
     func: *mut u8,
-    param_count: usize,
-    result_count: usize,
+    param_count: u32,
+    result_count: u32,
 ) -> Result<*mut ContinuationObject, TrapReason> {
     let func_ref = unsafe {
         func.cast::<VMFuncRef>().as_ref().ok_or_else(|| {
@@ -315,7 +320,12 @@ pub fn cont_new(
             .map_err(|error| TrapReason::user_without_backtrace(error.into()))?;
         let args_ptr = payload.data;
         let fiber = Fiber::new(stack, move |_first_val: (), _suspend: &Yield| unsafe {
-            (func_ref.array_call)(callee_ctx, caller_ctx, args_ptr.cast::<ValRaw>(), capacity)
+            (func_ref.array_call)(
+                callee_ctx,
+                caller_ctx,
+                args_ptr.cast::<ValRaw>(),
+                capacity as usize,
+            )
         })
         .map_err(|error| TrapReason::user_without_backtrace(error.into()))?;
         Box::new(fiber)

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -782,11 +782,10 @@ pub mod relocs {
 fn tc_cont_new(
     instance: &mut Instance,
     func: *mut u8,
-    param_count: u64,
-    result_count: u64,
+    param_count: u32,
+    result_count: u32,
 ) -> Result<*mut u8, TrapReason> {
-    let ans =
-        crate::continuation::cont_new(instance, func, param_count as usize, result_count as usize)?;
+    let ans = crate::continuation::cont_new(instance, func, param_count, result_count)?;
     Ok(ans.cast::<u8>())
 }
 


### PR DESCRIPTION
Currentlly, `wasmtime_continuations::Payloads` looks like this (after inlining some definitions):

```rust
pub struct Payloads {
    pub length: usize,
    pub capacity: usize,
    pub data: *mut u128,
}
```

This PR changes the type of the `capacity` and `length` fields from `usize` to `u32`. This is reasonable, as the maximum length/capacity values we will see are bounded by the maximum of the following:
- Number of parameters/return values of any function used as a continuation
- Number of parameters/return values of any tag

Of course, it would be nice to somehow enforce the actual maximum of these values that we support, but that seems out of scope for this PR.

Each `ContinuationObject` contains two such `Payloads` objects, so this change saves us 16 bytes per continuation. This is probably not a meaningful optimization by itself, but shrinking these values is useful for subsequent work where it may come in handy when I'm packing parts of this in an enum in a custom way.

This PR also adds a `repr(C)` to `Payloads`, which should have been there the whole time, but wasn't.

