### PR TITLE
Document the culprit of disas expect tests diversion

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2877,6 +2877,12 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             // will remove it. However, it would be nicer to check if the
             // function actually contains resume instructions, and only run
             // `declare_vmruntime_limits_ptr` then.
+            //
+            // TODO(dhil): FIXME emission of the vmruntime_limits_ptr
+            // affects codegen of non-wasmfx programs, causing CLIF
+            // output expectation tests (disas) to diverge from
+            // upstream. We should come up with a design that let us
+            // emit this pointer only when necessary.
             self.declare_vmruntime_limits_ptr(builder);
         }
         // Additionally we initialize `fuel_var` if it will get used.


### PR DESCRIPTION
This commit adds a comment to `crates/cranelift/src/func_environ.rs` to document that the hack in `before_translate_function` is the culprit of the disas expect test diversion.