### PR TITLE
Restore compatibility with upstream disas tests

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2869,20 +2869,15 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     ) -> WasmResult<()> {
         // If the `vmruntime_limits_ptr` variable will get used then we initialize
         // it here.
-        if true || self.tunables.consume_fuel || self.tunables.epoch_interruption {
-            // TODO(frank-emrich) This is now done unconditionally because we
-            // need the `vmruntime_limits_ptr` variable when translating resume.
-            // This has no runtime overhead: We are adding a load to every
-            // function, but if it is not actually used, cranelift's DCE pass
-            // will remove it. However, it would be nicer to check if the
-            // function actually contains resume instructions, and only run
-            // `declare_vmruntime_limits_ptr` then.
-            //
-            // TODO(dhil): FIXME emission of the vmruntime_limits_ptr
-            // affects codegen of non-wasmfx programs, causing CLIF
-            // output expectation tests (disas) to diverge from
-            // upstream. We should come up with a design that let us
-            // emit this pointer only when necessary.
+        if self.tunables.consume_fuel || self.tunables.epoch_interruption {
+            // TODO(frank-emrich) Ideally, we would like to use this global
+            // variable in the translation of `resume` instructions. However, in
+            // order to decide whether to declare the variable or not we would
+            // have to know if the function body contains a `resume` instruction
+            // before actually translating it. If we instead called
+            // `declare_vmruntime_limits_ptr` unconditionally, we would change
+            // the CLIF output of functions using no wasmfx instructions, which
+            // is undesirable.
             self.declare_vmruntime_limits_ptr(builder);
         }
         // Additionally we initialize `fuel_var` if it will get used.

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -39,6 +39,49 @@ macro_rules! foreach_builtin_function {
             /// Invoked when we reach a new epoch.
             new_epoch(vmctx: vmctx) -> i64;
 
+            /// Invoked before malloc returns.
+            check_malloc(vmctx: vmctx, addr: i32, len: i32) -> i32;
+            /// Invoked before the free returns.
+            check_free(vmctx: vmctx, addr: i32) -> i32;
+            /// Invoked before a load is executed.
+            check_load(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> i32;
+            /// Invoked before a store is executed.
+            check_store(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> i32;
+            /// Invoked after malloc is called.
+            malloc_start(vmctx: vmctx);
+            /// Invoked after free is called.
+            free_start(vmctx: vmctx);
+            /// Invoked when wasm stack pointer is updated.
+            update_stack_pointer(vmctx: vmctx, value: i32);
+            /// Invoked before memory.grow is called.
+            update_mem_size(vmctx: vmctx, num_bytes: i32);
+
+            /// Returns an index to drop a `VMExternRef`.
+            #[cfg(feature = "gc")]
+            drop_externref(vmctx: vmctx, val: pointer);
+
+            /// Returns an index to do a GC and then insert a `VMExternRef` into the
+            /// `VMExternRefActivationsTable`.
+            #[cfg(feature = "gc")]
+            activations_table_insert_with_gc(vmctx: vmctx, val: reference);
+
+            /// Returns an index for Wasm's `global.get` instruction for `externref`s.
+            #[cfg(feature = "gc")]
+            externref_global_get(vmctx: vmctx, global: i32) -> reference;
+
+            /// Returns an index for Wasm's `global.get` instruction for `externref`s.
+            #[cfg(feature = "gc")]
+            externref_global_set(vmctx: vmctx, global: i32, val: reference);
+
+            /// Returns an index for Wasm's `table.grow` instruction for `externref`s.
+            #[cfg(feature = "gc")]
+            table_grow_externref(vmctx: vmctx, table: i32, delta: i32, init: reference) -> i32;
+
+            /// Returns an index for Wasm's `table.fill` instruction for `externref`s.
+            #[cfg(feature = "gc")]
+            table_fill_externref(vmctx: vmctx, table: i32, dst: i32, val: reference, len: i32);
+
+
             /// Creates a new continuation from a funcref.
             tc_cont_new(vmctx: vmctx, r: pointer, param_count: i32, result_count: i32) -> pointer;
             /// Resumes a continuation. The result value is of type
@@ -109,48 +152,6 @@ macro_rules! foreach_builtin_function {
             tc_print_int(vmctx: vmctx, arg : i64);
             /// TODO
             tc_print_pointer(vmctx: vmctx, arg : pointer);
-
-            /// Invoked before malloc returns.
-            check_malloc(vmctx: vmctx, addr: i32, len: i32) -> i32;
-            /// Invoked before the free returns.
-            check_free(vmctx: vmctx, addr: i32) -> i32;
-            /// Invoked before a load is executed.
-            check_load(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> i32;
-            /// Invoked before a store is executed.
-            check_store(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> i32;
-            /// Invoked after malloc is called.
-            malloc_start(vmctx: vmctx);
-            /// Invoked after free is called.
-            free_start(vmctx: vmctx);
-            /// Invoked when wasm stack pointer is updated.
-            update_stack_pointer(vmctx: vmctx, value: i32);
-            /// Invoked before memory.grow is called.
-            update_mem_size(vmctx: vmctx, num_bytes: i32);
-
-            /// Returns an index to drop a `VMExternRef`.
-            #[cfg(feature = "gc")]
-            drop_externref(vmctx: vmctx, val: pointer);
-
-            /// Returns an index to do a GC and then insert a `VMExternRef` into the
-            /// `VMExternRefActivationsTable`.
-            #[cfg(feature = "gc")]
-            activations_table_insert_with_gc(vmctx: vmctx, val: reference);
-
-            /// Returns an index for Wasm's `global.get` instruction for `externref`s.
-            #[cfg(feature = "gc")]
-            externref_global_get(vmctx: vmctx, global: i32) -> reference;
-
-            /// Returns an index for Wasm's `global.get` instruction for `externref`s.
-            #[cfg(feature = "gc")]
-            externref_global_set(vmctx: vmctx, global: i32, val: reference);
-
-            /// Returns an index for Wasm's `table.grow` instruction for `externref`s.
-            #[cfg(feature = "gc")]
-            table_grow_externref(vmctx: vmctx, table: i32, delta: i32, init: reference) -> i32;
-
-            /// Returns an index for Wasm's `table.fill` instruction for `externref`s.
-            #[cfg(feature = "gc")]
-            table_fill_externref(vmctx: vmctx, table: i32, dst: i32, val: reference, len: i32);
         }
     };
 }

--- a/tests/disas/arith.wat
+++ b/tests/disas/arith.wat
@@ -18,26 +18,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @001f                               v2 = iconst.i32 0
-;; @001f                               v3 = global_value.i64 gv3
-;; @001f                               v4 = load.i64 notrap aligned v3+8
-;; @0021                               v5 = iconst.i32 4
-;; @0023                               v6 = iconst.i32 4
-;; @0025                               v7 = isub v5, v6  ; v5 = 4, v6 = 4
-;; @002a                               brif v7, block2, block4
+;; @0021                               v3 = iconst.i32 4
+;; @0023                               v4 = iconst.i32 4
+;; @0025                               v5 = isub v3, v4  ; v3 = 4, v4 = 4
+;; @002a                               brif v5, block2, block4
 ;;
 ;;                                 block2:
 ;; @002c                               trap unreachable
 ;;
 ;;                                 block4:
-;; @002e                               v8 = iconst.i32 6
-;; @0032                               v9 = imul v8, v7  ; v8 = 6
+;; @002e                               v6 = iconst.i32 6
+;; @0032                               v7 = imul v6, v5  ; v6 = 6
 ;; @0034                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -21,18 +21,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @001e                               v5 = global_value.i64 gv3
-;; @001e                               v6 = load.i64 notrap aligned v5+8
-;; @0021                               v7 = uextend.i64 v2
-;; @0021                               v8 = global_value.i64 gv4
-;; @0021                               v9 = iadd v8, v7
-;; @0021                               v10 = load.i32 little heap v9
-;; @0026                               v11 = uextend.i64 v3
-;; @0026                               v12 = global_value.i64 gv4
-;; @0026                               v13 = iadd v12, v11
-;; @0026                               v14 = load.i32 little heap v13
-;; @0029                               v15 = iadd v10, v14
-;; @002a                               jump block1(v15)
+;; @0021                               v5 = uextend.i64 v2
+;; @0021                               v6 = global_value.i64 gv4
+;; @0021                               v7 = iadd v6, v5
+;; @0021                               v8 = load.i32 little heap v7
+;; @0026                               v9 = uextend.i64 v3
+;; @0026                               v10 = global_value.i64 gv4
+;; @0026                               v11 = iadd v10, v9
+;; @0026                               v12 = load.i32 little heap v11
+;; @0029                               v13 = iadd v8, v12
+;; @002a                               jump block1(v13)
 ;;
 ;;                                 block1(v4: i32):
 ;; @002a                               return v4

--- a/tests/disas/br_table.wat
+++ b/tests/disas/br_table.wat
@@ -35,38 +35,35 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @001a                               v3 = global_value.i64 gv3
-;; @001a                               v4 = load.i64 notrap aligned v3+8
-;; @0021                               v8 = iconst.i32 42
-;; @0023                               v9 = iconst.i32 0
-;; @0025                               br_table v9, block8, [block5, block6, block7]  ; v9 = 0
+;; @0021                               v6 = iconst.i32 42
+;; @0023                               v7 = iconst.i32 0
+;; @0025                               br_table v7, block8, [block5, block6, block7]  ; v7 = 0
 ;;
 ;;                                 block5:
-;; @0025                               jump block4(v8)  ; v8 = 42
+;; @0025                               jump block4(v6)  ; v6 = 42
 ;;
 ;;                                 block6:
-;; @0025                               jump block3(v8)  ; v8 = 42
+;; @0025                               jump block3(v6)  ; v6 = 42
 ;;
 ;;                                 block7:
-;; @0025                               jump block2(v8)  ; v8 = 42
+;; @0025                               jump block2(v6)  ; v6 = 42
 ;;
 ;;                                 block8:
-;; @0025                               jump block1(v8)  ; v8 = 42
+;; @0025                               jump block1(v6)  ; v6 = 42
 ;;
-;;                                 block4(v7: i32):
-;; @002c                               jump block3(v7)
+;;                                 block4(v5: i32):
+;; @002c                               jump block3(v5)
 ;;
-;;                                 block3(v6: i32):
-;; @002d                               jump block2(v6)
+;;                                 block3(v4: i32):
+;; @002d                               jump block2(v4)
 ;;
-;;                                 block2(v5: i32):
-;; @002e                               jump block1(v5)
+;;                                 block2(v3: i32):
+;; @002e                               jump block1(v3)
 ;;
 ;;                                 block1(v2: i32):
 ;; @002e                               return v2
@@ -76,38 +73,35 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0030                               v3 = global_value.i64 gv3
-;; @0030                               v4 = load.i64 notrap aligned v3+8
-;; @0037                               v8 = iconst.i32 42
-;; @0039                               v9 = iconst.i32 0
-;; @003b                               br_table v9, block8, [block5, block6, block7]  ; v9 = 0
+;; @0037                               v6 = iconst.i32 42
+;; @0039                               v7 = iconst.i32 0
+;; @003b                               br_table v7, block8, [block5, block6, block7]  ; v7 = 0
 ;;
 ;;                                 block5:
-;; @003b                               jump block1(v8)  ; v8 = 42
+;; @003b                               jump block1(v6)  ; v6 = 42
 ;;
 ;;                                 block6:
-;; @003b                               jump block2(v8)  ; v8 = 42
+;; @003b                               jump block2(v6)  ; v6 = 42
 ;;
 ;;                                 block7:
-;; @003b                               jump block3(v8)  ; v8 = 42
+;; @003b                               jump block3(v6)  ; v6 = 42
 ;;
 ;;                                 block8:
-;; @003b                               jump block4(v8)  ; v8 = 42
+;; @003b                               jump block4(v6)  ; v6 = 42
 ;;
-;;                                 block4(v7: i32):
-;; @0042                               jump block3(v7)
+;;                                 block4(v5: i32):
+;; @0042                               jump block3(v5)
 ;;
-;;                                 block3(v6: i32):
-;; @0043                               jump block2(v6)
+;;                                 block3(v4: i32):
+;; @0043                               jump block2(v4)
 ;;
-;;                                 block2(v5: i32):
-;; @0044                               jump block1(v5)
+;;                                 block2(v3: i32):
+;; @0044                               jump block1(v3)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0044                               return v2
@@ -117,26 +111,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0046                               v3 = global_value.i64 gv3
-;; @0046                               v4 = load.i64 notrap aligned v3+8
-;; @0049                               v6 = iconst.i32 42
-;; @004b                               v7 = iconst.i32 0
-;; @004d                               br_table v7, block4, [block3, block3, block4]  ; v7 = 0
+;; @0049                               v4 = iconst.i32 42
+;; @004b                               v5 = iconst.i32 0
+;; @004d                               br_table v5, block4, [block3, block3, block4]  ; v5 = 0
 ;;
 ;;                                 block3:
-;; @004d                               jump block2(v6)  ; v6 = 42
+;; @004d                               jump block2(v4)  ; v4 = 42
 ;;
 ;;                                 block4:
-;; @004d                               jump block1(v6)  ; v6 = 42
+;; @004d                               jump block1(v4)  ; v4 = 42
 ;;
-;;                                 block2(v5: i32):
-;; @0054                               jump block1(v5)
+;;                                 block2(v3: i32):
+;; @0054                               jump block1(v3)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0054                               return v2
@@ -146,26 +137,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0056                               v3 = global_value.i64 gv3
-;; @0056                               v4 = load.i64 notrap aligned v3+8
-;; @0059                               v6 = iconst.i32 42
-;; @005b                               v7 = iconst.i32 0
-;; @005d                               br_table v7, block4, [block3, block3, block4]  ; v7 = 0
+;; @0059                               v4 = iconst.i32 42
+;; @005b                               v5 = iconst.i32 0
+;; @005d                               br_table v5, block4, [block3, block3, block4]  ; v5 = 0
 ;;
 ;;                                 block3:
-;; @005d                               jump block1(v6)  ; v6 = 42
+;; @005d                               jump block1(v4)  ; v4 = 42
 ;;
 ;;                                 block4:
-;; @005d                               jump block2(v6)  ; v6 = 42
+;; @005d                               jump block2(v4)  ; v4 = 42
 ;;
-;;                                 block2(v5: i32):
-;; @0064                               jump block1(v5)
+;;                                 block2(v3: i32):
+;; @0064                               jump block1(v3)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0064                               return v2

--- a/tests/disas/byteswap.wat
+++ b/tests/disas/byteswap.wat
@@ -75,34 +75,30 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v4 -> v0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v21 = bswap.i32 v2
-;; @0057                               return v21
+;;                                     v19 = bswap.i32 v2
+;; @0057                               return v19
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i64 fast {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;;                                     v4 -> v0
 ;; @00ad                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v41 = bswap.i64 v2
-;; @00ad                               return v41
+;;                                     v39 = bswap.i64 v2
+;; @00ad                               return v39
 ;; }

--- a/tests/disas/call-simd.wat
+++ b/tests/disas/call-simd.wat
@@ -19,7 +19,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i8x16, i8x16) -> i8x16 fast
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig2 = (i64 vmctx, i32 uext) -> i32 uext system_v
@@ -28,11 +27,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0020                               v2 = global_value.i64 gv3
-;; @0020                               v3 = load.i64 notrap aligned v2+8
-;; @0021                               v4 = vconst.i8x16 const0
-;; @0033                               v5 = vconst.i8x16 const0
-;; @0045                               v6 = call fn0(v0, v0, v4, v5)  ; v4 = const0, v5 = const0
+;; @0021                               v2 = vconst.i8x16 const0
+;; @0033                               v3 = vconst.i8x16 const0
+;; @0045                               v4 = call fn0(v0, v0, v2, v3)  ; v2 = const0, v3 = const0
 ;; @0048                               jump block1
 ;;
 ;;                                 block1:
@@ -43,19 +40,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16, v3: i8x16):
-;; @004a                               v5 = global_value.i64 gv3
-;; @004a                               v6 = load.i64 notrap aligned v5+8
-;; @004f                               v7 = bitcast.i32x4 little v2
-;; @004f                               v8 = bitcast.i32x4 little v3
-;; @004f                               v9 = iadd v7, v8
-;; @0052                               v10 = bitcast.i8x16 little v9
-;; @0052                               jump block1(v10)
+;; @004f                               v5 = bitcast.i32x4 little v2
+;; @004f                               v6 = bitcast.i32x4 little v3
+;; @004f                               v7 = iadd v5, v6
+;; @0052                               v8 = bitcast.i8x16 little v7
+;; @0052                               jump block1(v8)
 ;;
 ;;                                 block1(v4: i8x16):
 ;; @0052                               return v4

--- a/tests/disas/call.wat
+++ b/tests/disas/call.wat
@@ -15,7 +15,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64) -> i32 fast
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig2 = (i64 vmctx, i32 uext) -> i32 uext system_v
@@ -24,10 +23,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @001f                               v2 = iconst.i32 0
-;; @001f                               v3 = global_value.i64 gv3
-;; @001f                               v4 = load.i64 notrap aligned v3+8
-;; @0021                               v5 = iconst.i32 0
-;; @0025                               v6 = call fn0(v0, v0)
+;; @0021                               v3 = iconst.i32 0
+;; @0025                               v4 = call fn0(v0, v0)
 ;; @0028                               jump block1
 ;;
 ;;                                 block1:
@@ -38,16 +35,13 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @002a                               v3 = global_value.i64 gv3
-;; @002a                               v4 = load.i64 notrap aligned v3+8
-;; @002b                               v5 = iconst.i32 1
-;; @002d                               jump block1(v5)  ; v5 = 1
+;; @002b                               v3 = iconst.i32 1
+;; @002d                               jump block1(v3)  ; v3 = 1
 ;;
 ;;                                 block1(v2: i32):
 ;; @002d                               return v2

--- a/tests/disas/dead-code.wat
+++ b/tests/disas/dead-code.wat
@@ -25,19 +25,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 -> v2
-;; @0022                               v3 = global_value.i64 gv3
-;; @0022                               v4 = load.i64 notrap aligned v3+8
+;;                                     v3 -> v2
 ;; @0023                               jump block2
 ;;
 ;;                                 block2:
-;; @0029                               brif.i32 v5, block4, block5
+;; @0029                               brif.i32 v3, block4, block5
 ;;
 ;;                                 block5:
 ;; @002b                               jump block2
@@ -56,12 +53,9 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0031                               v3 = global_value.i64 gv3
-;; @0031                               v4 = load.i64 notrap aligned v3+8
 ;; @0032                               jump block2
 ;;
 ;;                                 block2:
@@ -72,14 +66,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @003e                               v2 = global_value.i64 gv3
-;; @003e                               v3 = load.i64 notrap aligned v2+8
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -90,14 +81,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0041                               v4 = global_value.i64 gv3
-;; @0041                               v5 = load.i64 notrap aligned v4+8
-;; @0042                               v6 = iconst.i32 1
-;; @0044                               return v6  ; v6 = 1
+;; @0042                               v4 = iconst.i32 1
+;; @0044                               return v4  ; v4 = 1
 ;; }

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -35,24 +35,23 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 -> v0
+;;                                     v21 -> v0
+;;                                     v22 -> v0
 ;;                                     v23 -> v0
 ;;                                     v24 -> v0
-;;                                     v25 -> v0
-;;                                     v26 -> v0
-;; @0057                               v8 = load.i64 notrap aligned v0+88
-;; @0057                               v10 = load.i64 notrap aligned checked v0+80
-;; @0057                               v7 = uextend.i64 v2
-;; @0057                               v9 = icmp ugt v7, v8
-;; @0057                               v12 = iconst.i64 0
-;; @0057                               v11 = iadd v10, v7
-;; @0057                               v13 = select_spectre_guard v9, v12, v11  ; v12 = 0
-;; @0057                               v14 = load.i32 little heap v13
-;;                                     v3 -> v14
+;; @0057                               v6 = load.i64 notrap aligned v0+88
+;; @0057                               v8 = load.i64 notrap aligned checked v0+80
+;; @0057                               v5 = uextend.i64 v2
+;; @0057                               v7 = icmp ugt v5, v6
+;; @0057                               v10 = iconst.i64 0
+;; @0057                               v9 = iadd v8, v5
+;; @0057                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
+;; @0057                               v12 = load.i32 little heap v11
+;;                                     v3 -> v12
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
-;; @005f                               return v14, v14
+;; @005f                               return v12, v12
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 fast {
@@ -68,24 +67,23 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 -> v0
+;;                                     v25 -> v0
+;;                                     v26 -> v0
 ;;                                     v27 -> v0
 ;;                                     v28 -> v0
-;;                                     v29 -> v0
-;;                                     v30 -> v0
-;; @0064                               v8 = load.i64 notrap aligned v0+88
-;; @0064                               v10 = load.i64 notrap aligned checked v0+80
-;; @0064                               v7 = uextend.i64 v2
-;; @0064                               v9 = icmp ugt v7, v8
-;; @0064                               v14 = iconst.i64 0
-;; @0064                               v11 = iadd v10, v7
-;; @0064                               v12 = iconst.i64 1234
-;; @0064                               v13 = iadd v11, v12  ; v12 = 1234
-;; @0064                               v15 = select_spectre_guard v9, v14, v13  ; v14 = 0
-;; @0064                               v16 = load.i32 little heap v15
-;;                                     v3 -> v16
+;; @0064                               v6 = load.i64 notrap aligned v0+88
+;; @0064                               v8 = load.i64 notrap aligned checked v0+80
+;; @0064                               v5 = uextend.i64 v2
+;; @0064                               v7 = icmp ugt v5, v6
+;; @0064                               v12 = iconst.i64 0
+;; @0064                               v9 = iadd v8, v5
+;; @0064                               v10 = iconst.i64 1234
+;; @0064                               v11 = iadd v9, v10  ; v10 = 1234
+;; @0064                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0064                               v14 = load.i32 little heap v13
+;;                                     v3 -> v14
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:
-;; @006e                               return v16, v16
+;; @006e                               return v14, v14
 ;; }

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -29,18 +29,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 -> v0
-;;                                     v15 -> v0
-;;                                     v16 -> v0
-;; @0057                               v8 = load.i64 notrap aligned readonly checked v0+80
-;; @0057                               v7 = uextend.i64 v2
-;; @0057                               v9 = iadd v8, v7
-;; @0057                               v10 = load.i32 little heap v9
-;;                                     v3 -> v10
+;;                                     v13 -> v0
+;;                                     v14 -> v0
+;; @0057                               v6 = load.i64 notrap aligned readonly checked v0+80
+;; @0057                               v5 = uextend.i64 v2
+;; @0057                               v7 = iadd v6, v5
+;; @0057                               v8 = load.i32 little heap v7
+;;                                     v3 -> v8
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
-;; @005f                               return v10, v10
+;; @005f                               return v8, v8
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 fast {
@@ -55,18 +54,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 -> v0
-;;                                     v19 -> v0
-;;                                     v20 -> v0
-;; @0064                               v8 = load.i64 notrap aligned readonly checked v0+80
-;; @0064                               v7 = uextend.i64 v2
-;; @0064                               v9 = iadd v8, v7
-;; @0064                               v10 = iconst.i64 1234
-;; @0064                               v11 = iadd v9, v10  ; v10 = 1234
-;; @0064                               v12 = load.i32 little heap v11
-;;                                     v3 -> v12
+;;                                     v17 -> v0
+;;                                     v18 -> v0
+;; @0064                               v6 = load.i64 notrap aligned readonly checked v0+80
+;; @0064                               v5 = uextend.i64 v2
+;; @0064                               v7 = iadd v6, v5
+;; @0064                               v8 = iconst.i64 1234
+;; @0064                               v9 = iadd v7, v8  ; v8 = 1234
+;; @0064                               v10 = load.i32 little heap v9
+;;                                     v3 -> v10
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:
-;; @006e                               return v12, v12
+;; @006e                               return v10, v10
 ;; }

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -48,55 +48,54 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v6 -> v0
+;;                                     v30 -> v0
+;;                                     v31 -> v0
 ;;                                     v32 -> v0
 ;;                                     v33 -> v0
 ;;                                     v34 -> v0
 ;;                                     v35 -> v0
-;;                                     v36 -> v0
-;;                                     v37 -> v0
-;; @0047                               v9 = load.i64 notrap aligned v0+88
-;; @0047                               v8 = uextend.i64 v2
-;; @0047                               v10 = icmp ugt v8, v9
-;; @0047                               brif v10, block2, block3
+;; @0047                               v7 = load.i64 notrap aligned v0+88
+;; @0047                               v6 = uextend.i64 v2
+;; @0047                               v8 = icmp ugt v6, v7
+;; @0047                               brif v8, block2, block3
 ;;
 ;;                                 block2 cold:
 ;; @0047                               trap heap_oob
 ;;
 ;;                                 block3:
-;; @0047                               v11 = load.i64 notrap aligned checked v0+80
-;; @0047                               v12 = iadd v11, v8
-;; @0047                               v13 = load.i32 little heap v12
-;;                                     v3 -> v13
-;; @004c                               brif.i8 v10, block4, block5
+;; @0047                               v9 = load.i64 notrap aligned checked v0+80
+;; @0047                               v10 = iadd v9, v6
+;; @0047                               v11 = load.i32 little heap v10
+;;                                     v3 -> v11
+;; @004c                               brif.i8 v8, block4, block5
 ;;
 ;;                                 block4 cold:
 ;; @004c                               trap heap_oob
 ;;
 ;;                                 block5:
-;; @004c                               v19 = iconst.i64 4
-;; @004c                               v20 = iadd.i64 v12, v19  ; v19 = 4
-;; @004c                               v21 = load.i32 little heap v20
-;;                                     v4 -> v21
-;; @0051                               v23 = iconst.i64 0x0010_0003
-;; @0051                               v24 = uadd_overflow_trap.i64 v8, v23, heap_oob  ; v23 = 0x0010_0003
-;; @0051                               v26 = icmp ugt v24, v9
-;; @0051                               brif v26, block6, block7
+;; @004c                               v17 = iconst.i64 4
+;; @004c                               v18 = iadd.i64 v10, v17  ; v17 = 4
+;; @004c                               v19 = load.i32 little heap v18
+;;                                     v4 -> v19
+;; @0051                               v21 = iconst.i64 0x0010_0003
+;; @0051                               v22 = uadd_overflow_trap.i64 v6, v21, heap_oob  ; v21 = 0x0010_0003
+;; @0051                               v24 = icmp ugt v22, v7
+;; @0051                               brif v24, block6, block7
 ;;
 ;;                                 block6 cold:
 ;; @0051                               trap heap_oob
 ;;
 ;;                                 block7:
-;; @0051                               v27 = load.i64 notrap aligned checked v0+80
-;; @0051                               v28 = iadd v27, v8
-;; @0051                               v29 = iconst.i64 0x000f_ffff
-;; @0051                               v30 = iadd v28, v29  ; v29 = 0x000f_ffff
-;; @0051                               v31 = load.i32 little heap v30
-;;                                     v5 -> v31
+;; @0051                               v25 = load.i64 notrap aligned checked v0+80
+;; @0051                               v26 = iadd v25, v6
+;; @0051                               v27 = iconst.i64 0x000f_ffff
+;; @0051                               v28 = iadd v26, v27  ; v27 = 0x000f_ffff
+;; @0051                               v29 = load.i32 little heap v28
+;;                                     v5 -> v29
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v13, v21, v31
+;; @0056                               return v11, v19, v29
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) fast {
@@ -112,48 +111,47 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v6 -> v0
+;;                                     v27 -> v0
+;;                                     v28 -> v0
 ;;                                     v29 -> v0
 ;;                                     v30 -> v0
 ;;                                     v31 -> v0
 ;;                                     v32 -> v0
-;;                                     v33 -> v0
-;;                                     v34 -> v0
-;; @005d                               v9 = load.i64 notrap aligned v0+88
-;; @005d                               v8 = uextend.i64 v2
-;; @005d                               v10 = icmp ugt v8, v9
-;; @005d                               brif v10, block2, block3
+;; @005d                               v7 = load.i64 notrap aligned v0+88
+;; @005d                               v6 = uextend.i64 v2
+;; @005d                               v8 = icmp ugt v6, v7
+;; @005d                               brif v8, block2, block3
 ;;
 ;;                                 block2 cold:
 ;; @005d                               trap heap_oob
 ;;
 ;;                                 block3:
-;; @005d                               v11 = load.i64 notrap aligned checked v0+80
-;; @005d                               v12 = iadd v11, v8
-;; @005d                               store.i32 little heap v3, v12
-;; @0064                               brif.i8 v10, block4, block5
+;; @005d                               v9 = load.i64 notrap aligned checked v0+80
+;; @005d                               v10 = iadd v9, v6
+;; @005d                               store.i32 little heap v3, v10
+;; @0064                               brif.i8 v8, block4, block5
 ;;
 ;;                                 block4 cold:
 ;; @0064                               trap heap_oob
 ;;
 ;;                                 block5:
-;; @0064                               v18 = iconst.i64 4
-;; @0064                               v19 = iadd.i64 v12, v18  ; v18 = 4
-;; @0064                               store.i32 little heap v4, v19
-;; @006b                               v21 = iconst.i64 0x0010_0003
-;; @006b                               v22 = uadd_overflow_trap.i64 v8, v21, heap_oob  ; v21 = 0x0010_0003
-;; @006b                               v24 = icmp ugt v22, v9
-;; @006b                               brif v24, block6, block7
+;; @0064                               v16 = iconst.i64 4
+;; @0064                               v17 = iadd.i64 v10, v16  ; v16 = 4
+;; @0064                               store.i32 little heap v4, v17
+;; @006b                               v19 = iconst.i64 0x0010_0003
+;; @006b                               v20 = uadd_overflow_trap.i64 v6, v19, heap_oob  ; v19 = 0x0010_0003
+;; @006b                               v22 = icmp ugt v20, v7
+;; @006b                               brif v22, block6, block7
 ;;
 ;;                                 block6 cold:
 ;; @006b                               trap heap_oob
 ;;
 ;;                                 block7:
-;; @006b                               v25 = load.i64 notrap aligned checked v0+80
-;; @006b                               v26 = iadd v25, v8
-;; @006b                               v27 = iconst.i64 0x000f_ffff
-;; @006b                               v28 = iadd v26, v27  ; v27 = 0x000f_ffff
-;; @006b                               store.i32 little heap v5, v28
+;; @006b                               v23 = load.i64 notrap aligned checked v0+80
+;; @006b                               v24 = iadd v23, v6
+;; @006b                               v25 = iconst.i64 0x000f_ffff
+;; @006b                               v26 = iadd v24, v25  ; v25 = 0x000f_ffff
+;; @006b                               store.i32 little heap v5, v26
 ;; @0070                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -44,39 +44,38 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v6 -> v0
+;;                                     v36 -> v0
+;;                                     v37 -> v0
 ;;                                     v38 -> v0
 ;;                                     v39 -> v0
 ;;                                     v40 -> v0
 ;;                                     v41 -> v0
-;;                                     v42 -> v0
-;;                                     v43 -> v0
-;; @0047                               v9 = load.i64 notrap aligned v0+88
-;; @0047                               v11 = load.i64 notrap aligned checked v0+80
-;; @0047                               v8 = uextend.i64 v2
-;; @0047                               v10 = icmp ugt v8, v9
-;; @0047                               v13 = iconst.i64 0
-;; @0047                               v12 = iadd v11, v8
-;; @0047                               v14 = select_spectre_guard v10, v13, v12  ; v13 = 0
-;; @0047                               v15 = load.i32 little heap v14
-;;                                     v3 -> v15
-;; @004c                               v21 = iconst.i64 4
-;; @004c                               v22 = iadd v12, v21  ; v21 = 4
-;; @004c                               v24 = select_spectre_guard v10, v13, v22  ; v13 = 0
-;; @004c                               v25 = load.i32 little heap v24
-;;                                     v4 -> v25
-;; @0051                               v27 = iconst.i64 0x0010_0003
-;; @0051                               v28 = uadd_overflow_trap v8, v27, heap_oob  ; v27 = 0x0010_0003
-;; @0051                               v30 = icmp ugt v28, v9
-;; @0051                               v33 = iconst.i64 0x000f_ffff
-;; @0051                               v34 = iadd v12, v33  ; v33 = 0x000f_ffff
-;; @0051                               v36 = select_spectre_guard v30, v13, v34  ; v13 = 0
-;; @0051                               v37 = load.i32 little heap v36
-;;                                     v5 -> v37
+;; @0047                               v7 = load.i64 notrap aligned v0+88
+;; @0047                               v9 = load.i64 notrap aligned checked v0+80
+;; @0047                               v6 = uextend.i64 v2
+;; @0047                               v8 = icmp ugt v6, v7
+;; @0047                               v11 = iconst.i64 0
+;; @0047                               v10 = iadd v9, v6
+;; @0047                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
+;; @0047                               v13 = load.i32 little heap v12
+;;                                     v3 -> v13
+;; @004c                               v19 = iconst.i64 4
+;; @004c                               v20 = iadd v10, v19  ; v19 = 4
+;; @004c                               v22 = select_spectre_guard v8, v11, v20  ; v11 = 0
+;; @004c                               v23 = load.i32 little heap v22
+;;                                     v4 -> v23
+;; @0051                               v25 = iconst.i64 0x0010_0003
+;; @0051                               v26 = uadd_overflow_trap v6, v25, heap_oob  ; v25 = 0x0010_0003
+;; @0051                               v28 = icmp ugt v26, v7
+;; @0051                               v31 = iconst.i64 0x000f_ffff
+;; @0051                               v32 = iadd v10, v31  ; v31 = 0x000f_ffff
+;; @0051                               v34 = select_spectre_guard v28, v11, v32  ; v11 = 0
+;; @0051                               v35 = load.i32 little heap v34
+;;                                     v5 -> v35
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v15, v25, v37
+;; @0056                               return v13, v23, v35
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) fast {
@@ -92,32 +91,31 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v6 -> v0
+;;                                     v33 -> v0
+;;                                     v34 -> v0
 ;;                                     v35 -> v0
 ;;                                     v36 -> v0
 ;;                                     v37 -> v0
 ;;                                     v38 -> v0
-;;                                     v39 -> v0
-;;                                     v40 -> v0
-;; @005d                               v9 = load.i64 notrap aligned v0+88
-;; @005d                               v11 = load.i64 notrap aligned checked v0+80
-;; @005d                               v8 = uextend.i64 v2
-;; @005d                               v10 = icmp ugt v8, v9
-;; @005d                               v13 = iconst.i64 0
-;; @005d                               v12 = iadd v11, v8
-;; @005d                               v14 = select_spectre_guard v10, v13, v12  ; v13 = 0
-;; @005d                               store little heap v3, v14
-;; @0064                               v20 = iconst.i64 4
-;; @0064                               v21 = iadd v12, v20  ; v20 = 4
-;; @0064                               v23 = select_spectre_guard v10, v13, v21  ; v13 = 0
-;; @0064                               store little heap v4, v23
-;; @006b                               v25 = iconst.i64 0x0010_0003
-;; @006b                               v26 = uadd_overflow_trap v8, v25, heap_oob  ; v25 = 0x0010_0003
-;; @006b                               v28 = icmp ugt v26, v9
-;; @006b                               v31 = iconst.i64 0x000f_ffff
-;; @006b                               v32 = iadd v12, v31  ; v31 = 0x000f_ffff
-;; @006b                               v34 = select_spectre_guard v28, v13, v32  ; v13 = 0
-;; @006b                               store little heap v5, v34
+;; @005d                               v7 = load.i64 notrap aligned v0+88
+;; @005d                               v9 = load.i64 notrap aligned checked v0+80
+;; @005d                               v6 = uextend.i64 v2
+;; @005d                               v8 = icmp ugt v6, v7
+;; @005d                               v11 = iconst.i64 0
+;; @005d                               v10 = iadd v9, v6
+;; @005d                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
+;; @005d                               store little heap v3, v12
+;; @0064                               v18 = iconst.i64 4
+;; @0064                               v19 = iadd v10, v18  ; v18 = 4
+;; @0064                               v21 = select_spectre_guard v8, v11, v19  ; v11 = 0
+;; @0064                               store little heap v4, v21
+;; @006b                               v23 = iconst.i64 0x0010_0003
+;; @006b                               v24 = uadd_overflow_trap v6, v23, heap_oob  ; v23 = 0x0010_0003
+;; @006b                               v26 = icmp ugt v24, v7
+;; @006b                               v29 = iconst.i64 0x000f_ffff
+;; @006b                               v30 = iadd v10, v29  ; v29 = 0x000f_ffff
+;; @006b                               v32 = select_spectre_guard v26, v11, v30  ; v11 = 0
+;; @006b                               store little heap v5, v32
 ;; @0070                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -18,13 +18,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002b                               v4 = global_value.i64 gv3
-;; @002b                               v5 = load.i64 notrap aligned v4+8
-;; @002e                               v6 = uextend.i64 v2
-;; @002e                               v7 = global_value.i64 gv4
-;; @002e                               v8 = iadd v7, v6
-;; @002e                               v9 = load.f32 little heap v8
-;; @0031                               jump block1(v9)
+;; @002e                               v4 = uextend.i64 v2
+;; @002e                               v5 = global_value.i64 gv4
+;; @002e                               v6 = iadd v5, v4
+;; @002e                               v7 = load.f32 little heap v6
+;; @0031                               jump block1(v7)
 ;;
 ;;                                 block1(v3: f32):
 ;; @0031                               return v3

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -21,12 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
-;; @002c                               v4 = global_value.i64 gv3
-;; @002c                               v5 = load.i64 notrap aligned v4+8
-;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v7 = global_value.i64 gv4
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               store little heap v3, v8
+;; @0031                               v4 = uextend.i64 v2
+;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v6 = iadd v5, v4
+;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002b                               v4 = global_value.i64 gv3
-;; @002b                               v5 = load.i64 notrap aligned v4+8
-;; @002e                               v6 = uextend.i64 v2
-;; @002e                               v7 = global_value.i64 gv4
-;; @002e                               v8 = iadd v7, v6
-;; @002e                               v9 = load.f64 little heap v8
-;; @0031                               jump block1(v9)
+;; @002e                               v4 = uextend.i64 v2
+;; @002e                               v5 = global_value.i64 gv4
+;; @002e                               v6 = iadd v5, v4
+;; @002e                               v7 = load.f64 little heap v6
+;; @0031                               jump block1(v7)
 ;;
 ;;                                 block1(v3: f64):
 ;; @0031                               return v3

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -21,12 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f64):
-;; @002c                               v4 = global_value.i64 gv3
-;; @002c                               v5 = load.i64 notrap aligned v4+8
-;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v7 = global_value.i64 gv4
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               store little heap v3, v8
+;; @0031                               v4 = uextend.i64 v2
+;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v6 = iadd v5, v4
+;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/fac-multi-value.wat
+++ b/tests/disas/fac-multi-value.wat
@@ -24,14 +24,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @003b                               v5 = global_value.i64 gv3
-;; @003b                               v6 = load.i64 notrap aligned v5+8
 ;; @0040                               jump block1(v2, v2)
 ;;
 ;;                                 block1(v3: i64, v4: i64):
@@ -42,14 +39,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @0042                               v7 = global_value.i64 gv3
-;; @0042                               v8 = load.i64 notrap aligned v7+8
 ;; @0049                               jump block1(v2, v3, v2)
 ;;
 ;;                                 block1(v4: i64, v5: i64, v6: i64):
@@ -60,7 +54,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i64, i64) -> i64, i64, i64 fast
 ;;     sig1 = (i64 vmctx, i64, i64) -> i64, i64 fast
 ;;     sig2 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
@@ -70,24 +63,22 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004b                               v4 = global_value.i64 gv3
-;; @004b                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 1
-;; @0050                               jump block2(v6, v2)  ; v6 = 1
+;; @004c                               v4 = iconst.i64 1
+;; @0050                               jump block2(v4, v2)  ; v4 = 1
 ;;
-;;                                 block2(v7: i64, v8: i64):
-;; @0052                               v10, v11, v12 = call fn0(v0, v0, v7, v8)
-;; @0054                               v13, v14, v15 = call fn0(v0, v0, v11, v12)
-;; @0056                               v16 = imul v14, v15
-;; @0057                               v17, v18, v19 = call fn0(v0, v0, v13, v16)
-;; @0059                               v20 = iconst.i64 1
-;; @005b                               v21 = isub v19, v20  ; v20 = 1
-;; @005c                               v22, v23 = call fn1(v0, v0, v21)
-;; @005e                               v24 = iconst.i64 0
-;; @0060                               v25 = icmp ugt v23, v24  ; v24 = 0
-;; @0060                               v26 = uextend.i32 v25
-;; @0061                               brif v26, block2(v18, v22), block4
+;;                                 block2(v5: i64, v6: i64):
+;; @0052                               v8, v9, v10 = call fn0(v0, v0, v5, v6)
+;; @0054                               v11, v12, v13 = call fn0(v0, v0, v9, v10)
+;; @0056                               v14 = imul v12, v13
+;; @0057                               v15, v16, v17 = call fn0(v0, v0, v11, v14)
+;; @0059                               v18 = iconst.i64 1
+;; @005b                               v19 = isub v17, v18  ; v18 = 1
+;; @005c                               v20, v21 = call fn1(v0, v0, v19)
+;; @005e                               v22 = iconst.i64 0
+;; @0060                               v23 = icmp ugt v21, v22  ; v22 = 0
+;; @0060                               v24 = uextend.i32 v23
+;; @0061                               brif v24, block2(v16, v20), block4
 ;;
 ;;                                 block4:
-;; @0064                               return v18
+;; @0064                               return v16
 ;; }

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -36,32 +36,30 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @001f                               v2 = iconst.i32 0
-;; @001f                               v3 = global_value.i64 gv3
-;; @001f                               v4 = load.i64 notrap aligned v3+8
-;; @0021                               v5 = iconst.i32 0
-;; @0025                               v6 = iconst.i32 1
-;; @0029                               v7 = iconst.i32 1
-;; @002d                               v8 = iconst.i32 0
-;; @0033                               jump block3(v5, v7, v6)  ; v5 = 0, v7 = 1, v6 = 1
+;; @0021                               v3 = iconst.i32 0
+;; @0025                               v4 = iconst.i32 1
+;; @0029                               v5 = iconst.i32 1
+;; @002d                               v6 = iconst.i32 0
+;; @0033                               jump block3(v3, v5, v4)  ; v3 = 0, v5 = 1, v4 = 1
 ;;
-;;                                 block3(v9: i32, v13: i32, v14: i32):
-;; @0037                               v10 = iconst.i32 5
-;; @0039                               v11 = icmp sgt v9, v10  ; v10 = 5
-;; @0039                               v12 = uextend.i32 v11
-;; @003a                               brif v12, block2, block5
+;;                                 block3(v7: i32, v11: i32, v12: i32):
+;; @0037                               v8 = iconst.i32 5
+;; @0039                               v9 = icmp sgt v7, v8  ; v8 = 5
+;; @0039                               v10 = uextend.i32 v9
+;; @003a                               brif v10, block2, block5
 ;;
 ;;                                 block5:
-;; @0044                               v15 = iadd.i32 v13, v14
-;; @004d                               v16 = iconst.i32 1
-;; @004f                               v17 = iadd.i32 v9, v16  ; v16 = 1
-;; @0052                               jump block3(v17, v15, v13)
+;; @0044                               v13 = iadd.i32 v11, v12
+;; @004d                               v14 = iconst.i32 1
+;; @004f                               v15 = iadd.i32 v7, v14  ; v14 = 1
+;; @0052                               jump block3(v15, v13, v11)
 ;;
 ;;                                 block2:
-;; @0056                               v18 = iconst.i32 0
-;; @005a                               v19 = uextend.i64 v18  ; v18 = 0
-;; @005a                               v20 = global_value.i64 gv4
-;; @005a                               v21 = iadd v20, v19
-;; @005a                               store.i32 little heap v13, v21
+;; @0056                               v16 = iconst.i32 0
+;; @005a                               v17 = uextend.i64 v16  ; v16 = 0
+;; @005a                               v18 = global_value.i64 gv4
+;; @005a                               v19 = iadd v18, v17
+;; @005a                               store.i32 little heap v11, v19
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -33,15 +33,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003c                               v4 = global_value.i64 gv3
-;; @003c                               v5 = load.i64 notrap aligned v4+8
-;; @0041                               v6 = uextend.i64 v2
-;; @0041                               v7 = iconst.i64 0x0001_0000
-;; @0041                               v8 = icmp uge v6, v7  ; v7 = 0x0001_0000
-;; @0041                               trapnz v8, heap_oob
-;; @0041                               v9 = global_value.i64 gv5
-;; @0041                               v10 = iadd v9, v6
-;; @0041                               istore8 little heap v3, v10
+;; @0041                               v4 = uextend.i64 v2
+;; @0041                               v5 = iconst.i64 0x0001_0000
+;; @0041                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
+;; @0041                               trapnz v6, heap_oob
+;; @0041                               v7 = global_value.i64 gv5
+;; @0041                               v8 = iadd v7, v4
+;; @0041                               istore8 little heap v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,16 +59,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = iconst.i64 0x0001_0000
-;; @0049                               v8 = icmp uge v6, v7  ; v7 = 0x0001_0000
-;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = global_value.i64 gv5
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = uload8.i32 little heap v10
-;; @004c                               jump block1(v11)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = iconst.i64 0x0001_0000
+;; @0049                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = uload8.i32 little heap v8
+;; @004c                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004c                               return v3

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -22,15 +22,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0027                               v2 = iconst.i32 0
-;; @0027                               v3 = global_value.i64 gv3
-;; @0027                               v4 = load.i64 notrap aligned v3+8
-;; @0029                               v5 = iconst.i32 0
-;; @002b                               v6 = global_value.i64 gv3
-;; @002b                               v7 = load.i32 notrap aligned table v6+96
-;; @002d                               v8 = uextend.i64 v5  ; v5 = 0
-;; @002d                               v9 = global_value.i64 gv4
-;; @002d                               v10 = iadd v9, v8
-;; @002d                               store little heap v7, v10
+;; @0029                               v3 = iconst.i32 0
+;; @002b                               v4 = global_value.i64 gv3
+;; @002b                               v5 = load.i32 notrap aligned table v4+96
+;; @002d                               v6 = uextend.i64 v3  ; v3 = 0
+;; @002d                               v7 = global_value.i64 gv4
+;; @002d                               v8 = iadd v7, v6
+;; @002d                               store little heap v5, v8
 ;; @0030                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002b                               v4 = global_value.i64 gv3
-;; @002b                               v5 = load.i64 notrap aligned v4+8
-;; @002e                               v6 = uextend.i64 v2
-;; @002e                               v7 = global_value.i64 gv4
-;; @002e                               v8 = iadd v7, v6
-;; @002e                               v9 = load.i32 little heap v8
-;; @0031                               jump block1(v9)
+;; @002e                               v4 = uextend.i64 v2
+;; @002e                               v5 = global_value.i64 gv4
+;; @002e                               v6 = iadd v5, v4
+;; @002e                               v7 = load.i32 little heap v6
+;; @0031                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0031                               return v3

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002f                               v4 = global_value.i64 gv3
-;; @002f                               v5 = load.i64 notrap aligned v4+8
-;; @0032                               v6 = uextend.i64 v2
-;; @0032                               v7 = global_value.i64 gv4
-;; @0032                               v8 = iadd v7, v6
-;; @0032                               v9 = sload16.i32 little heap v8
-;; @0035                               jump block1(v9)
+;; @0032                               v4 = uextend.i64 v2
+;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v6 = iadd v5, v4
+;; @0032                               v7 = sload16.i32 little heap v6
+;; @0035                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0035                               return v3

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002f                               v4 = global_value.i64 gv3
-;; @002f                               v5 = load.i64 notrap aligned v4+8
-;; @0032                               v6 = uextend.i64 v2
-;; @0032                               v7 = global_value.i64 gv4
-;; @0032                               v8 = iadd v7, v6
-;; @0032                               v9 = uload16.i32 little heap v8
-;; @0035                               jump block1(v9)
+;; @0032                               v4 = uextend.i64 v2
+;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v6 = iadd v5, v4
+;; @0032                               v7 = uload16.i32 little heap v6
+;; @0035                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0035                               return v3

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = global_value.i64 gv3
-;; @002e                               v5 = load.i64 notrap aligned v4+8
-;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v7 = global_value.i64 gv4
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               v9 = sload8.i32 little heap v8
-;; @0034                               jump block1(v9)
+;; @0031                               v4 = uextend.i64 v2
+;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v6 = iadd v5, v4
+;; @0031                               v7 = sload8.i32 little heap v6
+;; @0034                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0034                               return v3

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = global_value.i64 gv3
-;; @002e                               v5 = load.i64 notrap aligned v4+8
-;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v7 = global_value.i64 gv4
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               v9 = uload8.i32 little heap v8
-;; @0034                               jump block1(v9)
+;; @0031                               v4 = uextend.i64 v2
+;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v6 = iadd v5, v4
+;; @0031                               v7 = uload8.i32 little heap v6
+;; @0034                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0034                               return v3

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -21,12 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @002c                               v4 = global_value.i64 gv3
-;; @002c                               v5 = load.i64 notrap aligned v4+8
-;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v7 = global_value.i64 gv4
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               store little heap v3, v8
+;; @0031                               v4 = uextend.i64 v2
+;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v6 = iadd v5, v4
+;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -21,12 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @002e                               v4 = global_value.i64 gv3
-;; @002e                               v5 = load.i64 notrap aligned v4+8
-;; @0033                               v6 = uextend.i64 v2
-;; @0033                               v7 = global_value.i64 gv4
-;; @0033                               v8 = iadd v7, v6
-;; @0033                               istore16 little heap v3, v8
+;; @0033                               v4 = uextend.i64 v2
+;; @0033                               v5 = global_value.i64 gv4
+;; @0033                               v6 = iadd v5, v4
+;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -21,12 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @002d                               v4 = global_value.i64 gv3
-;; @002d                               v5 = load.i64 notrap aligned v4+8
-;; @0032                               v6 = uextend.i64 v2
-;; @0032                               v7 = global_value.i64 gv4
-;; @0032                               v8 = iadd v7, v6
-;; @0032                               istore8 little heap v3, v8
+;; @0032                               v4 = uextend.i64 v2
+;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v6 = iadd v5, v4
+;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002b                               v4 = global_value.i64 gv3
-;; @002b                               v5 = load.i64 notrap aligned v4+8
-;; @002e                               v6 = uextend.i64 v2
-;; @002e                               v7 = global_value.i64 gv4
-;; @002e                               v8 = iadd v7, v6
-;; @002e                               v9 = load.i64 little heap v8
-;; @0031                               jump block1(v9)
+;; @002e                               v4 = uextend.i64 v2
+;; @002e                               v5 = global_value.i64 gv4
+;; @002e                               v6 = iadd v5, v4
+;; @002e                               v7 = load.i64 little heap v6
+;; @0031                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i64):
 ;; @0031                               return v3

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002f                               v4 = global_value.i64 gv3
-;; @002f                               v5 = load.i64 notrap aligned v4+8
-;; @0032                               v6 = uextend.i64 v2
-;; @0032                               v7 = global_value.i64 gv4
-;; @0032                               v8 = iadd v7, v6
-;; @0032                               v9 = sload16.i64 little heap v8
-;; @0035                               jump block1(v9)
+;; @0032                               v4 = uextend.i64 v2
+;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v6 = iadd v5, v4
+;; @0032                               v7 = sload16.i64 little heap v6
+;; @0035                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i64):
 ;; @0035                               return v3

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002f                               v4 = global_value.i64 gv3
-;; @002f                               v5 = load.i64 notrap aligned v4+8
-;; @0032                               v6 = uextend.i64 v2
-;; @0032                               v7 = global_value.i64 gv4
-;; @0032                               v8 = iadd v7, v6
-;; @0032                               v9 = uload16.i64 little heap v8
-;; @0035                               jump block1(v9)
+;; @0032                               v4 = uextend.i64 v2
+;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v6 = iadd v5, v4
+;; @0032                               v7 = uload16.i64 little heap v6
+;; @0035                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i64):
 ;; @0035                               return v3

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = global_value.i64 gv3
-;; @002e                               v5 = load.i64 notrap aligned v4+8
-;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v7 = global_value.i64 gv4
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               v9 = sload8.i64 little heap v8
-;; @0034                               jump block1(v9)
+;; @0031                               v4 = uextend.i64 v2
+;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v6 = iadd v5, v4
+;; @0031                               v7 = sload8.i64 little heap v6
+;; @0034                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i64):
 ;; @0034                               return v3

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002e                               v4 = global_value.i64 gv3
-;; @002e                               v5 = load.i64 notrap aligned v4+8
-;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v7 = global_value.i64 gv4
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               v9 = uload8.i64 little heap v8
-;; @0034                               jump block1(v9)
+;; @0031                               v4 = uextend.i64 v2
+;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v6 = iadd v5, v4
+;; @0031                               v7 = uload8.i64 little heap v6
+;; @0034                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i64):
 ;; @0034                               return v3

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -21,12 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
-;; @002c                               v4 = global_value.i64 gv3
-;; @002c                               v5 = load.i64 notrap aligned v4+8
-;; @0031                               v6 = uextend.i64 v2
-;; @0031                               v7 = global_value.i64 gv4
-;; @0031                               v8 = iadd v7, v6
-;; @0031                               store little heap v3, v8
+;; @0031                               v4 = uextend.i64 v2
+;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v6 = iadd v5, v4
+;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -21,12 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
-;; @002e                               v4 = global_value.i64 gv3
-;; @002e                               v5 = load.i64 notrap aligned v4+8
-;; @0033                               v6 = uextend.i64 v2
-;; @0033                               v7 = global_value.i64 gv4
-;; @0033                               v8 = iadd v7, v6
-;; @0033                               istore16 little heap v3, v8
+;; @0033                               v4 = uextend.i64 v2
+;; @0033                               v5 = global_value.i64 gv4
+;; @0033                               v6 = iadd v5, v4
+;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -21,12 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
-;; @002e                               v4 = global_value.i64 gv3
-;; @002e                               v5 = load.i64 notrap aligned v4+8
-;; @0033                               v6 = uextend.i64 v2
-;; @0033                               v7 = global_value.i64 gv4
-;; @0033                               v8 = iadd v7, v6
-;; @0033                               istore32 little heap v3, v8
+;; @0033                               v4 = uextend.i64 v2
+;; @0033                               v5 = global_value.i64 gv4
+;; @0033                               v6 = iadd v5, v4
+;; @0033                               istore32 little heap v3, v6
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -21,12 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
-;; @002d                               v4 = global_value.i64 gv3
-;; @002d                               v5 = load.i64 notrap aligned v4+8
-;; @0032                               v6 = uextend.i64 v2
-;; @0032                               v7 = global_value.i64 gv4
-;; @0032                               v8 = iadd v7, v6
-;; @0032                               istore8 little heap v3, v8
+;; @0032                               v4 = uextend.i64 v2
+;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v6 = iadd v5, v4
+;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -21,39 +21,37 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i8x16):
-;; @002e                               v5 = global_value.i64 gv3
-;; @002e                               v6 = load.i64 notrap aligned v5+8
-;; @0033                               v7 = iconst.i32 23
-;; @0033                               v8 = icmp uge v2, v7  ; v7 = 23
-;; @0033                               v9 = uextend.i64 v2
-;; @0033                               v10 = global_value.i64 gv4
-;; @0033                               v11 = ishl_imm v9, 3
-;; @0033                               v12 = iadd v10, v11
-;; @0033                               v13 = iconst.i64 0
-;; @0033                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0033                               v15 = load.i64 table_oob aligned table v14
-;; @0033                               v16 = band_imm v15, -2
-;; @0033                               brif v15, block3(v16), block2
+;; @0033                               v5 = iconst.i32 23
+;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
+;; @0033                               v7 = uextend.i64 v2
+;; @0033                               v8 = global_value.i64 gv4
+;; @0033                               v9 = ishl_imm v7, 3
+;; @0033                               v10 = iadd v8, v9
+;; @0033                               v11 = iconst.i64 0
+;; @0033                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0033                               v13 = load.i64 table_oob aligned table v12
+;; @0033                               v14 = band_imm v13, -2
+;; @0033                               brif v13, block3(v14), block2
 ;;
 ;;                                 block2 cold:
-;; @0033                               v18 = iconst.i32 0
-;; @0033                               v19 = global_value.i64 gv3
-;; @0033                               v20 = load.i64 notrap aligned readonly v19+56
-;; @0033                               v21 = load.i64 notrap aligned readonly v20+72
-;; @0033                               v22 = call_indirect sig1, v21(v19, v18, v2)  ; v18 = 0
-;; @0033                               jump block3(v22)
+;; @0033                               v16 = iconst.i32 0
+;; @0033                               v17 = global_value.i64 gv3
+;; @0033                               v18 = load.i64 notrap aligned readonly v17+56
+;; @0033                               v19 = load.i64 notrap aligned readonly v18+72
+;; @0033                               v20 = call_indirect sig1, v19(v17, v16, v2)  ; v16 = 0
+;; @0033                               jump block3(v20)
 ;;
-;;                                 block3(v17: i64):
-;; @0033                               v23 = global_value.i64 gv3
-;; @0033                               v24 = load.i64 notrap aligned readonly v23+64
-;; @0033                               v25 = load.i32 notrap aligned readonly v24
-;; @0033                               v26 = load.i32 icall_null aligned readonly v17+24
-;; @0033                               v27 = icmp eq v26, v25
-;; @0033                               trapz v27, bad_sig
-;; @0033                               v28 = load.i64 notrap aligned readonly v17+16
-;; @0033                               v29 = load.i64 notrap aligned readonly v17+32
-;; @0033                               v30 = call_indirect sig0, v28(v29, v0, v3)
-;; @0036                               jump block1(v30)
+;;                                 block3(v15: i64):
+;; @0033                               v21 = global_value.i64 gv3
+;; @0033                               v22 = load.i64 notrap aligned readonly v21+64
+;; @0033                               v23 = load.i32 notrap aligned readonly v22
+;; @0033                               v24 = load.i32 icall_null aligned readonly v15+24
+;; @0033                               v25 = icmp eq v24, v23
+;; @0033                               trapz v25, bad_sig
+;; @0033                               v26 = load.i64 notrap aligned readonly v15+16
+;; @0033                               v27 = load.i64 notrap aligned readonly v15+32
+;; @0033                               v28 = call_indirect sig0, v26(v27, v0, v3)
+;; @0036                               jump block1(v28)
 ;;
 ;;                                 block1(v4: i8x16):
 ;; @0036                               return v4

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -21,39 +21,37 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
-;; @002e                               v5 = global_value.i64 gv3
-;; @002e                               v6 = load.i64 notrap aligned v5+8
-;; @0033                               v7 = iconst.i32 23
-;; @0033                               v8 = icmp uge v2, v7  ; v7 = 23
-;; @0033                               v9 = uextend.i64 v2
-;; @0033                               v10 = global_value.i64 gv4
-;; @0033                               v11 = ishl_imm v9, 3
-;; @0033                               v12 = iadd v10, v11
-;; @0033                               v13 = iconst.i64 0
-;; @0033                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0033                               v15 = load.i64 table_oob aligned table v14
-;; @0033                               v16 = band_imm v15, -2
-;; @0033                               brif v15, block3(v16), block2
+;; @0033                               v5 = iconst.i32 23
+;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
+;; @0033                               v7 = uextend.i64 v2
+;; @0033                               v8 = global_value.i64 gv4
+;; @0033                               v9 = ishl_imm v7, 3
+;; @0033                               v10 = iadd v8, v9
+;; @0033                               v11 = iconst.i64 0
+;; @0033                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0033                               v13 = load.i64 table_oob aligned table v12
+;; @0033                               v14 = band_imm v13, -2
+;; @0033                               brif v13, block3(v14), block2
 ;;
 ;;                                 block2 cold:
-;; @0033                               v18 = iconst.i32 0
-;; @0033                               v19 = global_value.i64 gv3
-;; @0033                               v20 = load.i64 notrap aligned readonly v19+56
-;; @0033                               v21 = load.i64 notrap aligned readonly v20+72
-;; @0033                               v22 = call_indirect sig1, v21(v19, v18, v2)  ; v18 = 0
-;; @0033                               jump block3(v22)
+;; @0033                               v16 = iconst.i32 0
+;; @0033                               v17 = global_value.i64 gv3
+;; @0033                               v18 = load.i64 notrap aligned readonly v17+56
+;; @0033                               v19 = load.i64 notrap aligned readonly v18+72
+;; @0033                               v20 = call_indirect sig1, v19(v17, v16, v2)  ; v16 = 0
+;; @0033                               jump block3(v20)
 ;;
-;;                                 block3(v17: i64):
-;; @0033                               v23 = global_value.i64 gv3
-;; @0033                               v24 = load.i64 notrap aligned readonly v23+64
-;; @0033                               v25 = load.i32 notrap aligned readonly v24
-;; @0033                               v26 = load.i32 icall_null aligned readonly v17+24
-;; @0033                               v27 = icmp eq v26, v25
-;; @0033                               trapz v27, bad_sig
-;; @0033                               v28 = load.i64 notrap aligned readonly v17+16
-;; @0033                               v29 = load.i64 notrap aligned readonly v17+32
-;; @0033                               v30 = call_indirect sig0, v28(v29, v0, v3)
-;; @0036                               jump block1(v30)
+;;                                 block3(v15: i64):
+;; @0033                               v21 = global_value.i64 gv3
+;; @0033                               v22 = load.i64 notrap aligned readonly v21+64
+;; @0033                               v23 = load.i32 notrap aligned readonly v22
+;; @0033                               v24 = load.i32 icall_null aligned readonly v15+24
+;; @0033                               v25 = icmp eq v24, v23
+;; @0033                               trapz v25, bad_sig
+;; @0033                               v26 = load.i64 notrap aligned readonly v15+16
+;; @0033                               v27 = load.i64 notrap aligned readonly v15+32
+;; @0033                               v28 = call_indirect sig0, v26(v27, v0, v3)
+;; @0036                               jump block1(v28)
 ;;
 ;;                                 block1(v4: i32):
 ;; @0036                               return v4

--- a/tests/disas/if-reachability-translation-0.wat
+++ b/tests/disas/if-reachability-translation-0.wat
@@ -17,11 +17,8 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0018                               v4 = global_value.i64 gv3
-;; @0018                               v5 = load.i64 notrap aligned v4+8
 ;; @0019                               trap unreachable
 ;; }

--- a/tests/disas/if-reachability-translation-1.wat
+++ b/tests/disas/if-reachability-translation-1.wat
@@ -17,14 +17,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0018                               v4 = global_value.i64 gv3
-;; @0018                               v5 = load.i64 notrap aligned v4+8
 ;; @001b                               brif v2, block2, block4
 ;;
 ;;                                 block2:
@@ -34,8 +31,8 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0021                               v6 = iconst.i32 0
-;; @0023                               jump block1(v6)  ; v6 = 0
+;; @0021                               v4 = iconst.i32 0
+;; @0023                               jump block1(v4)  ; v4 = 0
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/if-reachability-translation-2.wat
+++ b/tests/disas/if-reachability-translation-2.wat
@@ -17,14 +17,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0018                               v4 = global_value.i64 gv3
-;; @0018                               v5 = load.i64 notrap aligned v4+8
 ;; @001b                               brif v2, block2, block4
 ;;
 ;;                                 block2:
@@ -34,8 +31,8 @@
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0021                               v6 = iconst.i32 0
-;; @0023                               jump block1(v6)  ; v6 = 0
+;; @0021                               v4 = iconst.i32 0
+;; @0023                               jump block1(v4)  ; v4 = 0
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/if-reachability-translation-3.wat
+++ b/tests/disas/if-reachability-translation-3.wat
@@ -17,14 +17,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0018                               v4 = global_value.i64 gv3
-;; @0018                               v5 = load.i64 notrap aligned v4+8
 ;; @001b                               brif v2, block2, block4
 ;;
 ;;                                 block2:
@@ -34,8 +31,8 @@
 ;; @001f                               trap unreachable
 ;;
 ;;                                 block3:
-;; @0021                               v6 = iconst.i32 0
-;; @0023                               jump block1(v6)  ; v6 = 0
+;; @0021                               v4 = iconst.i32 0
+;; @0023                               jump block1(v4)  ; v4 = 0
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/if-reachability-translation-4.wat
+++ b/tests/disas/if-reachability-translation-4.wat
@@ -17,12 +17,9 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0018                               v4 = global_value.i64 gv3
-;; @0018                               v5 = load.i64 notrap aligned v4+8
 ;; @001b                               brif v2, block2, block4
 ;;
 ;;                                 block2:

--- a/tests/disas/if-reachability-translation-5.wat
+++ b/tests/disas/if-reachability-translation-5.wat
@@ -19,14 +19,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0019                               v5 = global_value.i64 gv3
-;; @0019                               v6 = load.i64 notrap aligned v5+8
 ;; @001c                               brif v2, block2, block5
 ;;
 ;;                                 block2:
@@ -39,8 +36,8 @@
 ;; @0024                               trap unreachable
 ;;
 ;;                                 block3:
-;; @0026                               v7 = iconst.i32 0
-;; @0028                               jump block1(v7)  ; v7 = 0
+;; @0026                               v5 = iconst.i32 0
+;; @0028                               jump block1(v5)  ; v5 = 0
 ;;
 ;;                                 block1(v4: i32):
 ;; @0028                               return v4

--- a/tests/disas/if-reachability-translation-6.wat
+++ b/tests/disas/if-reachability-translation-6.wat
@@ -19,14 +19,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0019                               v5 = global_value.i64 gv3
-;; @0019                               v6 = load.i64 notrap aligned v5+8
 ;; @001c                               brif v2, block2, block4
 ;;
 ;;                                 block2:
@@ -39,8 +36,8 @@
 ;; @0024                               trap unreachable
 ;;
 ;;                                 block3:
-;; @0026                               v7 = iconst.i32 0
-;; @0028                               jump block1(v7)  ; v7 = 0
+;; @0026                               v5 = iconst.i32 0
+;; @0028                               jump block1(v5)  ; v5 = 0
 ;;
 ;;                                 block1(v4: i32):
 ;; @0028                               return v4

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -31,23 +31,21 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0048                               v5 = global_value.i64 gv3
-;; @0048                               v6 = load.i64 notrap aligned v5+8
-;; @0049                               v7 = f64const 0x1.0000000000000p0
+;; @0049                               v5 = f64const 0x1.0000000000000p0
 ;; @0056                               brif v3, block2, block4(v2)
 ;;
 ;;                                 block2:
-;; @0058                               v9 = uextend.i64 v2
-;; @0058                               v10 = global_value.i64 gv4
-;; @0058                               v11 = iadd v10, v9
-;; @0058                               v12 = sload16.i64 little heap v11
+;; @0058                               v7 = uextend.i64 v2
+;; @0058                               v8 = global_value.i64 gv4
+;; @0058                               v9 = iadd v8, v7
+;; @0058                               v10 = sload16.i64 little heap v9
 ;; @005c                               jump block3
 ;;
-;;                                 block4(v8: i32):
+;;                                 block4(v6: i32):
 ;; @005d                               trap unreachable
 ;;
 ;;                                 block3:
-;; @005f                               jump block1(v7)  ; v7 = 0x1.0000000000000p0
+;; @005f                               jump block1(v5)  ; v5 = 0x1.0000000000000p0
 ;;
 ;;                                 block1(v4: f64):
 ;; @005f                               return v4

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -54,23 +54,21 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v7 -> v2
-;; @0042                               v3 = global_value.i64 gv3
-;; @0042                               v4 = load.i64 notrap aligned v3+8
-;; @0043                               v5 = iconst.i32 35
-;; @0045                               jump block2(v5)  ; v5 = 35
+;;                                     v5 -> v2
+;; @0043                               v3 = iconst.i32 35
+;; @0045                               jump block2(v3)  ; v3 = 35
 ;;
-;;                                 block2(v6: i32):
-;; @0049                               brif.i32 v7, block4, block6(v6)
+;;                                 block2(v4: i32):
+;; @0049                               brif.i32 v5, block4, block6(v4)
 ;;
 ;;                                 block4:
-;; @004b                               v9 = uextend.i64 v6
-;; @004b                               v10 = global_value.i64 gv4
-;; @004b                               v11 = iadd v10, v9
-;; @004b                               v12 = sload16.i64 little heap v11
+;; @004b                               v7 = uextend.i64 v4
+;; @004b                               v8 = global_value.i64 gv4
+;; @004b                               v9 = iadd v8, v7
+;; @004b                               v10 = sload16.i64 little heap v9
 ;; @004e                               trap unreachable
 ;;
-;;                                 block6(v8: i32):
-;; @005d                               v13 = popcnt.i32 v6
+;;                                 block6(v6: i32):
+;; @005d                               v11 = popcnt.i32 v4
 ;; @0060                               return
 ;; }

--- a/tests/disas/issue-5696.wat
+++ b/tests/disas/issue-5696.wat
@@ -13,16 +13,14 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;;                                     v4 -> v0
 ;; @001e                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v9 = iconst.i64 0
-;; @001e                               return v9  ; v9 = 0
+;;                                     v7 = iconst.i64 0
+;; @001e                               return v7  ; v7 = 0
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iconst.i64 4
-;; @0040                               v9 = isub v7, v8  ; v8 = 4
-;; @0040                               v10 = icmp ugt v6, v9
-;; @0040                               trapnz v10, heap_oob
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               store little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iconst.i64 4
+;; @0040                               v7 = isub v5, v6  ; v6 = 4
+;; @0040                               v8 = icmp ugt v4, v7
+;; @0040                               trapnz v8, heap_oob
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               store little heap v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = iconst.i64 4
-;; @0048                               v9 = isub v7, v8  ; v8 = 4
-;; @0048                               v10 = icmp ugt v6, v9
-;; @0048                               trapnz v10, heap_oob
-;; @0048                               v11 = global_value.i64 gv5
-;; @0048                               v12 = iadd v11, v6
-;; @0048                               v13 = load.i32 little heap v12
-;; @004b                               jump block1(v13)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = iconst.i64 4
+;; @0048                               v7 = isub v5, v6  ; v6 = 4
+;; @0048                               v8 = icmp ugt v4, v7
+;; @0048                               trapnz v8, heap_oob
+;; @0048                               v9 = global_value.i64 gv5
+;; @0048                               v10 = iadd v9, v4
+;; @0048                               v11 = load.i32 little heap v10
+;; @004b                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -31,19 +31,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iconst.i64 4100
-;; @0040                               v9 = isub v7, v8  ; v8 = 4100
-;; @0040                               v10 = icmp ugt v6, v9
-;; @0040                               trapnz v10, heap_oob
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               v13 = iconst.i64 4096
-;; @0040                               v14 = iadd v12, v13  ; v13 = 4096
-;; @0040                               store little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iconst.i64 4100
+;; @0040                               v7 = isub v5, v6  ; v6 = 4100
+;; @0040                               v8 = icmp ugt v4, v7
+;; @0040                               trapnz v8, heap_oob
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               v11 = iconst.i64 4096
+;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
+;; @0040                               store little heap v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -63,20 +61,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = iconst.i64 4100
-;; @0049                               v9 = isub v7, v8  ; v8 = 4100
-;; @0049                               v10 = icmp ugt v6, v9
-;; @0049                               trapnz v10, heap_oob
-;; @0049                               v11 = global_value.i64 gv5
-;; @0049                               v12 = iadd v11, v6
-;; @0049                               v13 = iconst.i64 4096
-;; @0049                               v14 = iadd v12, v13  ; v13 = 4096
-;; @0049                               v15 = load.i32 little heap v14
-;; @004d                               jump block1(v15)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = iconst.i64 4100
+;; @0049                               v7 = isub v5, v6  ; v6 = 4100
+;; @0049                               v8 = icmp ugt v4, v7
+;; @0049                               trapnz v8, heap_oob
+;; @0049                               v9 = global_value.i64 gv5
+;; @0049                               v10 = iadd v9, v4
+;; @0049                               v11 = iconst.i64 4096
+;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
+;; @0049                               v13 = load.i32 little heap v12
+;; @004d                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -31,19 +31,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_0004
-;; @0040                               v8 = uadd_overflow_trap v6, v7, heap_oob  ; v7 = 0xffff_0004
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = icmp ugt v8, v9
-;; @0040                               trapnz v10, heap_oob
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               v13 = iconst.i64 0xffff_0000
-;; @0040                               v14 = iadd v12, v13  ; v13 = 0xffff_0000
-;; @0040                               store little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_0004
+;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = icmp ugt v6, v7
+;; @0040                               trapnz v8, heap_oob
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               v11 = iconst.i64 0xffff_0000
+;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
+;; @0040                               store little heap v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -63,20 +61,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = iconst.i64 0xffff_0004
-;; @004c                               v8 = uadd_overflow_trap v6, v7, heap_oob  ; v7 = 0xffff_0004
-;; @004c                               v9 = global_value.i64 gv4
-;; @004c                               v10 = icmp ugt v8, v9
-;; @004c                               trapnz v10, heap_oob
-;; @004c                               v11 = global_value.i64 gv5
-;; @004c                               v12 = iadd v11, v6
-;; @004c                               v13 = iconst.i64 0xffff_0000
-;; @004c                               v14 = iadd v12, v13  ; v13 = 0xffff_0000
-;; @004c                               v15 = load.i32 little heap v14
-;; @0053                               jump block1(v15)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = iconst.i64 0xffff_0004
+;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
+;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v8 = icmp ugt v6, v7
+;; @004c                               trapnz v8, heap_oob
+;; @004c                               v9 = global_value.i64 gv5
+;; @004c                               v10 = iadd v9, v4
+;; @004c                               v11 = iconst.i64 0xffff_0000
+;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
+;; @004c                               v13 = load.i32 little heap v12
+;; @0053                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -31,15 +31,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp uge v6, v7
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               istore8 little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp uge v4, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               istore8 little heap v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,16 +57,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = icmp uge v6, v7
-;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = global_value.i64 gv5
-;; @0048                               v10 = iadd v9, v6
-;; @0048                               v11 = uload8.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = icmp uge v4, v5
+;; @0048                               trapnz v6, heap_oob
+;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v8 = iadd v7, v4
+;; @0048                               v9 = uload8.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -31,19 +31,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iconst.i64 4097
-;; @0040                               v9 = isub v7, v8  ; v8 = 4097
-;; @0040                               v10 = icmp ugt v6, v9
-;; @0040                               trapnz v10, heap_oob
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               v13 = iconst.i64 4096
-;; @0040                               v14 = iadd v12, v13  ; v13 = 4096
-;; @0040                               istore8 little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iconst.i64 4097
+;; @0040                               v7 = isub v5, v6  ; v6 = 4097
+;; @0040                               v8 = icmp ugt v4, v7
+;; @0040                               trapnz v8, heap_oob
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               v11 = iconst.i64 4096
+;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
+;; @0040                               istore8 little heap v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -63,20 +61,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = iconst.i64 4097
-;; @0049                               v9 = isub v7, v8  ; v8 = 4097
-;; @0049                               v10 = icmp ugt v6, v9
-;; @0049                               trapnz v10, heap_oob
-;; @0049                               v11 = global_value.i64 gv5
-;; @0049                               v12 = iadd v11, v6
-;; @0049                               v13 = iconst.i64 4096
-;; @0049                               v14 = iadd v12, v13  ; v13 = 4096
-;; @0049                               v15 = uload8.i32 little heap v14
-;; @004d                               jump block1(v15)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = iconst.i64 4097
+;; @0049                               v7 = isub v5, v6  ; v6 = 4097
+;; @0049                               v8 = icmp ugt v4, v7
+;; @0049                               trapnz v8, heap_oob
+;; @0049                               v9 = global_value.i64 gv5
+;; @0049                               v10 = iadd v9, v4
+;; @0049                               v11 = iconst.i64 4096
+;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
+;; @0049                               v13 = uload8.i32 little heap v12
+;; @004d                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -31,19 +31,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_0001
-;; @0040                               v8 = uadd_overflow_trap v6, v7, heap_oob  ; v7 = 0xffff_0001
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = icmp ugt v8, v9
-;; @0040                               trapnz v10, heap_oob
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               v13 = iconst.i64 0xffff_0000
-;; @0040                               v14 = iadd v12, v13  ; v13 = 0xffff_0000
-;; @0040                               istore8 little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_0001
+;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = icmp ugt v6, v7
+;; @0040                               trapnz v8, heap_oob
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               v11 = iconst.i64 0xffff_0000
+;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
+;; @0040                               istore8 little heap v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -63,20 +61,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = iconst.i64 0xffff_0001
-;; @004c                               v8 = uadd_overflow_trap v6, v7, heap_oob  ; v7 = 0xffff_0001
-;; @004c                               v9 = global_value.i64 gv4
-;; @004c                               v10 = icmp ugt v8, v9
-;; @004c                               trapnz v10, heap_oob
-;; @004c                               v11 = global_value.i64 gv5
-;; @004c                               v12 = iadd v11, v6
-;; @004c                               v13 = iconst.i64 0xffff_0000
-;; @004c                               v14 = iadd v12, v13  ; v13 = 0xffff_0000
-;; @004c                               v15 = uload8.i32 little heap v14
-;; @0053                               jump block1(v15)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = iconst.i64 0xffff_0001
+;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
+;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v8 = icmp ugt v6, v7
+;; @004c                               trapnz v8, heap_oob
+;; @004c                               v9 = global_value.i64 gv5
+;; @004c                               v10 = iadd v9, v4
+;; @004c                               v11 = iconst.i64 0xffff_0000
+;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
+;; @004c                               v13 = uload8.i32 little heap v12
+;; @0053                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -31,18 +31,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iconst.i64 4
-;; @0040                               v9 = isub v7, v8  ; v8 = 4
-;; @0040                               v10 = icmp ugt v6, v9
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               v13 = iconst.i64 0
-;; @0040                               v14 = select_spectre_guard v10, v13, v12  ; v13 = 0
-;; @0040                               store little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iconst.i64 4
+;; @0040                               v7 = isub v5, v6  ; v6 = 4
+;; @0040                               v8 = icmp ugt v4, v7
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
+;; @0040                               store little heap v3, v12
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -62,19 +60,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = iconst.i64 4
-;; @0048                               v9 = isub v7, v8  ; v8 = 4
-;; @0048                               v10 = icmp ugt v6, v9
-;; @0048                               v11 = global_value.i64 gv5
-;; @0048                               v12 = iadd v11, v6
-;; @0048                               v13 = iconst.i64 0
-;; @0048                               v14 = select_spectre_guard v10, v13, v12  ; v13 = 0
-;; @0048                               v15 = load.i32 little heap v14
-;; @004b                               jump block1(v15)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = iconst.i64 4
+;; @0048                               v7 = isub v5, v6  ; v6 = 4
+;; @0048                               v8 = icmp ugt v4, v7
+;; @0048                               v9 = global_value.i64 gv5
+;; @0048                               v10 = iadd v9, v4
+;; @0048                               v11 = iconst.i64 0
+;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
+;; @0048                               v13 = load.i32 little heap v12
+;; @004b                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -31,20 +31,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iconst.i64 4100
-;; @0040                               v9 = isub v7, v8  ; v8 = 4100
-;; @0040                               v10 = icmp ugt v6, v9
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               v13 = iconst.i64 4096
-;; @0040                               v14 = iadd v12, v13  ; v13 = 4096
-;; @0040                               v15 = iconst.i64 0
-;; @0040                               v16 = select_spectre_guard v10, v15, v14  ; v15 = 0
-;; @0040                               store little heap v3, v16
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iconst.i64 4100
+;; @0040                               v7 = isub v5, v6  ; v6 = 4100
+;; @0040                               v8 = icmp ugt v4, v7
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               v11 = iconst.i64 4096
+;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
+;; @0040                               v13 = iconst.i64 0
+;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
+;; @0040                               store little heap v3, v14
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -64,21 +62,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = iconst.i64 4100
-;; @0049                               v9 = isub v7, v8  ; v8 = 4100
-;; @0049                               v10 = icmp ugt v6, v9
-;; @0049                               v11 = global_value.i64 gv5
-;; @0049                               v12 = iadd v11, v6
-;; @0049                               v13 = iconst.i64 4096
-;; @0049                               v14 = iadd v12, v13  ; v13 = 4096
-;; @0049                               v15 = iconst.i64 0
-;; @0049                               v16 = select_spectre_guard v10, v15, v14  ; v15 = 0
-;; @0049                               v17 = load.i32 little heap v16
-;; @004d                               jump block1(v17)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = iconst.i64 4100
+;; @0049                               v7 = isub v5, v6  ; v6 = 4100
+;; @0049                               v8 = icmp ugt v4, v7
+;; @0049                               v9 = global_value.i64 gv5
+;; @0049                               v10 = iadd v9, v4
+;; @0049                               v11 = iconst.i64 4096
+;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
+;; @0049                               v13 = iconst.i64 0
+;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
+;; @0049                               v15 = load.i32 little heap v14
+;; @004d                               jump block1(v15)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -31,20 +31,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_0004
-;; @0040                               v8 = uadd_overflow_trap v6, v7, heap_oob  ; v7 = 0xffff_0004
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = icmp ugt v8, v9
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               v13 = iconst.i64 0xffff_0000
-;; @0040                               v14 = iadd v12, v13  ; v13 = 0xffff_0000
-;; @0040                               v15 = iconst.i64 0
-;; @0040                               v16 = select_spectre_guard v10, v15, v14  ; v15 = 0
-;; @0040                               store little heap v3, v16
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_0004
+;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = icmp ugt v6, v7
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               v11 = iconst.i64 0xffff_0000
+;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
+;; @0040                               v13 = iconst.i64 0
+;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
+;; @0040                               store little heap v3, v14
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -64,21 +62,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = iconst.i64 0xffff_0004
-;; @004c                               v8 = uadd_overflow_trap v6, v7, heap_oob  ; v7 = 0xffff_0004
-;; @004c                               v9 = global_value.i64 gv4
-;; @004c                               v10 = icmp ugt v8, v9
-;; @004c                               v11 = global_value.i64 gv5
-;; @004c                               v12 = iadd v11, v6
-;; @004c                               v13 = iconst.i64 0xffff_0000
-;; @004c                               v14 = iadd v12, v13  ; v13 = 0xffff_0000
-;; @004c                               v15 = iconst.i64 0
-;; @004c                               v16 = select_spectre_guard v10, v15, v14  ; v15 = 0
-;; @004c                               v17 = load.i32 little heap v16
-;; @0053                               jump block1(v17)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = iconst.i64 0xffff_0004
+;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
+;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v8 = icmp ugt v6, v7
+;; @004c                               v9 = global_value.i64 gv5
+;; @004c                               v10 = iadd v9, v4
+;; @004c                               v11 = iconst.i64 0xffff_0000
+;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
+;; @004c                               v13 = iconst.i64 0
+;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
+;; @004c                               v15 = load.i32 little heap v14
+;; @0053                               jump block1(v15)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -31,16 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp uge v6, v7
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0
-;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0040                               istore8 little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp uge v4, v5
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0
+;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0040                               istore8 little heap v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -60,17 +58,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = icmp uge v6, v7
-;; @0048                               v9 = global_value.i64 gv5
-;; @0048                               v10 = iadd v9, v6
-;; @0048                               v11 = iconst.i64 0
-;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0048                               v13 = uload8.i32 little heap v12
-;; @004b                               jump block1(v13)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = icmp uge v4, v5
+;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v8 = iadd v7, v4
+;; @0048                               v9 = iconst.i64 0
+;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0048                               v11 = uload8.i32 little heap v10
+;; @004b                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -31,20 +31,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iconst.i64 4097
-;; @0040                               v9 = isub v7, v8  ; v8 = 4097
-;; @0040                               v10 = icmp ugt v6, v9
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               v13 = iconst.i64 4096
-;; @0040                               v14 = iadd v12, v13  ; v13 = 4096
-;; @0040                               v15 = iconst.i64 0
-;; @0040                               v16 = select_spectre_guard v10, v15, v14  ; v15 = 0
-;; @0040                               istore8 little heap v3, v16
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iconst.i64 4097
+;; @0040                               v7 = isub v5, v6  ; v6 = 4097
+;; @0040                               v8 = icmp ugt v4, v7
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               v11 = iconst.i64 4096
+;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
+;; @0040                               v13 = iconst.i64 0
+;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
+;; @0040                               istore8 little heap v3, v14
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -64,21 +62,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = iconst.i64 4097
-;; @0049                               v9 = isub v7, v8  ; v8 = 4097
-;; @0049                               v10 = icmp ugt v6, v9
-;; @0049                               v11 = global_value.i64 gv5
-;; @0049                               v12 = iadd v11, v6
-;; @0049                               v13 = iconst.i64 4096
-;; @0049                               v14 = iadd v12, v13  ; v13 = 4096
-;; @0049                               v15 = iconst.i64 0
-;; @0049                               v16 = select_spectre_guard v10, v15, v14  ; v15 = 0
-;; @0049                               v17 = uload8.i32 little heap v16
-;; @004d                               jump block1(v17)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = iconst.i64 4097
+;; @0049                               v7 = isub v5, v6  ; v6 = 4097
+;; @0049                               v8 = icmp ugt v4, v7
+;; @0049                               v9 = global_value.i64 gv5
+;; @0049                               v10 = iadd v9, v4
+;; @0049                               v11 = iconst.i64 4096
+;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
+;; @0049                               v13 = iconst.i64 0
+;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
+;; @0049                               v15 = uload8.i32 little heap v14
+;; @004d                               jump block1(v15)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -31,20 +31,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_0001
-;; @0040                               v8 = uadd_overflow_trap v6, v7, heap_oob  ; v7 = 0xffff_0001
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = icmp ugt v8, v9
-;; @0040                               v11 = global_value.i64 gv5
-;; @0040                               v12 = iadd v11, v6
-;; @0040                               v13 = iconst.i64 0xffff_0000
-;; @0040                               v14 = iadd v12, v13  ; v13 = 0xffff_0000
-;; @0040                               v15 = iconst.i64 0
-;; @0040                               v16 = select_spectre_guard v10, v15, v14  ; v15 = 0
-;; @0040                               istore8 little heap v3, v16
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_0001
+;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = icmp ugt v6, v7
+;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v10 = iadd v9, v4
+;; @0040                               v11 = iconst.i64 0xffff_0000
+;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
+;; @0040                               v13 = iconst.i64 0
+;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
+;; @0040                               istore8 little heap v3, v14
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -64,21 +62,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = iconst.i64 0xffff_0001
-;; @004c                               v8 = uadd_overflow_trap v6, v7, heap_oob  ; v7 = 0xffff_0001
-;; @004c                               v9 = global_value.i64 gv4
-;; @004c                               v10 = icmp ugt v8, v9
-;; @004c                               v11 = global_value.i64 gv5
-;; @004c                               v12 = iadd v11, v6
-;; @004c                               v13 = iconst.i64 0xffff_0000
-;; @004c                               v14 = iadd v12, v13  ; v13 = 0xffff_0000
-;; @004c                               v15 = iconst.i64 0
-;; @004c                               v16 = select_spectre_guard v10, v15, v14  ; v15 = 0
-;; @004c                               v17 = uload8.i32 little heap v16
-;; @0053                               jump block1(v17)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = iconst.i64 0xffff_0001
+;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
+;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v8 = icmp ugt v6, v7
+;; @004c                               v9 = global_value.i64 gv5
+;; @004c                               v10 = iadd v9, v4
+;; @004c                               v11 = iconst.i64 0xffff_0000
+;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
+;; @004c                               v13 = iconst.i64 0
+;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
+;; @004c                               v15 = uload8.i32 little heap v14
+;; @0053                               jump block1(v15)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -31,15 +31,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               store little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               store little heap v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,16 +57,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = icmp ugt v6, v7
-;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = global_value.i64 gv5
-;; @0048                               v10 = iadd v9, v6
-;; @0048                               v11 = load.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = icmp ugt v4, v5
+;; @0048                               trapnz v6, heap_oob
+;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v8 = iadd v7, v4
+;; @0048                               v9 = load.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 4096
-;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               store little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               store little heap v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = icmp ugt v6, v7
-;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = global_value.i64 gv5
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = load.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = icmp ugt v4, v5
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = load.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0xffff_0000
-;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               store little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0xffff_0000
+;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @0040                               store little heap v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = global_value.i64 gv4
-;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = global_value.i64 gv5
-;; @004c                               v10 = iadd v9, v6
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = load.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v6 = icmp ugt v4, v5
+;; @004c                               trapnz v6, heap_oob
+;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v8 = iadd v7, v4
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = load.i32 little heap v10
+;; @0053                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -31,15 +31,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp uge v6, v7
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               istore8 little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp uge v4, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               istore8 little heap v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,16 +57,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = icmp uge v6, v7
-;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = global_value.i64 gv5
-;; @0048                               v10 = iadd v9, v6
-;; @0048                               v11 = uload8.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = icmp uge v4, v5
+;; @0048                               trapnz v6, heap_oob
+;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v8 = iadd v7, v4
+;; @0048                               v9 = uload8.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 4096
-;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               istore8 little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               istore8 little heap v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = icmp ugt v6, v7
-;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = global_value.i64 gv5
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = uload8.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = icmp ugt v4, v5
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = uload8.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0xffff_0000
-;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               istore8 little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0xffff_0000
+;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @0040                               istore8 little heap v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = global_value.i64 gv4
-;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = global_value.i64 gv5
-;; @004c                               v10 = iadd v9, v6
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = uload8.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v6 = icmp ugt v4, v5
+;; @004c                               trapnz v6, heap_oob
+;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v8 = iadd v7, v4
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = uload8.i32 little heap v10
+;; @0053                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -31,16 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0
-;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0040                               store little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0
+;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0040                               store little heap v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -60,17 +58,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = icmp ugt v6, v7
-;; @0048                               v9 = global_value.i64 gv5
-;; @0048                               v10 = iadd v9, v6
-;; @0048                               v11 = iconst.i64 0
-;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0048                               v13 = load.i32 little heap v12
-;; @004b                               jump block1(v13)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = icmp ugt v4, v5
+;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v8 = iadd v7, v4
+;; @0048                               v9 = iconst.i64 0
+;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0048                               v11 = load.i32 little heap v10
+;; @004b                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -31,18 +31,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 4096
-;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               v13 = iconst.i64 0
-;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               store little heap v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -62,19 +60,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = icmp ugt v6, v7
-;; @0049                               v9 = global_value.i64 gv5
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = iconst.i64 0
-;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = load.i32 little heap v14
-;; @004d                               jump block1(v15)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = icmp ugt v4, v5
+;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = iconst.i64 0
+;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0049                               v13 = load.i32 little heap v12
+;; @004d                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -31,18 +31,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0xffff_0000
-;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               v13 = iconst.i64 0
-;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0xffff_0000
+;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               store little heap v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -62,19 +60,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = global_value.i64 gv4
-;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = global_value.i64 gv5
-;; @004c                               v10 = iadd v9, v6
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = iconst.i64 0
-;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = load.i32 little heap v14
-;; @0053                               jump block1(v15)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v6 = icmp ugt v4, v5
+;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v8 = iadd v7, v4
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = iconst.i64 0
+;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @004c                               v13 = load.i32 little heap v12
+;; @0053                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -31,16 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp uge v6, v7
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0
-;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0040                               istore8 little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp uge v4, v5
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0
+;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0040                               istore8 little heap v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -60,17 +58,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = icmp uge v6, v7
-;; @0048                               v9 = global_value.i64 gv5
-;; @0048                               v10 = iadd v9, v6
-;; @0048                               v11 = iconst.i64 0
-;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0048                               v13 = uload8.i32 little heap v12
-;; @004b                               jump block1(v13)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = icmp uge v4, v5
+;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v8 = iadd v7, v4
+;; @0048                               v9 = iconst.i64 0
+;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0048                               v11 = uload8.i32 little heap v10
+;; @004b                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -31,18 +31,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 4096
-;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               v13 = iconst.i64 0
-;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               istore8 little heap v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -62,19 +60,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = icmp ugt v6, v7
-;; @0049                               v9 = global_value.i64 gv5
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = iconst.i64 0
-;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = uload8.i32 little heap v14
-;; @004d                               jump block1(v15)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = icmp ugt v4, v5
+;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = iconst.i64 0
+;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0049                               v13 = uload8.i32 little heap v12
+;; @004d                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -31,18 +31,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = global_value.i64 gv5
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0xffff_0000
-;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               v13 = iconst.i64 0
-;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = icmp ugt v4, v5
+;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0xffff_0000
+;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               istore8 little heap v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -62,19 +60,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = global_value.i64 gv4
-;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = global_value.i64 gv5
-;; @004c                               v10 = iadd v9, v6
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = iconst.i64 0
-;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = uload8.i32 little heap v14
-;; @0053                               jump block1(v15)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v6 = icmp ugt v4, v5
+;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v8 = iadd v7, v4
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = iconst.i64 0
+;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @004c                               v13 = uload8.i32 little heap v12
+;; @0053                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -31,16 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = iconst.i64 4
-;; @0040                               v8 = isub v6, v7  ; v7 = 4
-;; @0040                               v9 = icmp ugt v2, v8
-;; @0040                               trapnz v9, heap_oob
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = iconst.i64 4
+;; @0040                               v6 = isub v4, v5  ; v5 = 4
+;; @0040                               v7 = icmp ugt v2, v6
+;; @0040                               trapnz v7, heap_oob
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               store little heap v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -60,17 +58,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = global_value.i64 gv4
-;; @0048                               v7 = iconst.i64 4
-;; @0048                               v8 = isub v6, v7  ; v7 = 4
-;; @0048                               v9 = icmp ugt v2, v8
-;; @0048                               trapnz v9, heap_oob
-;; @0048                               v10 = global_value.i64 gv5
-;; @0048                               v11 = iadd v10, v2
-;; @0048                               v12 = load.i32 little heap v11
-;; @004b                               jump block1(v12)
+;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v5 = iconst.i64 4
+;; @0048                               v6 = isub v4, v5  ; v5 = 4
+;; @0048                               v7 = icmp ugt v2, v6
+;; @0048                               trapnz v7, heap_oob
+;; @0048                               v8 = global_value.i64 gv5
+;; @0048                               v9 = iadd v8, v2
+;; @0048                               v10 = load.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -31,18 +31,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = iconst.i64 4100
-;; @0040                               v8 = isub v6, v7  ; v7 = 4100
-;; @0040                               v9 = icmp ugt v2, v8
-;; @0040                               trapnz v9, heap_oob
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               v12 = iconst.i64 4096
-;; @0040                               v13 = iadd v11, v12  ; v12 = 4096
-;; @0040                               store little heap v3, v13
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = iconst.i64 4100
+;; @0040                               v6 = isub v4, v5  ; v5 = 4100
+;; @0040                               v7 = icmp ugt v2, v6
+;; @0040                               trapnz v7, heap_oob
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               v10 = iconst.i64 4096
+;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0040                               store little heap v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -62,19 +60,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = global_value.i64 gv4
-;; @0049                               v7 = iconst.i64 4100
-;; @0049                               v8 = isub v6, v7  ; v7 = 4100
-;; @0049                               v9 = icmp ugt v2, v8
-;; @0049                               trapnz v9, heap_oob
-;; @0049                               v10 = global_value.i64 gv5
-;; @0049                               v11 = iadd v10, v2
-;; @0049                               v12 = iconst.i64 4096
-;; @0049                               v13 = iadd v11, v12  ; v12 = 4096
-;; @0049                               v14 = load.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v5 = iconst.i64 4100
+;; @0049                               v6 = isub v4, v5  ; v5 = 4100
+;; @0049                               v7 = icmp ugt v2, v6
+;; @0049                               trapnz v7, heap_oob
+;; @0049                               v8 = global_value.i64 gv5
+;; @0049                               v9 = iadd v8, v2
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = load.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -31,18 +31,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_0004
-;; @0040                               v7 = uadd_overflow_trap v2, v6, heap_oob  ; v6 = 0xffff_0004
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = icmp ugt v7, v8
-;; @0040                               trapnz v9, heap_oob
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               v12 = iconst.i64 0xffff_0000
-;; @0040                               v13 = iadd v11, v12  ; v12 = 0xffff_0000
-;; @0040                               store little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xffff_0004
+;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = icmp ugt v5, v6
+;; @0040                               trapnz v7, heap_oob
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               v10 = iconst.i64 0xffff_0000
+;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @0040                               store little heap v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -62,19 +60,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xffff_0004
-;; @004c                               v7 = uadd_overflow_trap v2, v6, heap_oob  ; v6 = 0xffff_0004
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = icmp ugt v7, v8
-;; @004c                               trapnz v9, heap_oob
-;; @004c                               v10 = global_value.i64 gv5
-;; @004c                               v11 = iadd v10, v2
-;; @004c                               v12 = iconst.i64 0xffff_0000
-;; @004c                               v13 = iadd v11, v12  ; v12 = 0xffff_0000
-;; @004c                               v14 = load.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @004c                               v4 = iconst.i64 0xffff_0004
+;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = icmp ugt v5, v6
+;; @004c                               trapnz v7, heap_oob
+;; @004c                               v8 = global_value.i64 gv5
+;; @004c                               v9 = iadd v8, v2
+;; @004c                               v10 = iconst.i64 0xffff_0000
+;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @004c                               v12 = load.i32 little heap v11
+;; @0053                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -31,14 +31,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp uge v2, v6
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               istore8 little heap v3, v9
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp uge v2, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -58,15 +56,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = global_value.i64 gv4
-;; @0048                               v7 = icmp uge v2, v6
-;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = global_value.i64 gv5
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = uload8.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v5 = icmp uge v2, v4
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = uload8.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -31,18 +31,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = iconst.i64 4097
-;; @0040                               v8 = isub v6, v7  ; v7 = 4097
-;; @0040                               v9 = icmp ugt v2, v8
-;; @0040                               trapnz v9, heap_oob
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               v12 = iconst.i64 4096
-;; @0040                               v13 = iadd v11, v12  ; v12 = 4096
-;; @0040                               istore8 little heap v3, v13
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = iconst.i64 4097
+;; @0040                               v6 = isub v4, v5  ; v5 = 4097
+;; @0040                               v7 = icmp ugt v2, v6
+;; @0040                               trapnz v7, heap_oob
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               v10 = iconst.i64 4096
+;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0040                               istore8 little heap v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -62,19 +60,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = global_value.i64 gv4
-;; @0049                               v7 = iconst.i64 4097
-;; @0049                               v8 = isub v6, v7  ; v7 = 4097
-;; @0049                               v9 = icmp ugt v2, v8
-;; @0049                               trapnz v9, heap_oob
-;; @0049                               v10 = global_value.i64 gv5
-;; @0049                               v11 = iadd v10, v2
-;; @0049                               v12 = iconst.i64 4096
-;; @0049                               v13 = iadd v11, v12  ; v12 = 4096
-;; @0049                               v14 = uload8.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v5 = iconst.i64 4097
+;; @0049                               v6 = isub v4, v5  ; v5 = 4097
+;; @0049                               v7 = icmp ugt v2, v6
+;; @0049                               trapnz v7, heap_oob
+;; @0049                               v8 = global_value.i64 gv5
+;; @0049                               v9 = iadd v8, v2
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = uload8.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -31,18 +31,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_0001
-;; @0040                               v7 = uadd_overflow_trap v2, v6, heap_oob  ; v6 = 0xffff_0001
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = icmp ugt v7, v8
-;; @0040                               trapnz v9, heap_oob
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               v12 = iconst.i64 0xffff_0000
-;; @0040                               v13 = iadd v11, v12  ; v12 = 0xffff_0000
-;; @0040                               istore8 little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xffff_0001
+;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = icmp ugt v5, v6
+;; @0040                               trapnz v7, heap_oob
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               v10 = iconst.i64 0xffff_0000
+;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @0040                               istore8 little heap v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -62,19 +60,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xffff_0001
-;; @004c                               v7 = uadd_overflow_trap v2, v6, heap_oob  ; v6 = 0xffff_0001
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = icmp ugt v7, v8
-;; @004c                               trapnz v9, heap_oob
-;; @004c                               v10 = global_value.i64 gv5
-;; @004c                               v11 = iadd v10, v2
-;; @004c                               v12 = iconst.i64 0xffff_0000
-;; @004c                               v13 = iadd v11, v12  ; v12 = 0xffff_0000
-;; @004c                               v14 = uload8.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @004c                               v4 = iconst.i64 0xffff_0001
+;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = icmp ugt v5, v6
+;; @004c                               trapnz v7, heap_oob
+;; @004c                               v8 = global_value.i64 gv5
+;; @004c                               v9 = iadd v8, v2
+;; @004c                               v10 = iconst.i64 0xffff_0000
+;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @004c                               v12 = uload8.i32 little heap v11
+;; @0053                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = iconst.i64 4
-;; @0040                               v8 = isub v6, v7  ; v7 = 4
-;; @0040                               v9 = icmp ugt v2, v8
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v9, v12, v11  ; v12 = 0
-;; @0040                               store little heap v3, v13
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = iconst.i64 4
+;; @0040                               v6 = isub v4, v5  ; v5 = 4
+;; @0040                               v7 = icmp ugt v2, v6
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
+;; @0040                               store little heap v3, v11
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = global_value.i64 gv4
-;; @0048                               v7 = iconst.i64 4
-;; @0048                               v8 = isub v6, v7  ; v7 = 4
-;; @0048                               v9 = icmp ugt v2, v8
-;; @0048                               v10 = global_value.i64 gv5
-;; @0048                               v11 = iadd v10, v2
-;; @0048                               v12 = iconst.i64 0
-;; @0048                               v13 = select_spectre_guard v9, v12, v11  ; v12 = 0
-;; @0048                               v14 = load.i32 little heap v13
-;; @004b                               jump block1(v14)
+;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v5 = iconst.i64 4
+;; @0048                               v6 = isub v4, v5  ; v5 = 4
+;; @0048                               v7 = icmp ugt v2, v6
+;; @0048                               v8 = global_value.i64 gv5
+;; @0048                               v9 = iadd v8, v2
+;; @0048                               v10 = iconst.i64 0
+;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
+;; @0048                               v12 = load.i32 little heap v11
+;; @004b                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -31,19 +31,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = iconst.i64 4100
-;; @0040                               v8 = isub v6, v7  ; v7 = 4100
-;; @0040                               v9 = icmp ugt v2, v8
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               v12 = iconst.i64 4096
-;; @0040                               v13 = iadd v11, v12  ; v12 = 4096
-;; @0040                               v14 = iconst.i64 0
-;; @0040                               v15 = select_spectre_guard v9, v14, v13  ; v14 = 0
-;; @0040                               store little heap v3, v15
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = iconst.i64 4100
+;; @0040                               v6 = isub v4, v5  ; v5 = 4100
+;; @0040                               v7 = icmp ugt v2, v6
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               v10 = iconst.i64 4096
+;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0040                               v12 = iconst.i64 0
+;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0040                               store little heap v3, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -63,20 +61,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = global_value.i64 gv4
-;; @0049                               v7 = iconst.i64 4100
-;; @0049                               v8 = isub v6, v7  ; v7 = 4100
-;; @0049                               v9 = icmp ugt v2, v8
-;; @0049                               v10 = global_value.i64 gv5
-;; @0049                               v11 = iadd v10, v2
-;; @0049                               v12 = iconst.i64 4096
-;; @0049                               v13 = iadd v11, v12  ; v12 = 4096
-;; @0049                               v14 = iconst.i64 0
-;; @0049                               v15 = select_spectre_guard v9, v14, v13  ; v14 = 0
-;; @0049                               v16 = load.i32 little heap v15
-;; @004d                               jump block1(v16)
+;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v5 = iconst.i64 4100
+;; @0049                               v6 = isub v4, v5  ; v5 = 4100
+;; @0049                               v7 = icmp ugt v2, v6
+;; @0049                               v8 = global_value.i64 gv5
+;; @0049                               v9 = iadd v8, v2
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = iconst.i64 0
+;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0049                               v14 = load.i32 little heap v13
+;; @004d                               jump block1(v14)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -31,19 +31,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_0004
-;; @0040                               v7 = uadd_overflow_trap v2, v6, heap_oob  ; v6 = 0xffff_0004
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = icmp ugt v7, v8
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               v12 = iconst.i64 0xffff_0000
-;; @0040                               v13 = iadd v11, v12  ; v12 = 0xffff_0000
-;; @0040                               v14 = iconst.i64 0
-;; @0040                               v15 = select_spectre_guard v9, v14, v13  ; v14 = 0
-;; @0040                               store little heap v3, v15
+;; @0040                               v4 = iconst.i64 0xffff_0004
+;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = icmp ugt v5, v6
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               v10 = iconst.i64 0xffff_0000
+;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @0040                               v12 = iconst.i64 0
+;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0040                               store little heap v3, v13
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -63,20 +61,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xffff_0004
-;; @004c                               v7 = uadd_overflow_trap v2, v6, heap_oob  ; v6 = 0xffff_0004
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = icmp ugt v7, v8
-;; @004c                               v10 = global_value.i64 gv5
-;; @004c                               v11 = iadd v10, v2
-;; @004c                               v12 = iconst.i64 0xffff_0000
-;; @004c                               v13 = iadd v11, v12  ; v12 = 0xffff_0000
-;; @004c                               v14 = iconst.i64 0
-;; @004c                               v15 = select_spectre_guard v9, v14, v13  ; v14 = 0
-;; @004c                               v16 = load.i32 little heap v15
-;; @0053                               jump block1(v16)
+;; @004c                               v4 = iconst.i64 0xffff_0004
+;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = icmp ugt v5, v6
+;; @004c                               v8 = global_value.i64 gv5
+;; @004c                               v9 = iadd v8, v2
+;; @004c                               v10 = iconst.i64 0xffff_0000
+;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @004c                               v12 = iconst.i64 0
+;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @004c                               v14 = load.i32 little heap v13
+;; @0053                               jump block1(v14)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -31,15 +31,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp uge v2, v6
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp uge v2, v4
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0040                               istore8 little heap v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,16 +57,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = global_value.i64 gv4
-;; @0048                               v7 = icmp uge v2, v6
-;; @0048                               v8 = global_value.i64 gv5
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = iconst.i64 0
-;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = uload8.i32 little heap v11
-;; @004b                               jump block1(v12)
+;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v5 = icmp uge v2, v4
+;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = uload8.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -31,19 +31,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = iconst.i64 4097
-;; @0040                               v8 = isub v6, v7  ; v7 = 4097
-;; @0040                               v9 = icmp ugt v2, v8
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               v12 = iconst.i64 4096
-;; @0040                               v13 = iadd v11, v12  ; v12 = 4096
-;; @0040                               v14 = iconst.i64 0
-;; @0040                               v15 = select_spectre_guard v9, v14, v13  ; v14 = 0
-;; @0040                               istore8 little heap v3, v15
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = iconst.i64 4097
+;; @0040                               v6 = isub v4, v5  ; v5 = 4097
+;; @0040                               v7 = icmp ugt v2, v6
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               v10 = iconst.i64 4096
+;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0040                               v12 = iconst.i64 0
+;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0040                               istore8 little heap v3, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -63,20 +61,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = global_value.i64 gv4
-;; @0049                               v7 = iconst.i64 4097
-;; @0049                               v8 = isub v6, v7  ; v7 = 4097
-;; @0049                               v9 = icmp ugt v2, v8
-;; @0049                               v10 = global_value.i64 gv5
-;; @0049                               v11 = iadd v10, v2
-;; @0049                               v12 = iconst.i64 4096
-;; @0049                               v13 = iadd v11, v12  ; v12 = 4096
-;; @0049                               v14 = iconst.i64 0
-;; @0049                               v15 = select_spectre_guard v9, v14, v13  ; v14 = 0
-;; @0049                               v16 = uload8.i32 little heap v15
-;; @004d                               jump block1(v16)
+;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v5 = iconst.i64 4097
+;; @0049                               v6 = isub v4, v5  ; v5 = 4097
+;; @0049                               v7 = icmp ugt v2, v6
+;; @0049                               v8 = global_value.i64 gv5
+;; @0049                               v9 = iadd v8, v2
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = iconst.i64 0
+;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0049                               v14 = uload8.i32 little heap v13
+;; @004d                               jump block1(v14)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -31,19 +31,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_0001
-;; @0040                               v7 = uadd_overflow_trap v2, v6, heap_oob  ; v6 = 0xffff_0001
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = icmp ugt v7, v8
-;; @0040                               v10 = global_value.i64 gv5
-;; @0040                               v11 = iadd v10, v2
-;; @0040                               v12 = iconst.i64 0xffff_0000
-;; @0040                               v13 = iadd v11, v12  ; v12 = 0xffff_0000
-;; @0040                               v14 = iconst.i64 0
-;; @0040                               v15 = select_spectre_guard v9, v14, v13  ; v14 = 0
-;; @0040                               istore8 little heap v3, v15
+;; @0040                               v4 = iconst.i64 0xffff_0001
+;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = icmp ugt v5, v6
+;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v9 = iadd v8, v2
+;; @0040                               v10 = iconst.i64 0xffff_0000
+;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @0040                               v12 = iconst.i64 0
+;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0040                               istore8 little heap v3, v13
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -63,20 +61,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xffff_0001
-;; @004c                               v7 = uadd_overflow_trap v2, v6, heap_oob  ; v6 = 0xffff_0001
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = icmp ugt v7, v8
-;; @004c                               v10 = global_value.i64 gv5
-;; @004c                               v11 = iadd v10, v2
-;; @004c                               v12 = iconst.i64 0xffff_0000
-;; @004c                               v13 = iadd v11, v12  ; v12 = 0xffff_0000
-;; @004c                               v14 = iconst.i64 0
-;; @004c                               v15 = select_spectre_guard v9, v14, v13  ; v14 = 0
-;; @004c                               v16 = uload8.i32 little heap v15
-;; @0053                               jump block1(v16)
+;; @004c                               v4 = iconst.i64 0xffff_0001
+;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = icmp ugt v5, v6
+;; @004c                               v8 = global_value.i64 gv5
+;; @004c                               v9 = iadd v8, v2
+;; @004c                               v10 = iconst.i64 0xffff_0000
+;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
+;; @004c                               v12 = iconst.i64 0
+;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @004c                               v14 = uload8.i32 little heap v13
+;; @0053                               jump block1(v14)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -31,14 +31,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               store little heap v3, v9
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -58,15 +56,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = global_value.i64 gv4
-;; @0048                               v7 = icmp ugt v2, v6
-;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = global_value.i64 gv5
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = load.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v5 = icmp ugt v2, v4
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = load.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -31,16 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               store little heap v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -60,17 +58,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = global_value.i64 gv4
-;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = global_value.i64 gv5
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = load.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v5 = icmp ugt v2, v4
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = load.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -31,16 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               store little heap v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -60,17 +58,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = global_value.i64 gv4
-;; @004c                               v7 = icmp ugt v2, v6
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv5
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = load.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @004c                               v4 = global_value.i64 gv4
+;; @004c                               v5 = icmp ugt v2, v4
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = load.i32 little heap v9
+;; @0053                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -31,14 +31,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp uge v2, v6
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               istore8 little heap v3, v9
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp uge v2, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -58,15 +56,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = global_value.i64 gv4
-;; @0048                               v7 = icmp uge v2, v6
-;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = global_value.i64 gv5
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = uload8.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v5 = icmp uge v2, v4
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = uload8.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -31,16 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               istore8 little heap v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -60,17 +58,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = global_value.i64 gv4
-;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = global_value.i64 gv5
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = uload8.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v5 = icmp ugt v2, v4
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = uload8.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -31,16 +31,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               istore8 little heap v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -60,17 +58,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = global_value.i64 gv4
-;; @004c                               v7 = icmp ugt v2, v6
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv5
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = uload8.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @004c                               v4 = global_value.i64 gv4
+;; @004c                               v5 = icmp ugt v2, v4
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = uload8.i32 little heap v9
+;; @0053                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -31,15 +31,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0040                               store little heap v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,16 +57,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = global_value.i64 gv4
-;; @0048                               v7 = icmp ugt v2, v6
-;; @0048                               v8 = global_value.i64 gv5
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = iconst.i64 0
-;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = load.i32 little heap v11
-;; @004b                               jump block1(v12)
+;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v5 = icmp ugt v2, v4
+;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = load.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little heap v3, v13
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               store little heap v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = global_value.i64 gv4
-;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = global_value.i64 gv5
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = iconst.i64 0
-;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = load.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v5 = icmp ugt v2, v4
+;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = load.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little heap v3, v13
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               store little heap v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = global_value.i64 gv4
-;; @004c                               v7 = icmp ugt v2, v6
-;; @004c                               v8 = global_value.i64 gv5
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = iconst.i64 0
-;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = load.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @004c                               v4 = global_value.i64 gv4
+;; @004c                               v5 = icmp ugt v2, v4
+;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = load.i32 little heap v11
+;; @0053                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -31,15 +31,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp uge v2, v6
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp uge v2, v4
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0040                               istore8 little heap v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,16 +57,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = global_value.i64 gv4
-;; @0048                               v7 = icmp uge v2, v6
-;; @0048                               v8 = global_value.i64 gv5
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = iconst.i64 0
-;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = uload8.i32 little heap v11
-;; @004b                               jump block1(v12)
+;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v5 = icmp uge v2, v4
+;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = uload8.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little heap v3, v13
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               istore8 little heap v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = global_value.i64 gv4
-;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = global_value.i64 gv5
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = iconst.i64 0
-;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = uload8.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v5 = icmp ugt v2, v4
+;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = uload8.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -31,17 +31,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = global_value.i64 gv4
-;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = global_value.i64 gv5
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little heap v3, v13
+;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v5 = icmp ugt v2, v4
+;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               istore8 little heap v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -61,18 +59,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = global_value.i64 gv4
-;; @004c                               v7 = icmp ugt v2, v6
-;; @004c                               v8 = global_value.i64 gv5
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = iconst.i64 0
-;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = uload8.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @004c                               v4 = global_value.i64 gv4
+;; @004c                               v5 = icmp ugt v2, v4
+;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = uload8.i32 little heap v11
+;; @0053                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -30,15 +30,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_fffc
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_fffc
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               store little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_fffc
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               store little heap v3, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -57,16 +55,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = iconst.i64 0xffff_fffc
-;; @0048                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_fffc
-;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = global_value.i64 gv4
-;; @0048                               v10 = iadd v9, v6
-;; @0048                               v11 = load.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = iconst.i64 0xffff_fffc
+;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
+;; @0048                               trapnz v6, heap_oob
+;; @0048                               v7 = global_value.i64 gv4
+;; @0048                               v8 = iadd v7, v4
+;; @0048                               v9 = load.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_effc
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_effc
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 4096
-;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               store little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_effc
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               store little heap v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = iconst.i64 0xffff_effc
-;; @0049                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_effc
-;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = global_value.i64 gv4
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = load.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = iconst.i64 0xffff_effc
+;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = global_value.i64 gv4
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = load.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xfffc
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xfffc
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0xffff_0000
-;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               store little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xfffc
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0xffff_0000
+;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @0040                               store little heap v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = iconst.i64 0xfffc
-;; @004c                               v8 = icmp ugt v6, v7  ; v7 = 0xfffc
-;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = global_value.i64 gv4
-;; @004c                               v10 = iadd v9, v6
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = load.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = iconst.i64 0xfffc
+;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
+;; @004c                               trapnz v6, heap_oob
+;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v8 = iadd v7, v4
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = load.i32 little heap v10
+;; @0053                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -30,12 +30,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               istore8 little heap v3, v8
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -54,13 +52,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = iadd v7, v6
-;; @0048                               v9 = uload8.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = iadd v5, v4
+;; @0048                               v7 = uload8.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_efff
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_efff
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 4096
-;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               istore8 little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_efff
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               istore8 little heap v3, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = iconst.i64 0xffff_efff
-;; @0049                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_efff
-;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = global_value.i64 gv4
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = uload8.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = iconst.i64 0xffff_efff
+;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = global_value.i64 gv4
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = uload8.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xffff
-;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0xffff_0000
-;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               istore8 little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0xffff_0000
+;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @0040                               istore8 little heap v3, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = iconst.i64 0xffff
-;; @004c                               v8 = icmp ugt v6, v7  ; v7 = 0xffff
-;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = global_value.i64 gv4
-;; @004c                               v10 = iadd v9, v6
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = uload8.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = iconst.i64 0xffff
+;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
+;; @004c                               trapnz v6, heap_oob
+;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v8 = iadd v7, v4
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = uload8.i32 little heap v10
+;; @0053                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -30,16 +30,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_fffc
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_fffc
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0
-;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0040                               store little heap v3, v12
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_fffc
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0
+;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0040                               store little heap v3, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -58,17 +56,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = iconst.i64 0xffff_fffc
-;; @0048                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_fffc
-;; @0048                               v9 = global_value.i64 gv4
-;; @0048                               v10 = iadd v9, v6
-;; @0048                               v11 = iconst.i64 0
-;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
-;; @0048                               v13 = load.i32 little heap v12
-;; @004b                               jump block1(v13)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = iconst.i64 0xffff_fffc
+;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
+;; @0048                               v7 = global_value.i64 gv4
+;; @0048                               v8 = iadd v7, v4
+;; @0048                               v9 = iconst.i64 0
+;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0048                               v11 = load.i32 little heap v10
+;; @004b                               jump block1(v11)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -30,18 +30,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_effc
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_effc
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 4096
-;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               v13 = iconst.i64 0
-;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_effc
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               store little heap v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -60,19 +58,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = iconst.i64 0xffff_effc
-;; @0049                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_effc
-;; @0049                               v9 = global_value.i64 gv4
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = iconst.i64 0
-;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = load.i32 little heap v14
-;; @004d                               jump block1(v15)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = iconst.i64 0xffff_effc
+;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
+;; @0049                               v7 = global_value.i64 gv4
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = iconst.i64 0
+;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0049                               v13 = load.i32 little heap v12
+;; @004d                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -30,18 +30,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xfffc
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xfffc
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0xffff_0000
-;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               v13 = iconst.i64 0
-;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               store little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xfffc
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0xffff_0000
+;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               store little heap v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -60,19 +58,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = iconst.i64 0xfffc
-;; @004c                               v8 = icmp ugt v6, v7  ; v7 = 0xfffc
-;; @004c                               v9 = global_value.i64 gv4
-;; @004c                               v10 = iadd v9, v6
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = iconst.i64 0
-;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = load.i32 little heap v14
-;; @0053                               jump block1(v15)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = iconst.i64 0xfffc
+;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
+;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v8 = iadd v7, v4
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = iconst.i64 0
+;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @004c                               v13 = load.i32 little heap v12
+;; @0053                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -30,12 +30,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               istore8 little heap v3, v8
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -54,13 +52,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = iadd v7, v6
-;; @0048                               v9 = uload8.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = iadd v5, v4
+;; @0048                               v7 = uload8.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -30,18 +30,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff_efff
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_efff
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 4096
-;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0040                               v13 = iconst.i64 0
-;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff_efff
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               istore8 little heap v3, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -60,19 +58,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = iconst.i64 0xffff_efff
-;; @0049                               v8 = icmp ugt v6, v7  ; v7 = 0xffff_efff
-;; @0049                               v9 = global_value.i64 gv4
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = iconst.i64 4096
-;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
-;; @0049                               v13 = iconst.i64 0
-;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0049                               v15 = uload8.i32 little heap v14
-;; @004d                               jump block1(v15)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = iconst.i64 0xffff_efff
+;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
+;; @0049                               v7 = global_value.i64 gv4
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = iconst.i64 0
+;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0049                               v13 = uload8.i32 little heap v12
+;; @004d                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -30,18 +30,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = iconst.i64 0xffff
-;; @0040                               v8 = icmp ugt v6, v7  ; v7 = 0xffff
-;; @0040                               v9 = global_value.i64 gv4
-;; @0040                               v10 = iadd v9, v6
-;; @0040                               v11 = iconst.i64 0xffff_0000
-;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @0040                               v13 = iconst.i64 0
-;; @0040                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @0040                               istore8 little heap v3, v14
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = iconst.i64 0xffff
+;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
+;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v8 = iadd v7, v4
+;; @0040                               v9 = iconst.i64 0xffff_0000
+;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               istore8 little heap v3, v12
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -60,19 +58,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = iconst.i64 0xffff
-;; @004c                               v8 = icmp ugt v6, v7  ; v7 = 0xffff
-;; @004c                               v9 = global_value.i64 gv4
-;; @004c                               v10 = iadd v9, v6
-;; @004c                               v11 = iconst.i64 0xffff_0000
-;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
-;; @004c                               v13 = iconst.i64 0
-;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
-;; @004c                               v15 = uload8.i32 little heap v14
-;; @0053                               jump block1(v15)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = iconst.i64 0xffff
+;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
+;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v8 = iadd v7, v4
+;; @004c                               v9 = iconst.i64 0xffff_0000
+;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
+;; @004c                               v11 = iconst.i64 0
+;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @004c                               v13 = uload8.i32 little heap v12
+;; @0053                               jump block1(v13)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -30,12 +30,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               store little heap v3, v8
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -54,13 +52,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = iadd v7, v6
-;; @0048                               v9 = load.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = iadd v5, v4
+;; @0048                               v7 = load.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = iconst.i64 4096
-;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               store little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               store little heap v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = iadd v7, v6
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = iadd v5, v4
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = load.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = iconst.i64 0xffff_0000
-;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               store little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               v7 = iconst.i64 0xffff_0000
+;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @0040                               store little heap v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = global_value.i64 gv4
-;; @004c                               v8 = iadd v7, v6
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v6 = iadd v5, v4
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = load.i32 little heap v8
+;; @0053                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -30,12 +30,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               istore8 little heap v3, v8
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -54,13 +52,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = iadd v7, v6
-;; @0048                               v9 = uload8.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = iadd v5, v4
+;; @0048                               v7 = uload8.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = iconst.i64 4096
-;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               istore8 little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               istore8 little heap v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = iadd v7, v6
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = iadd v5, v4
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = uload8.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = iconst.i64 0xffff_0000
-;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               istore8 little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               v7 = iconst.i64 0xffff_0000
+;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @0040                               istore8 little heap v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = global_value.i64 gv4
-;; @004c                               v8 = iadd v7, v6
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v6 = iadd v5, v4
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = uload8.i32 little heap v8
+;; @0053                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -30,12 +30,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               store little heap v3, v8
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -54,13 +52,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = iadd v7, v6
-;; @0048                               v9 = load.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = iadd v5, v4
+;; @0048                               v7 = load.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = iconst.i64 4096
-;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               store little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               store little heap v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = iadd v7, v6
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = iadd v5, v4
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = load.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = iconst.i64 0xffff_0000
-;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               store little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               v7 = iconst.i64 0xffff_0000
+;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @0040                               store little heap v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = global_value.i64 gv4
-;; @004c                               v8 = iadd v7, v6
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = load.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v6 = iadd v5, v4
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = load.i32 little heap v8
+;; @0053                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -30,12 +30,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               istore8 little heap v3, v8
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -54,13 +52,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = uextend.i64 v2
-;; @0048                               v7 = global_value.i64 gv4
-;; @0048                               v8 = iadd v7, v6
-;; @0048                               v9 = uload8.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v4 = uextend.i64 v2
+;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v6 = iadd v5, v4
+;; @0048                               v7 = uload8.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = iconst.i64 4096
-;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               istore8 little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               istore8 little heap v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = iadd v7, v6
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = iadd v5, v4
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = uload8.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = uextend.i64 v2
-;; @0040                               v7 = global_value.i64 gv4
-;; @0040                               v8 = iadd v7, v6
-;; @0040                               v9 = iconst.i64 0xffff_0000
-;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @0040                               istore8 little heap v3, v10
+;; @0040                               v4 = uextend.i64 v2
+;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v6 = iadd v5, v4
+;; @0040                               v7 = iconst.i64 0xffff_0000
+;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @0040                               istore8 little heap v3, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = uextend.i64 v2
-;; @004c                               v7 = global_value.i64 gv4
-;; @004c                               v8 = iadd v7, v6
-;; @004c                               v9 = iconst.i64 0xffff_0000
-;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
-;; @004c                               v11 = uload8.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @004c                               v4 = uextend.i64 v2
+;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v6 = iadd v5, v4
+;; @004c                               v7 = iconst.i64 0xffff_0000
+;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
+;; @004c                               v9 = uload8.i32 little heap v8
+;; @0053                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_fffc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_fffc
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               store little heap v3, v9
+;; @0040                               v4 = iconst.i64 0xffff_fffc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = iconst.i64 0xffff_fffc
-;; @0048                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_fffc
-;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = global_value.i64 gv4
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = load.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @0048                               v4 = iconst.i64 0xffff_fffc
+;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = load.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -30,16 +30,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_effc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_effc
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff_effc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               store little heap v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -58,17 +56,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = iconst.i64 0xffff_effc
-;; @0049                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_effc
-;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = global_value.i64 gv4
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = load.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v4 = iconst.i64 0xffff_effc
+;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = load.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -30,16 +30,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xfffc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xfffc
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xfffc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               store little heap v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -58,17 +56,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xfffc
-;; @004c                               v7 = icmp ugt v2, v6  ; v6 = 0xfffc
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = load.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @004c                               v4 = iconst.i64 0xfffc
+;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = load.i32 little heap v9
+;; @0053                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_ffff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_ffff
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               istore8 little heap v3, v9
+;; @0040                               v4 = iconst.i64 0xffff_ffff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = iconst.i64 0xffff_ffff
-;; @0048                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_ffff
-;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = global_value.i64 gv4
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = uload8.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @0048                               v4 = iconst.i64 0xffff_ffff
+;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = uload8.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -30,16 +30,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_efff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_efff
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff_efff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               istore8 little heap v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -58,17 +56,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = iconst.i64 0xffff_efff
-;; @0049                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_efff
-;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = global_value.i64 gv4
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = uload8.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v4 = iconst.i64 0xffff_efff
+;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = uload8.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -30,16 +30,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               istore8 little heap v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -58,17 +56,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xffff
-;; @004c                               v7 = icmp ugt v2, v6  ; v6 = 0xffff
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = uload8.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @004c                               v4 = iconst.i64 0xffff
+;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = uload8.i32 little heap v9
+;; @0053                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -30,15 +30,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_fffc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_fffc
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff_fffc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0040                               store little heap v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -57,16 +55,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = iconst.i64 0xffff_fffc
-;; @0048                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_fffc
-;; @0048                               v8 = global_value.i64 gv4
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = iconst.i64 0
-;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = load.i32 little heap v11
-;; @004b                               jump block1(v12)
+;; @0048                               v4 = iconst.i64 0xffff_fffc
+;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
+;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = load.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_effc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_effc
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xffff_effc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               store little heap v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = iconst.i64 0xffff_effc
-;; @0049                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_effc
-;; @0049                               v8 = global_value.i64 gv4
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = iconst.i64 0
-;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = load.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @0049                               v4 = iconst.i64 0xffff_effc
+;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
+;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = load.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xfffc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xfffc
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xfffc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               store little heap v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xfffc
-;; @004c                               v7 = icmp ugt v2, v6  ; v6 = 0xfffc
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = iconst.i64 0
-;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = load.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @004c                               v4 = iconst.i64 0xfffc
+;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = load.i32 little heap v11
+;; @0053                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -30,15 +30,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_ffff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_ffff
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff_ffff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0040                               istore8 little heap v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -57,16 +55,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = iconst.i64 0xffff_ffff
-;; @0048                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_ffff
-;; @0048                               v8 = global_value.i64 gv4
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = iconst.i64 0
-;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = uload8.i32 little heap v11
-;; @004b                               jump block1(v12)
+;; @0048                               v4 = iconst.i64 0xffff_ffff
+;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
+;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = uload8.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_efff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_efff
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xffff_efff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               istore8 little heap v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = iconst.i64 0xffff_efff
-;; @0049                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_efff
-;; @0049                               v8 = global_value.i64 gv4
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = iconst.i64 0
-;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = uload8.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @0049                               v4 = iconst.i64 0xffff_efff
+;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
+;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = uload8.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xffff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               istore8 little heap v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xffff
-;; @004c                               v7 = icmp ugt v2, v6  ; v6 = 0xffff
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = iconst.i64 0
-;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = uload8.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @004c                               v4 = iconst.i64 0xffff
+;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = uload8.i32 little heap v11
+;; @0053                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_fffc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_fffc
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               store little heap v3, v9
+;; @0040                               v4 = iconst.i64 0xffff_fffc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = iconst.i64 0xffff_fffc
-;; @0048                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_fffc
-;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = global_value.i64 gv4
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = load.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @0048                               v4 = iconst.i64 0xffff_fffc
+;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = load.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -30,16 +30,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_effc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_effc
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff_effc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               store little heap v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -58,17 +56,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = iconst.i64 0xffff_effc
-;; @0049                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_effc
-;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = global_value.i64 gv4
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = load.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v4 = iconst.i64 0xffff_effc
+;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = load.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -30,16 +30,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xfffc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xfffc
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xfffc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               store little heap v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -58,17 +56,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xfffc
-;; @004c                               v7 = icmp ugt v2, v6  ; v6 = 0xfffc
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = load.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @004c                               v4 = iconst.i64 0xfffc
+;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = load.i32 little heap v9
+;; @0053                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -30,14 +30,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_ffff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_ffff
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               istore8 little heap v3, v9
+;; @0040                               v4 = iconst.i64 0xffff_ffff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -56,15 +54,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = iconst.i64 0xffff_ffff
-;; @0048                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_ffff
-;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = global_value.i64 gv4
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = uload8.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @0048                               v4 = iconst.i64 0xffff_ffff
+;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = uload8.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -30,16 +30,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_efff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_efff
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff_efff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               istore8 little heap v3, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -58,17 +56,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = iconst.i64 0xffff_efff
-;; @0049                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_efff
-;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = global_value.i64 gv4
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = uload8.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v4 = iconst.i64 0xffff_efff
+;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = uload8.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -30,16 +30,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               istore8 little heap v3, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -58,17 +56,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xffff
-;; @004c                               v7 = icmp ugt v2, v6  ; v6 = 0xffff
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = uload8.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @004c                               v4 = iconst.i64 0xffff
+;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = uload8.i32 little heap v9
+;; @0053                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -30,15 +30,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_fffc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_fffc
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               store little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff_fffc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0040                               store little heap v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -57,16 +55,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = iconst.i64 0xffff_fffc
-;; @0048                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_fffc
-;; @0048                               v8 = global_value.i64 gv4
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = iconst.i64 0
-;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = load.i32 little heap v11
-;; @004b                               jump block1(v12)
+;; @0048                               v4 = iconst.i64 0xffff_fffc
+;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
+;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = load.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_effc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_effc
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xffff_effc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               store little heap v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = iconst.i64 0xffff_effc
-;; @0049                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_effc
-;; @0049                               v8 = global_value.i64 gv4
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = iconst.i64 0
-;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = load.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @0049                               v4 = iconst.i64 0xffff_effc
+;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
+;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = load.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xfffc
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xfffc
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               store little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xfffc
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               store little heap v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xfffc
-;; @004c                               v7 = icmp ugt v2, v6  ; v6 = 0xfffc
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = iconst.i64 0
-;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = load.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @004c                               v4 = iconst.i64 0xfffc
+;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = load.i32 little heap v11
+;; @0053                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -30,15 +30,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_ffff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_ffff
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0040                               istore8 little heap v3, v11
+;; @0040                               v4 = iconst.i64 0xffff_ffff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0040                               istore8 little heap v3, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -57,16 +55,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0045                               v4 = global_value.i64 gv3
-;; @0045                               v5 = load.i64 notrap aligned v4+8
-;; @0048                               v6 = iconst.i64 0xffff_ffff
-;; @0048                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_ffff
-;; @0048                               v8 = global_value.i64 gv4
-;; @0048                               v9 = iadd v8, v2
-;; @0048                               v10 = iconst.i64 0
-;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
-;; @0048                               v12 = uload8.i32 little heap v11
-;; @004b                               jump block1(v12)
+;; @0048                               v4 = iconst.i64 0xffff_ffff
+;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
+;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v7 = iadd v6, v2
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = uload8.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004b                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff_efff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_efff
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 4096
-;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xffff_efff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               istore8 little heap v3, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = iconst.i64 0xffff_efff
-;; @0049                               v7 = icmp ugt v2, v6  ; v6 = 0xffff_efff
-;; @0049                               v8 = global_value.i64 gv4
-;; @0049                               v9 = iadd v8, v2
-;; @0049                               v10 = iconst.i64 4096
-;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
-;; @0049                               v12 = iconst.i64 0
-;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0049                               v14 = uload8.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @0049                               v4 = iconst.i64 0xffff_efff
+;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
+;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v7 = iadd v6, v2
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = uload8.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004d                               return v3

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -30,17 +30,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @003b                               v4 = global_value.i64 gv3
-;; @003b                               v5 = load.i64 notrap aligned v4+8
-;; @0040                               v6 = iconst.i64 0xffff
-;; @0040                               v7 = icmp ugt v2, v6  ; v6 = 0xffff
-;; @0040                               v8 = global_value.i64 gv4
-;; @0040                               v9 = iadd v8, v2
-;; @0040                               v10 = iconst.i64 0xffff_0000
-;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @0040                               v12 = iconst.i64 0
-;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0040                               istore8 little heap v3, v13
+;; @0040                               v4 = iconst.i64 0xffff
+;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
+;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v7 = iadd v6, v2
+;; @0040                               v8 = iconst.i64 0xffff_0000
+;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               istore8 little heap v3, v11
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -59,18 +57,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv3
-;; @0049                               v5 = load.i64 notrap aligned v4+8
-;; @004c                               v6 = iconst.i64 0xffff
-;; @004c                               v7 = icmp ugt v2, v6  ; v6 = 0xffff
-;; @004c                               v8 = global_value.i64 gv4
-;; @004c                               v9 = iadd v8, v2
-;; @004c                               v10 = iconst.i64 0xffff_0000
-;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
-;; @004c                               v12 = iconst.i64 0
-;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @004c                               v14 = uload8.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @004c                               v4 = iconst.i64 0xffff
+;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
+;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v7 = iadd v6, v2
+;; @004c                               v8 = iconst.i64 0xffff_0000
+;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
+;; @004c                               v10 = iconst.i64 0
+;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @004c                               v12 = uload8.i32 little heap v11
+;; @0053                               jump block1(v12)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0053                               return v3

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -26,37 +26,35 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @001f                               v2 = iconst.i32 0
-;; @001f                               v3 = global_value.i64 gv3
-;; @001f                               v4 = load.i64 notrap aligned v3+8
-;; @0021                               v5 = iconst.i32 0
-;; @0023                               v6 = iconst.i32 0
-;; @0025                               v7 = uextend.i64 v5  ; v5 = 0
-;; @0025                               v8 = global_value.i64 gv4
-;; @0025                               v9 = iadd v8, v7
-;; @0025                               store little heap v6, v9  ; v6 = 0
-;; @0028                               v10 = iconst.i32 0
-;; @002a                               v11 = uextend.i64 v10  ; v10 = 0
-;; @002a                               v12 = global_value.i64 gv4
-;; @002a                               v13 = iadd v12, v11
-;; @002a                               v14 = load.i32 little heap v13
-;; @002d                               brif v14, block2, block4
+;; @0021                               v3 = iconst.i32 0
+;; @0023                               v4 = iconst.i32 0
+;; @0025                               v5 = uextend.i64 v3  ; v3 = 0
+;; @0025                               v6 = global_value.i64 gv4
+;; @0025                               v7 = iadd v6, v5
+;; @0025                               store little heap v4, v7  ; v4 = 0
+;; @0028                               v8 = iconst.i32 0
+;; @002a                               v9 = uextend.i64 v8  ; v8 = 0
+;; @002a                               v10 = global_value.i64 gv4
+;; @002a                               v11 = iadd v10, v9
+;; @002a                               v12 = load.i32 little heap v11
+;; @002d                               brif v12, block2, block4
 ;;
 ;;                                 block2:
-;; @002f                               v15 = iconst.i32 0
-;; @0031                               v16 = iconst.i32 10
-;; @0033                               v17 = uextend.i64 v15  ; v15 = 0
-;; @0033                               v18 = global_value.i64 gv4
-;; @0033                               v19 = iadd v18, v17
-;; @0033                               store little heap v16, v19  ; v16 = 10
+;; @002f                               v13 = iconst.i32 0
+;; @0031                               v14 = iconst.i32 10
+;; @0033                               v15 = uextend.i64 v13  ; v13 = 0
+;; @0033                               v16 = global_value.i64 gv4
+;; @0033                               v17 = iadd v16, v15
+;; @0033                               store little heap v14, v17  ; v14 = 10
 ;; @0036                               jump block3
 ;;
 ;;                                 block4:
-;; @0037                               v20 = iconst.i32 0
-;; @0039                               v21 = iconst.i32 11
-;; @003b                               v22 = uextend.i64 v20  ; v20 = 0
-;; @003b                               v23 = global_value.i64 gv4
-;; @003b                               v24 = iadd v23, v22
-;; @003b                               store little heap v21, v24  ; v21 = 11
+;; @0037                               v18 = iconst.i32 0
+;; @0039                               v19 = iconst.i32 11
+;; @003b                               v20 = uextend.i64 v18  ; v18 = 0
+;; @003b                               v21 = global_value.i64 gv4
+;; @003b                               v22 = iadd v21, v20
+;; @003b                               store little heap v19, v22  ; v19 = 11
 ;; @003e                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/multi-0.wat
+++ b/tests/disas/multi-0.wat
@@ -8,14 +8,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0026                               v5 = global_value.i64 gv3
-;; @0026                               v6 = load.i64 notrap aligned v5+8
 ;; @002b                               jump block1(v2, v2)
 ;;
 ;;                                 block1(v3: i64, v4: i64):

--- a/tests/disas/multi-1.wat
+++ b/tests/disas/multi-1.wat
@@ -11,19 +11,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0033                               v7 = global_value.i64 gv3
-;; @0033                               v8 = load.i64 notrap aligned v7+8
-;; @003a                               v12 = f64const 0x1.34a0000000000p10
-;; @0043                               jump block2(v3, v2, v12)  ; v12 = 0x1.34a0000000000p10
+;; @003a                               v10 = f64const 0x1.34a0000000000p10
+;; @0043                               jump block2(v3, v2, v10)  ; v10 = 0x1.34a0000000000p10
 ;;
-;;                                 block2(v9: i32, v10: i64, v11: f64):
-;; @0044                               jump block1(v9, v10, v11)
+;;                                 block2(v7: i32, v8: i64, v9: f64):
+;; @0044                               jump block1(v7, v8, v9)
 ;;
 ;;                                 block1(v4: i32, v5: i64, v6: f64):
 ;; @0044                               return v4, v5, v6

--- a/tests/disas/multi-10.wat
+++ b/tests/disas/multi-10.wat
@@ -15,26 +15,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0027                               v6 = global_value.i64 gv3
-;; @0027                               v7 = load.i64 notrap aligned v6+8
 ;; @002c                               brif v3, block2, block4(v2)
 ;;
 ;;                                 block2:
-;; @002e                               v11 = iconst.i64 -1
-;; @0030                               jump block3(v2, v11)  ; v11 = -1
+;; @002e                               v9 = iconst.i64 -1
+;; @0030                               jump block3(v2, v9)  ; v9 = -1
 ;;
-;;                                 block4(v10: i64):
-;; @0031                               v12 = iconst.i64 -2
-;; @0033                               jump block3(v2, v12)  ; v12 = -2
+;;                                 block4(v8: i64):
+;; @0031                               v10 = iconst.i64 -2
+;; @0033                               jump block3(v2, v10)  ; v10 = -2
 ;;
-;;                                 block3(v8: i64, v9: i64):
-;; @0034                               jump block1(v8, v9)
+;;                                 block3(v6: i64, v7: i64):
+;; @0034                               jump block1(v6, v7)
 ;;
 ;;                                 block1(v4: i64, v5: i64):
 ;; @0034                               return v4, v5

--- a/tests/disas/multi-11.wat
+++ b/tests/disas/multi-11.wat
@@ -12,17 +12,14 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0028                               v5 = global_value.i64 gv3
-;; @0028                               v6 = load.i64 notrap aligned v5+8
 ;; @002b                               jump block2(v2)
 ;;
-;;                                 block2(v7: i64):
-;; @002d                               v10 = iconst.i64 42
-;; @002f                               return v7, v10  ; v10 = 42
+;;                                 block2(v5: i64):
+;; @002d                               v8 = iconst.i64 42
+;; @002f                               return v5, v8  ; v8 = 42
 ;; }

--- a/tests/disas/multi-12.wat
+++ b/tests/disas/multi-12.wat
@@ -14,16 +14,13 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @002a                               v7 = global_value.i64 gv3
-;; @002a                               v8 = load.i64 notrap aligned v7+8
 ;; @0031                               jump block2(v4, v3, v2)
 ;;
-;;                                 block2(v9: i64, v10: i64, v11: i64):
-;; @0034                               return v9, v10
+;;                                 block2(v7: i64, v8: i64, v9: i64):
+;; @0034                               return v7, v8
 ;; }

--- a/tests/disas/multi-13.wat
+++ b/tests/disas/multi-13.wat
@@ -15,28 +15,25 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0029                               v5 = global_value.i64 gv3
-;; @0029                               v6 = load.i64 notrap aligned v5+8
 ;; @002e                               brif v2, block3, block5
 ;;
 ;;                                 block3:
-;; @0030                               v9 = iconst.i32 3
-;; @0032                               jump block2(v9)  ; v9 = 3
+;; @0030                               v7 = iconst.i32 3
+;; @0032                               jump block2(v7)  ; v7 = 3
 ;;
 ;;                                 block5:
 ;; @0037                               jump block4(v3)
 ;;
-;;                                 block4(v8: i32):
-;; @0038                               jump block2(v8)
+;;                                 block4(v6: i32):
+;; @0038                               jump block2(v6)
 ;;
-;;                                 block2(v7: i32):
-;; @0039                               jump block1(v7)
+;;                                 block2(v5: i32):
+;; @0039                               jump block1(v5)
 ;;
 ;;                                 block1(v4: i32):
 ;; @0039                               return v4

--- a/tests/disas/multi-14.wat
+++ b/tests/disas/multi-14.wat
@@ -15,28 +15,25 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0029                               v5 = global_value.i64 gv3
-;; @0029                               v6 = load.i64 notrap aligned v5+8
 ;; @002e                               brif v2, block3, block5
 ;;
 ;;                                 block3:
 ;; @0032                               jump block4(v3)
 ;;
 ;;                                 block5:
-;; @0033                               v9 = iconst.i32 4
-;; @0035                               jump block2(v9)  ; v9 = 4
+;; @0033                               v7 = iconst.i32 4
+;; @0035                               jump block2(v7)  ; v7 = 4
 ;;
-;;                                 block4(v8: i32):
-;; @0038                               jump block2(v8)
+;;                                 block4(v6: i32):
+;; @0038                               jump block2(v6)
 ;;
-;;                                 block2(v7: i32):
-;; @0039                               jump block1(v7)
+;;                                 block2(v5: i32):
+;; @0039                               jump block1(v5)
 ;;
 ;;                                 block1(v4: i32):
 ;; @0039                               return v4

--- a/tests/disas/multi-15.wat
+++ b/tests/disas/multi-15.wat
@@ -27,14 +27,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: f32, v5: f32, v6: i32, v7: f64, v8: f32, v9: i32, v10: i32, v11: i32, v12: f32, v13: f64, v14: f64, v15: f64, v16: i32, v17: i32, v18: f32):
-;; @0046                               v35 = global_value.i64 gv3
-;; @0046                               v36 = load.i64 notrap aligned v35+8
 ;; @0067                               jump block1(v7, v4, v2, v10, v9, v3, v5, v11, v6, v8, v15, v13, v17, v18, v16, v14)
 ;;
 ;;                                 block1(v19: f64, v20: f32, v21: i32, v22: i32, v23: i32, v24: i64, v25: f32, v26: i32, v27: i32, v28: f32, v29: f64, v30: f64, v31: i32, v32: f32, v33: i32, v34: f64):

--- a/tests/disas/multi-16.wat
+++ b/tests/disas/multi-16.wat
@@ -14,29 +14,26 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0023                               v4 = global_value.i64 gv3
-;; @0023                               v5 = load.i64 notrap aligned v4+8
-;; @0024                               v6 = iconst.i32 1
-;; @0028                               brif v2, block2, block4(v6)  ; v6 = 1
+;; @0024                               v4 = iconst.i32 1
+;; @0028                               brif v2, block2, block4(v4)  ; v4 = 1
 ;;
 ;;                                 block2:
-;; @002a                               v8 = iconst.i32 2
-;; @002c                               v9 = iadd.i32 v6, v8  ; v6 = 1, v8 = 2
-;; @002d                               jump block3(v9)
+;; @002a                               v6 = iconst.i32 2
+;; @002c                               v7 = iadd.i32 v4, v6  ; v4 = 1, v6 = 2
+;; @002d                               jump block3(v7)
 ;;
-;;                                 block4(v10: i32):
-;; @002e                               v11 = iconst.i32 0xffff_fffe
-;; @0030                               v12 = iadd.i32 v6, v11  ; v6 = 1, v11 = 0xffff_fffe
-;; @0031                               jump block3(v12)
+;;                                 block4(v8: i32):
+;; @002e                               v9 = iconst.i32 0xffff_fffe
+;; @0030                               v10 = iadd.i32 v4, v9  ; v4 = 1, v9 = 0xffff_fffe
+;; @0031                               jump block3(v10)
 ;;
-;;                                 block3(v7: i32):
-;; @0032                               jump block1(v7)
+;;                                 block3(v5: i32):
+;; @0032                               jump block1(v5)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0032                               return v3

--- a/tests/disas/multi-17.wat
+++ b/tests/disas/multi-17.wat
@@ -31,7 +31,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32) -> i32 fast
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig2 = (i64 vmctx, i32 uext) -> i32 uext system_v
@@ -39,35 +38,33 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @0024                               v6 = global_value.i64 gv3
-;; @0024                               v7 = load.i64 notrap aligned v6+8
-;; @0025                               v8 = iconst.i32 0
-;; @0027                               v9 = iconst.i32 0
-;; @0029                               v10 = iconst.i32 0
-;; @002b                               v11 = iconst.i32 0
-;; @002d                               v12 = iconst.i32 0
-;; @002f                               brif v12, block2, block4(v9, v10, v11)  ; v12 = 0, v9 = 0, v10 = 0, v11 = 0
+;; @0025                               v6 = iconst.i32 0
+;; @0027                               v7 = iconst.i32 0
+;; @0029                               v8 = iconst.i32 0
+;; @002b                               v9 = iconst.i32 0
+;; @002d                               v10 = iconst.i32 0
+;; @002f                               brif v10, block2, block4(v7, v8, v9)  ; v10 = 0, v7 = 0, v8 = 0, v9 = 0
 ;;
 ;;                                 block2:
-;; @0031                               jump block3(v11)  ; v11 = 0
+;; @0031                               jump block3(v9)  ; v9 = 0
 ;;
-;;                                 block4(v14: i32, v15: i32, v16: i32):
-;; @0034                               v17 = call fn0(v0, v0, v9, v10, v11)  ; v9 = 0, v10 = 0, v11 = 0
-;; @0036                               jump block3(v17)
+;;                                 block4(v12: i32, v13: i32, v14: i32):
+;; @0034                               v15 = call fn0(v0, v0, v7, v8, v9)  ; v7 = 0, v8 = 0, v9 = 0
+;; @0036                               jump block3(v15)
 ;;
-;;                                 block3(v13: i32):
-;; @0037                               v18 = iconst.i32 0
-;; @0039                               v19 = iconst.i32 0
-;; @003b                               brif v19, block5, block7(v8, v13, v18)  ; v19 = 0, v8 = 0, v18 = 0
+;;                                 block3(v11: i32):
+;; @0037                               v16 = iconst.i32 0
+;; @0039                               v17 = iconst.i32 0
+;; @003b                               brif v17, block5, block7(v6, v11, v16)  ; v17 = 0, v6 = 0, v16 = 0
 ;;
 ;;                                 block5:
-;; @003f                               jump block6(v8)  ; v8 = 0
+;; @003f                               jump block6(v6)  ; v6 = 0
 ;;
-;;                                 block7(v21: i32, v22: i32, v23: i32):
-;; @0042                               jump block6(v8)  ; v8 = 0
+;;                                 block7(v19: i32, v20: i32, v21: i32):
+;; @0042                               jump block6(v6)  ; v6 = 0
 ;;
-;;                                 block6(v20: i32):
-;; @0043                               jump block1(v20)
+;;                                 block6(v18: i32):
+;; @0043                               jump block1(v18)
 ;;
 ;;                                 block1(v5: i32):
 ;; @0043                               return v5

--- a/tests/disas/multi-2.wat
+++ b/tests/disas/multi-2.wat
@@ -11,16 +11,13 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @0029                               v6 = global_value.i64 gv3
-;; @0029                               v7 = load.i64 notrap aligned v6+8
 ;; @002e                               jump block2(v3, v2)
 ;;
-;;                                 block2(v8: i64, v9: i64):
-;; @0030                               return v8, v9
+;;                                 block2(v6: i64, v7: i64):
+;; @0030                               return v6, v7
 ;; }

--- a/tests/disas/multi-3.wat
+++ b/tests/disas/multi-3.wat
@@ -18,26 +18,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i64):
-;; @002f                               v7 = global_value.i64 gv3
-;; @002f                               v8 = load.i64 notrap aligned v7+8
 ;; @0036                               brif v2, block2, block4(v4, v3)
 ;;
 ;;                                 block2:
 ;; @0038                               return v4, v3
 ;;
-;;                                 block4(v11: i64, v12: i64):
-;; @003c                               v13 = iconst.i64 0
-;; @003e                               v14 = iconst.i64 0
-;; @0040                               jump block3(v13, v14)  ; v13 = 0, v14 = 0
+;;                                 block4(v9: i64, v10: i64):
+;; @003c                               v11 = iconst.i64 0
+;; @003e                               v12 = iconst.i64 0
+;; @0040                               jump block3(v11, v12)  ; v11 = 0, v12 = 0
 ;;
-;;                                 block3(v9: i64, v10: i64):
-;; @0041                               jump block1(v9, v10)
+;;                                 block3(v7: i64, v8: i64):
+;; @0041                               jump block1(v7, v8)
 ;;
 ;;                                 block1(v5: i64, v6: i64):
 ;; @0041                               return v5, v6

--- a/tests/disas/multi-4.wat
+++ b/tests/disas/multi-4.wat
@@ -18,28 +18,25 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i64):
-;; @0030                               v7 = global_value.i64 gv3
-;; @0030                               v8 = load.i64 notrap aligned v7+8
 ;; @0037                               brif v2, block2, block4(v4, v3)
 ;;
 ;;                                 block2:
-;; @0039                               v11 = iadd.i64 v4, v3
-;; @003a                               v12 = iconst.i64 1
-;; @003c                               jump block3(v11, v12)  ; v12 = 1
+;; @0039                               v9 = iadd.i64 v4, v3
+;; @003a                               v10 = iconst.i64 1
+;; @003c                               jump block3(v9, v10)  ; v10 = 1
 ;;
-;;                                 block4(v13: i64, v14: i64):
-;; @003d                               v15 = isub.i64 v4, v3
-;; @003e                               v16 = iconst.i64 2
-;; @0040                               jump block3(v15, v16)  ; v16 = 2
+;;                                 block4(v11: i64, v12: i64):
+;; @003d                               v13 = isub.i64 v4, v3
+;; @003e                               v14 = iconst.i64 2
+;; @0040                               jump block3(v13, v14)  ; v14 = 2
 ;;
-;;                                 block3(v9: i64, v10: i64):
-;; @0041                               jump block1(v9, v10)
+;;                                 block3(v7: i64, v8: i64):
+;; @0041                               jump block1(v7, v8)
 ;;
 ;;                                 block1(v5: i64, v6: i64):
 ;; @0041                               return v5, v6

--- a/tests/disas/multi-5.wat
+++ b/tests/disas/multi-5.wat
@@ -16,19 +16,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0025                               v2 = global_value.i64 gv3
-;; @0025                               v3 = load.i64 notrap aligned v2+8
-;; @0026                               v4 = iconst.i32 1
-;; @0028                               v5 = iconst.i64 2
-;; @002d                               jump block2(v4)  ; v4 = 1
+;; @0026                               v2 = iconst.i32 1
+;; @0028                               v3 = iconst.i64 2
+;; @002d                               jump block2(v2)  ; v2 = 1
 ;;
-;;                                 block2(v6: i32):
+;;                                 block2(v4: i32):
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/multi-6.wat
+++ b/tests/disas/multi-6.wat
@@ -16,19 +16,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0025                               v2 = global_value.i64 gv3
-;; @0025                               v3 = load.i64 notrap aligned v2+8
-;; @0026                               v4 = iconst.i32 1
-;; @002a                               v7 = iconst.i64 2
-;; @002c                               jump block2(v4, v7)  ; v4 = 1, v7 = 2
+;; @0026                               v2 = iconst.i32 1
+;; @002a                               v5 = iconst.i64 2
+;; @002c                               jump block2(v2, v5)  ; v2 = 1, v5 = 2
 ;;
-;;                                 block2(v5: i32, v6: i64):
+;;                                 block2(v3: i32, v4: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/multi-7.wat
+++ b/tests/disas/multi-7.wat
@@ -14,22 +14,19 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0025                               v5 = global_value.i64 gv3
-;; @0025                               v6 = load.i64 notrap aligned v5+8
 ;; @002a                               brif v3, block2, block3(v2)
 ;;
 ;;                                 block2:
-;; @002d                               v8 = iconst.i64 -1
-;; @002f                               jump block3(v8)  ; v8 = -1
+;; @002d                               v6 = iconst.i64 -1
+;; @002f                               jump block3(v6)  ; v6 = -1
 ;;
-;;                                 block3(v7: i64):
-;; @0030                               jump block1(v7)
+;;                                 block3(v5: i64):
+;; @0030                               jump block1(v5)
 ;;
 ;;                                 block1(v4: i64):
 ;; @0030                               return v4

--- a/tests/disas/multi-8.wat
+++ b/tests/disas/multi-8.wat
@@ -17,26 +17,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0025                               v5 = global_value.i64 gv3
-;; @0025                               v6 = load.i64 notrap aligned v5+8
 ;; @002a                               brif v3, block2, block4(v2)
 ;;
 ;;                                 block2:
-;; @002d                               v8 = iconst.i64 -1
-;; @002f                               jump block3(v8)  ; v8 = -1
+;; @002d                               v6 = iconst.i64 -1
+;; @002f                               jump block3(v6)  ; v6 = -1
 ;;
-;;                                 block4(v9: i64):
-;; @0031                               v10 = iconst.i64 -2
-;; @0033                               jump block3(v10)  ; v10 = -2
+;;                                 block4(v7: i64):
+;; @0031                               v8 = iconst.i64 -2
+;; @0033                               jump block3(v8)  ; v8 = -2
 ;;
-;;                                 block3(v7: i64):
-;; @0034                               jump block1(v7)
+;;                                 block3(v5: i64):
+;; @0034                               jump block1(v5)
 ;;
 ;;                                 block1(v4: i64):
 ;; @0034                               return v4

--- a/tests/disas/multi-9.wat
+++ b/tests/disas/multi-9.wat
@@ -20,26 +20,23 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0020                               v5 = global_value.i64 gv3
-;; @0020                               v6 = load.i64 notrap aligned v5+8
 ;; @0027                               brif v3, block2, block4(v2, v3)
 ;;
 ;;                                 block2:
-;; @002b                               v10 = iconst.i64 -1
-;; @002d                               jump block3(v10)  ; v10 = -1
+;; @002b                               v8 = iconst.i64 -1
+;; @002d                               jump block3(v8)  ; v8 = -1
 ;;
-;;                                 block4(v8: i64, v9: i32):
-;; @0030                               v11 = iconst.i64 -2
-;; @0032                               jump block3(v11)  ; v11 = -2
+;;                                 block4(v6: i64, v7: i32):
+;; @0030                               v9 = iconst.i64 -2
+;; @0032                               jump block3(v9)  ; v9 = -2
 ;;
-;;                                 block3(v7: i64):
-;; @0033                               jump block1(v7)
+;;                                 block3(v5: i64):
+;; @0033                               jump block1(v5)
 ;;
 ;;                                 block1(v4: i64):
 ;; @0033                               return v4

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -33,15 +33,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003c                               v4 = global_value.i64 gv3
-;; @003c                               v5 = load.i64 notrap aligned v4+8
-;; @0041                               v6 = uextend.i64 v2
-;; @0041                               v7 = global_value.i64 gv4
-;; @0041                               v8 = icmp uge v6, v7
-;; @0041                               trapnz v8, heap_oob
-;; @0041                               v9 = global_value.i64 gv5
-;; @0041                               v10 = iadd v9, v6
-;; @0041                               istore8 little heap v3, v10
+;; @0041                               v4 = uextend.i64 v2
+;; @0041                               v5 = global_value.i64 gv4
+;; @0041                               v6 = icmp uge v4, v5
+;; @0041                               trapnz v6, heap_oob
+;; @0041                               v7 = global_value.i64 gv5
+;; @0041                               v8 = iadd v7, v4
+;; @0041                               istore8 little heap v3, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,16 +59,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0046                               v4 = global_value.i64 gv3
-;; @0046                               v5 = load.i64 notrap aligned v4+8
-;; @0049                               v6 = uextend.i64 v2
-;; @0049                               v7 = global_value.i64 gv4
-;; @0049                               v8 = icmp uge v6, v7
-;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = global_value.i64 gv5
-;; @0049                               v10 = iadd v9, v6
-;; @0049                               v11 = uload8.i32 little heap v10
-;; @004c                               jump block1(v11)
+;; @0049                               v4 = uextend.i64 v2
+;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v6 = icmp uge v4, v5
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v8 = iadd v7, v4
+;; @0049                               v9 = uload8.i32 little heap v8
+;; @004c                               jump block1(v9)
 ;;
 ;;                                 block1(v3: i32):
 ;; @004c                               return v3

--- a/tests/disas/nullref.wat
+++ b/tests/disas/nullref.wat
@@ -16,16 +16,13 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0018                               v3 = global_value.i64 gv3
-;; @0018                               v4 = load.i64 notrap aligned v3+8
-;; @0019                               v5 = null.r64 
-;; @001b                               jump block1(v5)
+;; @0019                               v3 = null.r64 
+;; @001b                               jump block1(v3)
 ;;
 ;;                                 block1(v2: r64):
 ;; @001b                               return v2
@@ -35,19 +32,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @001d                               v3 = global_value.i64 gv3
-;; @001d                               v4 = load.i64 notrap aligned v3+8
-;; @0020                               v6 = null.r64 
-;; @0022                               jump block2(v6)
+;; @0020                               v4 = null.r64 
+;; @0022                               jump block2(v4)
 ;;
-;;                                 block2(v5: r64):
-;; @0023                               jump block1(v5)
+;;                                 block2(v3: r64):
+;; @0023                               jump block1(v3)
 ;;
 ;;                                 block1(v2: r64):
 ;; @0023                               return v2

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -25,15 +25,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @0036                               v5 = global_value.i64 gv3
-;; @0036                               v6 = load.i64 notrap aligned v5+8
-;; @003d                               v7 = iconst.i32 0
-;; @003d                               v8 = iconst.i32 0
-;; @003d                               v9 = global_value.i64 gv3
-;; @003d                               v10 = load.i64 notrap aligned readonly v9+56
-;; @003d                               v11 = load.i64 notrap aligned readonly v10+48
-;; @003d                               v12 = uextend.i64 v2
-;; @003d                               call_indirect sig0, v11(v9, v7, v8, v12, v3, v4)  ; v7 = 0, v8 = 0
+;; @003d                               v5 = iconst.i32 0
+;; @003d                               v6 = iconst.i32 0
+;; @003d                               v7 = global_value.i64 gv3
+;; @003d                               v8 = load.i64 notrap aligned readonly v7+56
+;; @003d                               v9 = load.i64 notrap aligned readonly v8+48
+;; @003d                               v10 = uextend.i64 v2
+;; @003d                               call_indirect sig0, v9(v7, v5, v6, v10, v3, v4)  ; v5 = 0, v6 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
@@ -51,13 +49,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0043                               v2 = global_value.i64 gv3
-;; @0043                               v3 = load.i64 notrap aligned v2+8
-;; @0044                               v4 = iconst.i32 0
-;; @0044                               v5 = global_value.i64 gv3
-;; @0044                               v6 = load.i64 notrap aligned readonly v5+56
-;; @0044                               v7 = load.i64 notrap aligned readonly v6+64
-;; @0044                               call_indirect sig0, v7(v5, v4)  ; v4 = 0
+;; @0044                               v2 = iconst.i32 0
+;; @0044                               v3 = global_value.i64 gv3
+;; @0044                               v4 = load.i64 notrap aligned readonly v3+56
+;; @0044                               v5 = load.i64 notrap aligned readonly v4+64
+;; @0044                               call_indirect sig0, v5(v3, v2)  ; v2 = 0
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -29,53 +29,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0035                               v3 = global_value.i64 gv3
-;; @0035                               v4 = load.i64 notrap aligned v3+8
-;; @0036                               v5 = iconst.i32 48
-;; @0038                               v6 = iconst.i32 0
-;; @003a                               v7 = uextend.i64 v6  ; v6 = 0
-;; @003a                               v8 = global_value.i64 gv4
-;; @003a                               v9 = iadd v8, v7
-;; @003a                               v10 = load.i8x16 little heap v9
-;; @003e                               v11 = iconst.i32 16
-;; @0040                               v12 = uextend.i64 v11  ; v11 = 16
-;; @0040                               v13 = global_value.i64 gv4
-;; @0040                               v14 = iadd v13, v12
-;; @0040                               v15 = load.i8x16 little heap v14
-;; @0046                               brif v2, block2, block4(v10, v15)
+;; @0036                               v3 = iconst.i32 48
+;; @0038                               v4 = iconst.i32 0
+;; @003a                               v5 = uextend.i64 v4  ; v4 = 0
+;; @003a                               v6 = global_value.i64 gv4
+;; @003a                               v7 = iadd v6, v5
+;; @003a                               v8 = load.i8x16 little heap v7
+;; @003e                               v9 = iconst.i32 16
+;; @0040                               v10 = uextend.i64 v9  ; v9 = 16
+;; @0040                               v11 = global_value.i64 gv4
+;; @0040                               v12 = iadd v11, v10
+;; @0040                               v13 = load.i8x16 little heap v12
+;; @0046                               brif v2, block2, block4(v8, v13)
 ;;
 ;;                                 block2:
-;; @0048                               v18 = bitcast.i64x2 little v10
-;; @0048                               v19 = bitcast.i64x2 little v15
-;; @0048                               v20 = iadd v18, v19
-;; @004b                               v21 = iconst.i32 32
-;; @004d                               v22 = uextend.i64 v21  ; v21 = 32
-;; @004d                               v23 = global_value.i64 gv4
-;; @004d                               v24 = iadd v23, v22
-;; @004d                               v25 = load.i8x16 little heap v24
-;; @0051                               v28 = bitcast.i8x16 little v20
-;; @0051                               jump block3(v28, v25)
+;; @0048                               v16 = bitcast.i64x2 little v8
+;; @0048                               v17 = bitcast.i64x2 little v13
+;; @0048                               v18 = iadd v16, v17
+;; @004b                               v19 = iconst.i32 32
+;; @004d                               v20 = uextend.i64 v19  ; v19 = 32
+;; @004d                               v21 = global_value.i64 gv4
+;; @004d                               v22 = iadd v21, v20
+;; @004d                               v23 = load.i8x16 little heap v22
+;; @0051                               v26 = bitcast.i8x16 little v18
+;; @0051                               jump block3(v26, v23)
 ;;
-;;                                 block4(v26: i8x16, v27: i8x16):
-;; @0052                               v29 = bitcast.i32x4 little v10
-;; @0052                               v30 = bitcast.i32x4 little v15
-;; @0052                               v31 = isub v29, v30
-;; @0055                               v32 = iconst.i32 0
-;; @0057                               v33 = uextend.i64 v32  ; v32 = 0
-;; @0057                               v34 = global_value.i64 gv4
-;; @0057                               v35 = iadd v34, v33
-;; @0057                               v36 = load.i8x16 little heap v35
-;; @005b                               v37 = bitcast.i8x16 little v31
-;; @005b                               jump block3(v37, v36)
+;;                                 block4(v24: i8x16, v25: i8x16):
+;; @0052                               v27 = bitcast.i32x4 little v8
+;; @0052                               v28 = bitcast.i32x4 little v13
+;; @0052                               v29 = isub v27, v28
+;; @0055                               v30 = iconst.i32 0
+;; @0057                               v31 = uextend.i64 v30  ; v30 = 0
+;; @0057                               v32 = global_value.i64 gv4
+;; @0057                               v33 = iadd v32, v31
+;; @0057                               v34 = load.i8x16 little heap v33
+;; @005b                               v35 = bitcast.i8x16 little v29
+;; @005b                               jump block3(v35, v34)
 ;;
-;;                                 block3(v16: i8x16, v17: i8x16):
-;; @005c                               v38 = bitcast.i16x8 little v16
-;; @005c                               v39 = bitcast.i16x8 little v17
-;; @005c                               v40 = imul v38, v39
-;; @005f                               v41 = uextend.i64 v5  ; v5 = 48
-;; @005f                               v42 = global_value.i64 gv4
-;; @005f                               v43 = iadd v42, v41
-;; @005f                               store little heap v40, v43
+;;                                 block3(v14: i8x16, v15: i8x16):
+;; @005c                               v36 = bitcast.i16x8 little v14
+;; @005c                               v37 = bitcast.i16x8 little v15
+;; @005c                               v38 = imul v36, v37
+;; @005f                               v39 = uextend.i64 v3  ; v3 = 48
+;; @005f                               v40 = global_value.i64 gv4
+;; @005f                               v41 = iadd v40, v39
+;; @005f                               store little heap v38, v41
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pr2559.wat
+++ b/tests/disas/pr2559.wat
@@ -56,7 +56,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 fast
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig2 = (i64 vmctx, i32 uext) -> i32 uext system_v
@@ -64,33 +63,31 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @002d                               v5 = global_value.i64 gv3
-;; @002d                               v6 = load.i64 notrap aligned v5+8
-;; @002e                               v7, v8, v9 = call fn0(v0, v0)
-;; @0030                               v10 = iadd v8, v9
-;; @0032                               v11, v12, v13 = call fn0(v0, v0)
-;; @0034                               v14 = icmp uge v12, v13
-;; @0036                               v15 = bitcast.i16x8 little v11
-;; @0036                               v16 = bitcast.i16x8 little v14
-;; @0036                               v17 = icmp ne v15, v16
-;; @0038                               v18 = iconst.i32 13
-;; @003a                               v19 = bitcast.i8x16 little v17
-;; @003a                               brif v18, block1(v7, v10, v19), block2  ; v18 = 13
+;; @002e                               v5, v6, v7 = call fn0(v0, v0)
+;; @0030                               v8 = iadd v6, v7
+;; @0032                               v9, v10, v11 = call fn0(v0, v0)
+;; @0034                               v12 = icmp uge v10, v11
+;; @0036                               v13 = bitcast.i16x8 little v9
+;; @0036                               v14 = bitcast.i16x8 little v12
+;; @0036                               v15 = icmp ne v13, v14
+;; @0038                               v16 = iconst.i32 13
+;; @003a                               v17 = bitcast.i8x16 little v15
+;; @003a                               brif v16, block1(v5, v8, v17), block2  ; v16 = 13
 ;;
 ;;                                 block2:
-;; @003c                               v20 = iconst.i32 43
-;; @003e                               v21 = bitcast.i8x16 little v17
-;; @003e                               brif v20, block1(v7, v10, v21), block3  ; v20 = 43
+;; @003c                               v18 = iconst.i32 43
+;; @003e                               v19 = bitcast.i8x16 little v15
+;; @003e                               brif v18, block1(v5, v8, v19), block3  ; v18 = 43
 ;;
 ;;                                 block3:
-;; @0040                               v22 = iconst.i32 13
-;; @0042                               v23 = bitcast.i8x16 little v17
-;; @0042                               brif v22, block1(v7, v10, v23), block4  ; v22 = 13
+;; @0040                               v20 = iconst.i32 13
+;; @0042                               v21 = bitcast.i8x16 little v15
+;; @0042                               brif v20, block1(v5, v8, v21), block4  ; v20 = 13
 ;;
 ;;                                 block4:
-;; @0044                               v24 = iconst.i32 87
-;; @0047                               v25 = bitcast.i8x16 little v17
-;; @0047                               v26 = select.i8x16 v24, v10, v25  ; v24 = 87
+;; @0044                               v22 = iconst.i32 87
+;; @0047                               v23 = bitcast.i8x16 little v15
+;; @0047                               v24 = select.i8x16 v22, v8, v23  ; v22 = 87
 ;; @0048                               trap unreachable
 ;;
 ;;                                 block1(v2: i8x16, v3: i8x16, v4: i8x16):
@@ -101,7 +98,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 fast
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig2 = (i64 vmctx, i32 uext) -> i32 uext system_v
@@ -109,33 +105,31 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0057                               v5 = global_value.i64 gv3
-;; @0057                               v6 = load.i64 notrap aligned v5+8
-;; @0058                               v7, v8, v9 = call fn0(v0, v0)
-;; @005a                               v10 = iadd v8, v9
-;; @005c                               v11, v12, v13 = call fn0(v0, v0)
-;; @005e                               v14 = icmp uge v12, v13
-;; @0060                               v15 = bitcast.i16x8 little v11
-;; @0060                               v16 = bitcast.i16x8 little v14
-;; @0060                               v17 = icmp ne v15, v16
-;; @0062                               v18 = iconst.i32 13
-;; @0064                               v19 = bitcast.i8x16 little v17
-;; @0064                               brif v18, block1(v7, v10, v19), block2  ; v18 = 13
+;; @0058                               v5, v6, v7 = call fn0(v0, v0)
+;; @005a                               v8 = iadd v6, v7
+;; @005c                               v9, v10, v11 = call fn0(v0, v0)
+;; @005e                               v12 = icmp uge v10, v11
+;; @0060                               v13 = bitcast.i16x8 little v9
+;; @0060                               v14 = bitcast.i16x8 little v12
+;; @0060                               v15 = icmp ne v13, v14
+;; @0062                               v16 = iconst.i32 13
+;; @0064                               v17 = bitcast.i8x16 little v15
+;; @0064                               brif v16, block1(v5, v8, v17), block2  ; v16 = 13
 ;;
 ;;                                 block2:
-;; @0066                               v20 = iconst.i32 43
-;; @0068                               v21 = bitcast.i8x16 little v17
-;; @0068                               brif v20, block1(v7, v10, v21), block3  ; v20 = 43
+;; @0066                               v18 = iconst.i32 43
+;; @0068                               v19 = bitcast.i8x16 little v15
+;; @0068                               brif v18, block1(v5, v8, v19), block3  ; v18 = 43
 ;;
 ;;                                 block3:
-;; @006a                               v22 = iconst.i32 13
-;; @006c                               v23 = bitcast.i8x16 little v17
-;; @006c                               brif v22, block1(v7, v10, v23), block4  ; v22 = 13
+;; @006a                               v20 = iconst.i32 13
+;; @006c                               v21 = bitcast.i8x16 little v15
+;; @006c                               brif v20, block1(v5, v8, v21), block4  ; v20 = 13
 ;;
 ;;                                 block4:
-;; @006e                               v24 = iconst.i32 87
-;; @0071                               v25 = bitcast.i8x16 little v17
-;; @0071                               v26 = select.i8x16 v24, v10, v25  ; v24 = 87
+;; @006e                               v22 = iconst.i32 87
+;; @0071                               v23 = bitcast.i8x16 little v15
+;; @0071                               v24 = select.i8x16 v22, v8, v23  ; v22 = 87
 ;; @0074                               trap unreachable
 ;;
 ;;                                 block1(v2: i8x16, v3: i8x16, v4: i8x16):

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -24,23 +24,21 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @008e                               v6 = global_value.i64 gv3
-;; @008e                               v7 = load.i64 notrap aligned v6+8
-;; @008f                               v8 = global_value.i64 gv3
-;; @008f                               v9 = load.i64 notrap aligned readonly v8+56
-;; @008f                               v10 = load.i64 notrap aligned readonly v9+408
-;; @008f                               v11 = iconst.i32 0
-;; @008f                               v12 = call_indirect sig0, v10(v8, v11)  ; v11 = 0
-;; @0091                               v13 = global_value.i64 gv3
-;; @0091                               v14 = load.i64 notrap aligned readonly v13+56
-;; @0091                               v15 = load.i64 notrap aligned readonly v14+408
-;; @0091                               v16 = iconst.i32 1
-;; @0091                               v17 = call_indirect sig0, v15(v13, v16)  ; v16 = 1
-;; @0093                               v18 = global_value.i64 gv3
-;; @0093                               v19 = load.i64 notrap aligned table v18+144
-;; @0095                               v20 = global_value.i64 gv3
-;; @0095                               v21 = load.i64 notrap aligned table v20+160
-;; @0097                               jump block1(v12, v17, v19, v21)
+;; @008f                               v6 = global_value.i64 gv3
+;; @008f                               v7 = load.i64 notrap aligned readonly v6+56
+;; @008f                               v8 = load.i64 notrap aligned readonly v7+216
+;; @008f                               v9 = iconst.i32 0
+;; @008f                               v10 = call_indirect sig0, v8(v6, v9)  ; v9 = 0
+;; @0091                               v11 = global_value.i64 gv3
+;; @0091                               v12 = load.i64 notrap aligned readonly v11+56
+;; @0091                               v13 = load.i64 notrap aligned readonly v12+216
+;; @0091                               v14 = iconst.i32 1
+;; @0091                               v15 = call_indirect sig0, v13(v11, v14)  ; v14 = 1
+;; @0093                               v16 = global_value.i64 gv3
+;; @0093                               v17 = load.i64 notrap aligned table v16+144
+;; @0095                               v18 = global_value.i64 gv3
+;; @0095                               v19 = load.i64 notrap aligned table v18+160
+;; @0097                               jump block1(v10, v15, v17, v19)
 ;;
 ;;                                 block1(v2: r64, v3: r64, v4: i64, v5: i64):
 ;; @0097                               return v2, v3, v4, v5

--- a/tests/disas/select.wat
+++ b/tests/disas/select.wat
@@ -24,19 +24,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0022                               v3 = global_value.i64 gv3
-;; @0022                               v4 = load.i64 notrap aligned v3+8
-;; @0023                               v5 = iconst.i32 42
-;; @0025                               v6 = iconst.i32 24
-;; @0027                               v7 = iconst.i32 1
-;; @0029                               v8 = select v7, v5, v6  ; v7 = 1, v5 = 42, v6 = 24
-;; @002a                               jump block1(v8)
+;; @0023                               v3 = iconst.i32 42
+;; @0025                               v4 = iconst.i32 24
+;; @0027                               v5 = iconst.i32 1
+;; @0029                               v6 = select v5, v3, v4  ; v5 = 1, v3 = 42, v4 = 24
+;; @002a                               jump block1(v6)
 ;;
 ;;                                 block1(v2: i32):
 ;; @002a                               return v2
@@ -46,19 +43,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @002c                               v3 = global_value.i64 gv3
-;; @002c                               v4 = load.i64 notrap aligned v3+8
-;; @002d                               v5 = null.r64 
-;; @002f                               v6 = null.r64 
-;; @0031                               v7 = iconst.i32 1
-;; @0033                               v8 = select v7, v5, v6  ; v7 = 1
-;; @0036                               jump block1(v8)
+;; @002d                               v3 = null.r64 
+;; @002f                               v4 = null.r64 
+;; @0031                               v5 = iconst.i32 1
+;; @0033                               v6 = select v5, v3, v4  ; v5 = 1
+;; @0036                               jump block1(v6)
 ;;
 ;;                                 block1(v2: r64):
 ;; @0036                               return v2
@@ -68,18 +62,15 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: r64):
-;; @0038                               v4 = global_value.i64 gv3
-;; @0038                               v5 = load.i64 notrap aligned v4+8
-;; @0039                               v6 = null.r64 
-;; @003d                               v7 = iconst.i32 1
-;; @003f                               v8 = select v7, v6, v2  ; v7 = 1
-;; @0042                               jump block1(v8)
+;; @0039                               v4 = null.r64 
+;; @003d                               v5 = iconst.i32 1
+;; @003f                               v6 = select v5, v4, v2  ; v5 = 1
+;; @0042                               jump block1(v6)
 ;;
 ;;                                 block1(v3: r64):
 ;; @0042                               return v3

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -96,14 +96,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @003e                               v3 = global_value.i64 gv3
-;; @003e                               v4 = load.i64 notrap aligned v3+8
-;; @003f                               v5 = iconst.i32 0
-;; @0045                               v6 = icmp eq v2, v2
-;; @0047                               v7 = uextend.i64 v5  ; v5 = 0
-;; @0047                               v8 = global_value.i64 gv4
-;; @0047                               v9 = iadd v8, v7
-;; @0047                               store little heap v6, v9
+;; @003f                               v3 = iconst.i32 0
+;; @0045                               v4 = icmp eq v2, v2
+;; @0047                               v5 = uextend.i64 v3  ; v3 = 0
+;; @0047                               v6 = global_value.i64 gv4
+;; @0047                               v7 = iadd v6, v5
+;; @0047                               store little heap v4, v7
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -122,16 +120,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @004d                               v3 = global_value.i64 gv3
-;; @004d                               v4 = load.i64 notrap aligned v3+8
-;; @004e                               v5 = iconst.i32 0
-;; @0054                               v6 = bitcast.i16x8 little v2
-;; @0054                               v7 = bitcast.i16x8 little v2
-;; @0054                               v8 = icmp eq v6, v7
-;; @0056                               v9 = uextend.i64 v5  ; v5 = 0
-;; @0056                               v10 = global_value.i64 gv4
-;; @0056                               v11 = iadd v10, v9
-;; @0056                               store little heap v8, v11
+;; @004e                               v3 = iconst.i32 0
+;; @0054                               v4 = bitcast.i16x8 little v2
+;; @0054                               v5 = bitcast.i16x8 little v2
+;; @0054                               v6 = icmp eq v4, v5
+;; @0056                               v7 = uextend.i64 v3  ; v3 = 0
+;; @0056                               v8 = global_value.i64 gv4
+;; @0056                               v9 = iadd v8, v7
+;; @0056                               store little heap v6, v9
 ;; @005a                               jump block1
 ;;
 ;;                                 block1:
@@ -150,16 +146,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @005c                               v3 = global_value.i64 gv3
-;; @005c                               v4 = load.i64 notrap aligned v3+8
-;; @005d                               v5 = iconst.i32 0
-;; @0063                               v6 = bitcast.i32x4 little v2
-;; @0063                               v7 = bitcast.i32x4 little v2
-;; @0063                               v8 = icmp eq v6, v7
-;; @0065                               v9 = uextend.i64 v5  ; v5 = 0
-;; @0065                               v10 = global_value.i64 gv4
-;; @0065                               v11 = iadd v10, v9
-;; @0065                               store little heap v8, v11
+;; @005d                               v3 = iconst.i32 0
+;; @0063                               v4 = bitcast.i32x4 little v2
+;; @0063                               v5 = bitcast.i32x4 little v2
+;; @0063                               v6 = icmp eq v4, v5
+;; @0065                               v7 = uextend.i64 v3  ; v3 = 0
+;; @0065                               v8 = global_value.i64 gv4
+;; @0065                               v9 = iadd v8, v7
+;; @0065                               store little heap v6, v9
 ;; @0069                               jump block1
 ;;
 ;;                                 block1:
@@ -178,16 +172,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @006b                               v3 = global_value.i64 gv3
-;; @006b                               v4 = load.i64 notrap aligned v3+8
-;; @006c                               v5 = iconst.i32 0
-;; @0072                               v6 = bitcast.i64x2 little v2
-;; @0072                               v7 = bitcast.i64x2 little v2
-;; @0072                               v8 = icmp eq v6, v7
-;; @0075                               v9 = uextend.i64 v5  ; v5 = 0
-;; @0075                               v10 = global_value.i64 gv4
-;; @0075                               v11 = iadd v10, v9
-;; @0075                               store little heap v8, v11
+;; @006c                               v3 = iconst.i32 0
+;; @0072                               v4 = bitcast.i64x2 little v2
+;; @0072                               v5 = bitcast.i64x2 little v2
+;; @0072                               v6 = icmp eq v4, v5
+;; @0075                               v7 = uextend.i64 v3  ; v3 = 0
+;; @0075                               v8 = global_value.i64 gv4
+;; @0075                               v9 = iadd v8, v7
+;; @0075                               store little heap v6, v9
 ;; @0079                               jump block1
 ;;
 ;;                                 block1:
@@ -206,14 +198,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @007b                               v3 = global_value.i64 gv3
-;; @007b                               v4 = load.i64 notrap aligned v3+8
-;; @007c                               v5 = iconst.i32 0
-;; @0082                               v6 = icmp ne v2, v2
-;; @0084                               v7 = uextend.i64 v5  ; v5 = 0
-;; @0084                               v8 = global_value.i64 gv4
-;; @0084                               v9 = iadd v8, v7
-;; @0084                               store little heap v6, v9
+;; @007c                               v3 = iconst.i32 0
+;; @0082                               v4 = icmp ne v2, v2
+;; @0084                               v5 = uextend.i64 v3  ; v3 = 0
+;; @0084                               v6 = global_value.i64 gv4
+;; @0084                               v7 = iadd v6, v5
+;; @0084                               store little heap v4, v7
 ;; @0088                               jump block1
 ;;
 ;;                                 block1:
@@ -232,16 +222,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @008a                               v3 = global_value.i64 gv3
-;; @008a                               v4 = load.i64 notrap aligned v3+8
-;; @008b                               v5 = iconst.i32 0
-;; @0091                               v6 = bitcast.i16x8 little v2
-;; @0091                               v7 = bitcast.i16x8 little v2
-;; @0091                               v8 = icmp ne v6, v7
-;; @0093                               v9 = uextend.i64 v5  ; v5 = 0
-;; @0093                               v10 = global_value.i64 gv4
-;; @0093                               v11 = iadd v10, v9
-;; @0093                               store little heap v8, v11
+;; @008b                               v3 = iconst.i32 0
+;; @0091                               v4 = bitcast.i16x8 little v2
+;; @0091                               v5 = bitcast.i16x8 little v2
+;; @0091                               v6 = icmp ne v4, v5
+;; @0093                               v7 = uextend.i64 v3  ; v3 = 0
+;; @0093                               v8 = global_value.i64 gv4
+;; @0093                               v9 = iadd v8, v7
+;; @0093                               store little heap v6, v9
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:
@@ -260,16 +248,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0099                               v3 = global_value.i64 gv3
-;; @0099                               v4 = load.i64 notrap aligned v3+8
-;; @009a                               v5 = iconst.i32 0
-;; @00a0                               v6 = bitcast.i32x4 little v2
-;; @00a0                               v7 = bitcast.i32x4 little v2
-;; @00a0                               v8 = icmp ne v6, v7
-;; @00a2                               v9 = uextend.i64 v5  ; v5 = 0
-;; @00a2                               v10 = global_value.i64 gv4
-;; @00a2                               v11 = iadd v10, v9
-;; @00a2                               store little heap v8, v11
+;; @009a                               v3 = iconst.i32 0
+;; @00a0                               v4 = bitcast.i32x4 little v2
+;; @00a0                               v5 = bitcast.i32x4 little v2
+;; @00a0                               v6 = icmp ne v4, v5
+;; @00a2                               v7 = uextend.i64 v3  ; v3 = 0
+;; @00a2                               v8 = global_value.i64 gv4
+;; @00a2                               v9 = iadd v8, v7
+;; @00a2                               store little heap v6, v9
 ;; @00a6                               jump block1
 ;;
 ;;                                 block1:
@@ -288,16 +274,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @00a8                               v3 = global_value.i64 gv3
-;; @00a8                               v4 = load.i64 notrap aligned v3+8
-;; @00a9                               v5 = iconst.i32 0
-;; @00af                               v6 = bitcast.i64x2 little v2
-;; @00af                               v7 = bitcast.i64x2 little v2
-;; @00af                               v8 = icmp ne v6, v7
-;; @00b2                               v9 = uextend.i64 v5  ; v5 = 0
-;; @00b2                               v10 = global_value.i64 gv4
-;; @00b2                               v11 = iadd v10, v9
-;; @00b2                               store little heap v8, v11
+;; @00a9                               v3 = iconst.i32 0
+;; @00af                               v4 = bitcast.i64x2 little v2
+;; @00af                               v5 = bitcast.i64x2 little v2
+;; @00af                               v6 = icmp ne v4, v5
+;; @00b2                               v7 = uextend.i64 v3  ; v3 = 0
+;; @00b2                               v8 = global_value.i64 gv4
+;; @00b2                               v9 = iadd v8, v7
+;; @00b2                               store little heap v6, v9
 ;; @00b6                               jump block1
 ;;
 ;;                                 block1:
@@ -316,14 +300,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @00b8                               v3 = global_value.i64 gv3
-;; @00b8                               v4 = load.i64 notrap aligned v3+8
-;; @00b9                               v5 = iconst.i32 0
-;; @00bf                               v6 = icmp slt v2, v2
-;; @00c1                               v7 = uextend.i64 v5  ; v5 = 0
-;; @00c1                               v8 = global_value.i64 gv4
-;; @00c1                               v9 = iadd v8, v7
-;; @00c1                               store little heap v6, v9
+;; @00b9                               v3 = iconst.i32 0
+;; @00bf                               v4 = icmp slt v2, v2
+;; @00c1                               v5 = uextend.i64 v3  ; v3 = 0
+;; @00c1                               v6 = global_value.i64 gv4
+;; @00c1                               v7 = iadd v6, v5
+;; @00c1                               store little heap v4, v7
 ;; @00c5                               jump block1
 ;;
 ;;                                 block1:
@@ -342,16 +324,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @00c7                               v3 = global_value.i64 gv3
-;; @00c7                               v4 = load.i64 notrap aligned v3+8
-;; @00c8                               v5 = iconst.i32 0
-;; @00ce                               v6 = bitcast.i16x8 little v2
-;; @00ce                               v7 = bitcast.i16x8 little v2
-;; @00ce                               v8 = icmp slt v6, v7
-;; @00d0                               v9 = uextend.i64 v5  ; v5 = 0
-;; @00d0                               v10 = global_value.i64 gv4
-;; @00d0                               v11 = iadd v10, v9
-;; @00d0                               store little heap v8, v11
+;; @00c8                               v3 = iconst.i32 0
+;; @00ce                               v4 = bitcast.i16x8 little v2
+;; @00ce                               v5 = bitcast.i16x8 little v2
+;; @00ce                               v6 = icmp slt v4, v5
+;; @00d0                               v7 = uextend.i64 v3  ; v3 = 0
+;; @00d0                               v8 = global_value.i64 gv4
+;; @00d0                               v9 = iadd v8, v7
+;; @00d0                               store little heap v6, v9
 ;; @00d4                               jump block1
 ;;
 ;;                                 block1:
@@ -370,16 +350,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @00d6                               v3 = global_value.i64 gv3
-;; @00d6                               v4 = load.i64 notrap aligned v3+8
-;; @00d7                               v5 = iconst.i32 0
-;; @00dd                               v6 = bitcast.i32x4 little v2
-;; @00dd                               v7 = bitcast.i32x4 little v2
-;; @00dd                               v8 = icmp slt v6, v7
-;; @00df                               v9 = uextend.i64 v5  ; v5 = 0
-;; @00df                               v10 = global_value.i64 gv4
-;; @00df                               v11 = iadd v10, v9
-;; @00df                               store little heap v8, v11
+;; @00d7                               v3 = iconst.i32 0
+;; @00dd                               v4 = bitcast.i32x4 little v2
+;; @00dd                               v5 = bitcast.i32x4 little v2
+;; @00dd                               v6 = icmp slt v4, v5
+;; @00df                               v7 = uextend.i64 v3  ; v3 = 0
+;; @00df                               v8 = global_value.i64 gv4
+;; @00df                               v9 = iadd v8, v7
+;; @00df                               store little heap v6, v9
 ;; @00e3                               jump block1
 ;;
 ;;                                 block1:
@@ -398,16 +376,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @00e5                               v3 = global_value.i64 gv3
-;; @00e5                               v4 = load.i64 notrap aligned v3+8
-;; @00e6                               v5 = iconst.i32 0
-;; @00ec                               v6 = bitcast.i64x2 little v2
-;; @00ec                               v7 = bitcast.i64x2 little v2
-;; @00ec                               v8 = icmp slt v6, v7
-;; @00ef                               v9 = uextend.i64 v5  ; v5 = 0
-;; @00ef                               v10 = global_value.i64 gv4
-;; @00ef                               v11 = iadd v10, v9
-;; @00ef                               store little heap v8, v11
+;; @00e6                               v3 = iconst.i32 0
+;; @00ec                               v4 = bitcast.i64x2 little v2
+;; @00ec                               v5 = bitcast.i64x2 little v2
+;; @00ec                               v6 = icmp slt v4, v5
+;; @00ef                               v7 = uextend.i64 v3  ; v3 = 0
+;; @00ef                               v8 = global_value.i64 gv4
+;; @00ef                               v9 = iadd v8, v7
+;; @00ef                               store little heap v6, v9
 ;; @00f3                               jump block1
 ;;
 ;;                                 block1:
@@ -426,14 +402,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @00f5                               v3 = global_value.i64 gv3
-;; @00f5                               v4 = load.i64 notrap aligned v3+8
-;; @00f6                               v5 = iconst.i32 0
-;; @00fc                               v6 = icmp ult v2, v2
-;; @00fe                               v7 = uextend.i64 v5  ; v5 = 0
-;; @00fe                               v8 = global_value.i64 gv4
-;; @00fe                               v9 = iadd v8, v7
-;; @00fe                               store little heap v6, v9
+;; @00f6                               v3 = iconst.i32 0
+;; @00fc                               v4 = icmp ult v2, v2
+;; @00fe                               v5 = uextend.i64 v3  ; v3 = 0
+;; @00fe                               v6 = global_value.i64 gv4
+;; @00fe                               v7 = iadd v6, v5
+;; @00fe                               store little heap v4, v7
 ;; @0102                               jump block1
 ;;
 ;;                                 block1:
@@ -452,16 +426,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0104                               v3 = global_value.i64 gv3
-;; @0104                               v4 = load.i64 notrap aligned v3+8
-;; @0105                               v5 = iconst.i32 0
-;; @010b                               v6 = bitcast.i16x8 little v2
-;; @010b                               v7 = bitcast.i16x8 little v2
-;; @010b                               v8 = icmp ult v6, v7
-;; @010d                               v9 = uextend.i64 v5  ; v5 = 0
-;; @010d                               v10 = global_value.i64 gv4
-;; @010d                               v11 = iadd v10, v9
-;; @010d                               store little heap v8, v11
+;; @0105                               v3 = iconst.i32 0
+;; @010b                               v4 = bitcast.i16x8 little v2
+;; @010b                               v5 = bitcast.i16x8 little v2
+;; @010b                               v6 = icmp ult v4, v5
+;; @010d                               v7 = uextend.i64 v3  ; v3 = 0
+;; @010d                               v8 = global_value.i64 gv4
+;; @010d                               v9 = iadd v8, v7
+;; @010d                               store little heap v6, v9
 ;; @0111                               jump block1
 ;;
 ;;                                 block1:
@@ -480,16 +452,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0113                               v3 = global_value.i64 gv3
-;; @0113                               v4 = load.i64 notrap aligned v3+8
-;; @0114                               v5 = iconst.i32 0
-;; @011a                               v6 = bitcast.i32x4 little v2
-;; @011a                               v7 = bitcast.i32x4 little v2
-;; @011a                               v8 = icmp ult v6, v7
-;; @011c                               v9 = uextend.i64 v5  ; v5 = 0
-;; @011c                               v10 = global_value.i64 gv4
-;; @011c                               v11 = iadd v10, v9
-;; @011c                               store little heap v8, v11
+;; @0114                               v3 = iconst.i32 0
+;; @011a                               v4 = bitcast.i32x4 little v2
+;; @011a                               v5 = bitcast.i32x4 little v2
+;; @011a                               v6 = icmp ult v4, v5
+;; @011c                               v7 = uextend.i64 v3  ; v3 = 0
+;; @011c                               v8 = global_value.i64 gv4
+;; @011c                               v9 = iadd v8, v7
+;; @011c                               store little heap v6, v9
 ;; @0120                               jump block1
 ;;
 ;;                                 block1:
@@ -508,14 +478,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0122                               v3 = global_value.i64 gv3
-;; @0122                               v4 = load.i64 notrap aligned v3+8
-;; @0123                               v5 = iconst.i32 0
-;; @0129                               v6 = icmp sgt v2, v2
-;; @012b                               v7 = uextend.i64 v5  ; v5 = 0
-;; @012b                               v8 = global_value.i64 gv4
-;; @012b                               v9 = iadd v8, v7
-;; @012b                               store little heap v6, v9
+;; @0123                               v3 = iconst.i32 0
+;; @0129                               v4 = icmp sgt v2, v2
+;; @012b                               v5 = uextend.i64 v3  ; v3 = 0
+;; @012b                               v6 = global_value.i64 gv4
+;; @012b                               v7 = iadd v6, v5
+;; @012b                               store little heap v4, v7
 ;; @012f                               jump block1
 ;;
 ;;                                 block1:
@@ -534,16 +502,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0131                               v3 = global_value.i64 gv3
-;; @0131                               v4 = load.i64 notrap aligned v3+8
-;; @0132                               v5 = iconst.i32 0
-;; @0138                               v6 = bitcast.i16x8 little v2
-;; @0138                               v7 = bitcast.i16x8 little v2
-;; @0138                               v8 = icmp sgt v6, v7
-;; @013a                               v9 = uextend.i64 v5  ; v5 = 0
-;; @013a                               v10 = global_value.i64 gv4
-;; @013a                               v11 = iadd v10, v9
-;; @013a                               store little heap v8, v11
+;; @0132                               v3 = iconst.i32 0
+;; @0138                               v4 = bitcast.i16x8 little v2
+;; @0138                               v5 = bitcast.i16x8 little v2
+;; @0138                               v6 = icmp sgt v4, v5
+;; @013a                               v7 = uextend.i64 v3  ; v3 = 0
+;; @013a                               v8 = global_value.i64 gv4
+;; @013a                               v9 = iadd v8, v7
+;; @013a                               store little heap v6, v9
 ;; @013e                               jump block1
 ;;
 ;;                                 block1:
@@ -562,16 +528,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0140                               v3 = global_value.i64 gv3
-;; @0140                               v4 = load.i64 notrap aligned v3+8
-;; @0141                               v5 = iconst.i32 0
-;; @0147                               v6 = bitcast.i32x4 little v2
-;; @0147                               v7 = bitcast.i32x4 little v2
-;; @0147                               v8 = icmp sgt v6, v7
-;; @0149                               v9 = uextend.i64 v5  ; v5 = 0
-;; @0149                               v10 = global_value.i64 gv4
-;; @0149                               v11 = iadd v10, v9
-;; @0149                               store little heap v8, v11
+;; @0141                               v3 = iconst.i32 0
+;; @0147                               v4 = bitcast.i32x4 little v2
+;; @0147                               v5 = bitcast.i32x4 little v2
+;; @0147                               v6 = icmp sgt v4, v5
+;; @0149                               v7 = uextend.i64 v3  ; v3 = 0
+;; @0149                               v8 = global_value.i64 gv4
+;; @0149                               v9 = iadd v8, v7
+;; @0149                               store little heap v6, v9
 ;; @014d                               jump block1
 ;;
 ;;                                 block1:
@@ -590,16 +554,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @014f                               v3 = global_value.i64 gv3
-;; @014f                               v4 = load.i64 notrap aligned v3+8
-;; @0150                               v5 = iconst.i32 0
-;; @0156                               v6 = bitcast.i64x2 little v2
-;; @0156                               v7 = bitcast.i64x2 little v2
-;; @0156                               v8 = icmp sgt v6, v7
-;; @0159                               v9 = uextend.i64 v5  ; v5 = 0
-;; @0159                               v10 = global_value.i64 gv4
-;; @0159                               v11 = iadd v10, v9
-;; @0159                               store little heap v8, v11
+;; @0150                               v3 = iconst.i32 0
+;; @0156                               v4 = bitcast.i64x2 little v2
+;; @0156                               v5 = bitcast.i64x2 little v2
+;; @0156                               v6 = icmp sgt v4, v5
+;; @0159                               v7 = uextend.i64 v3  ; v3 = 0
+;; @0159                               v8 = global_value.i64 gv4
+;; @0159                               v9 = iadd v8, v7
+;; @0159                               store little heap v6, v9
 ;; @015d                               jump block1
 ;;
 ;;                                 block1:
@@ -618,14 +580,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @015f                               v3 = global_value.i64 gv3
-;; @015f                               v4 = load.i64 notrap aligned v3+8
-;; @0160                               v5 = iconst.i32 0
-;; @0166                               v6 = icmp ugt v2, v2
-;; @0168                               v7 = uextend.i64 v5  ; v5 = 0
-;; @0168                               v8 = global_value.i64 gv4
-;; @0168                               v9 = iadd v8, v7
-;; @0168                               store little heap v6, v9
+;; @0160                               v3 = iconst.i32 0
+;; @0166                               v4 = icmp ugt v2, v2
+;; @0168                               v5 = uextend.i64 v3  ; v3 = 0
+;; @0168                               v6 = global_value.i64 gv4
+;; @0168                               v7 = iadd v6, v5
+;; @0168                               store little heap v4, v7
 ;; @016c                               jump block1
 ;;
 ;;                                 block1:
@@ -644,16 +604,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @016e                               v3 = global_value.i64 gv3
-;; @016e                               v4 = load.i64 notrap aligned v3+8
-;; @016f                               v5 = iconst.i32 0
-;; @0175                               v6 = bitcast.i16x8 little v2
-;; @0175                               v7 = bitcast.i16x8 little v2
-;; @0175                               v8 = icmp ugt v6, v7
-;; @0177                               v9 = uextend.i64 v5  ; v5 = 0
-;; @0177                               v10 = global_value.i64 gv4
-;; @0177                               v11 = iadd v10, v9
-;; @0177                               store little heap v8, v11
+;; @016f                               v3 = iconst.i32 0
+;; @0175                               v4 = bitcast.i16x8 little v2
+;; @0175                               v5 = bitcast.i16x8 little v2
+;; @0175                               v6 = icmp ugt v4, v5
+;; @0177                               v7 = uextend.i64 v3  ; v3 = 0
+;; @0177                               v8 = global_value.i64 gv4
+;; @0177                               v9 = iadd v8, v7
+;; @0177                               store little heap v6, v9
 ;; @017b                               jump block1
 ;;
 ;;                                 block1:
@@ -672,16 +630,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @017d                               v3 = global_value.i64 gv3
-;; @017d                               v4 = load.i64 notrap aligned v3+8
-;; @017e                               v5 = iconst.i32 0
-;; @0184                               v6 = bitcast.i32x4 little v2
-;; @0184                               v7 = bitcast.i32x4 little v2
-;; @0184                               v8 = icmp ugt v6, v7
-;; @0186                               v9 = uextend.i64 v5  ; v5 = 0
-;; @0186                               v10 = global_value.i64 gv4
-;; @0186                               v11 = iadd v10, v9
-;; @0186                               store little heap v8, v11
+;; @017e                               v3 = iconst.i32 0
+;; @0184                               v4 = bitcast.i32x4 little v2
+;; @0184                               v5 = bitcast.i32x4 little v2
+;; @0184                               v6 = icmp ugt v4, v5
+;; @0186                               v7 = uextend.i64 v3  ; v3 = 0
+;; @0186                               v8 = global_value.i64 gv4
+;; @0186                               v9 = iadd v8, v7
+;; @0186                               store little heap v6, v9
 ;; @018a                               jump block1
 ;;
 ;;                                 block1:
@@ -700,16 +656,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @018c                               v3 = global_value.i64 gv3
-;; @018c                               v4 = load.i64 notrap aligned v3+8
-;; @018d                               v5 = iconst.i32 0
-;; @0193                               v6 = bitcast.f32x4 little v2
-;; @0193                               v7 = bitcast.f32x4 little v2
-;; @0193                               v8 = fcmp eq v6, v7
-;; @0195                               v9 = uextend.i64 v5  ; v5 = 0
-;; @0195                               v10 = global_value.i64 gv4
-;; @0195                               v11 = iadd v10, v9
-;; @0195                               store little heap v8, v11
+;; @018d                               v3 = iconst.i32 0
+;; @0193                               v4 = bitcast.f32x4 little v2
+;; @0193                               v5 = bitcast.f32x4 little v2
+;; @0193                               v6 = fcmp eq v4, v5
+;; @0195                               v7 = uextend.i64 v3  ; v3 = 0
+;; @0195                               v8 = global_value.i64 gv4
+;; @0195                               v9 = iadd v8, v7
+;; @0195                               store little heap v6, v9
 ;; @0199                               jump block1
 ;;
 ;;                                 block1:
@@ -728,16 +682,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @019b                               v3 = global_value.i64 gv3
-;; @019b                               v4 = load.i64 notrap aligned v3+8
-;; @019c                               v5 = iconst.i32 0
-;; @01a2                               v6 = bitcast.f64x2 little v2
-;; @01a2                               v7 = bitcast.f64x2 little v2
-;; @01a2                               v8 = fcmp eq v6, v7
-;; @01a4                               v9 = uextend.i64 v5  ; v5 = 0
-;; @01a4                               v10 = global_value.i64 gv4
-;; @01a4                               v11 = iadd v10, v9
-;; @01a4                               store little heap v8, v11
+;; @019c                               v3 = iconst.i32 0
+;; @01a2                               v4 = bitcast.f64x2 little v2
+;; @01a2                               v5 = bitcast.f64x2 little v2
+;; @01a2                               v6 = fcmp eq v4, v5
+;; @01a4                               v7 = uextend.i64 v3  ; v3 = 0
+;; @01a4                               v8 = global_value.i64 gv4
+;; @01a4                               v9 = iadd v8, v7
+;; @01a4                               store little heap v6, v9
 ;; @01a8                               jump block1
 ;;
 ;;                                 block1:
@@ -756,16 +708,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @01aa                               v3 = global_value.i64 gv3
-;; @01aa                               v4 = load.i64 notrap aligned v3+8
-;; @01ab                               v5 = iconst.i32 0
-;; @01b1                               v6 = bitcast.f32x4 little v2
-;; @01b1                               v7 = bitcast.f32x4 little v2
-;; @01b1                               v8 = fcmp ne v6, v7
-;; @01b3                               v9 = uextend.i64 v5  ; v5 = 0
-;; @01b3                               v10 = global_value.i64 gv4
-;; @01b3                               v11 = iadd v10, v9
-;; @01b3                               store little heap v8, v11
+;; @01ab                               v3 = iconst.i32 0
+;; @01b1                               v4 = bitcast.f32x4 little v2
+;; @01b1                               v5 = bitcast.f32x4 little v2
+;; @01b1                               v6 = fcmp ne v4, v5
+;; @01b3                               v7 = uextend.i64 v3  ; v3 = 0
+;; @01b3                               v8 = global_value.i64 gv4
+;; @01b3                               v9 = iadd v8, v7
+;; @01b3                               store little heap v6, v9
 ;; @01b7                               jump block1
 ;;
 ;;                                 block1:
@@ -784,16 +734,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @01b9                               v3 = global_value.i64 gv3
-;; @01b9                               v4 = load.i64 notrap aligned v3+8
-;; @01ba                               v5 = iconst.i32 0
-;; @01c0                               v6 = bitcast.f64x2 little v2
-;; @01c0                               v7 = bitcast.f64x2 little v2
-;; @01c0                               v8 = fcmp ne v6, v7
-;; @01c2                               v9 = uextend.i64 v5  ; v5 = 0
-;; @01c2                               v10 = global_value.i64 gv4
-;; @01c2                               v11 = iadd v10, v9
-;; @01c2                               store little heap v8, v11
+;; @01ba                               v3 = iconst.i32 0
+;; @01c0                               v4 = bitcast.f64x2 little v2
+;; @01c0                               v5 = bitcast.f64x2 little v2
+;; @01c0                               v6 = fcmp ne v4, v5
+;; @01c2                               v7 = uextend.i64 v3  ; v3 = 0
+;; @01c2                               v8 = global_value.i64 gv4
+;; @01c2                               v9 = iadd v8, v7
+;; @01c2                               store little heap v6, v9
 ;; @01c6                               jump block1
 ;;
 ;;                                 block1:
@@ -812,16 +760,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @01c8                               v3 = global_value.i64 gv3
-;; @01c8                               v4 = load.i64 notrap aligned v3+8
-;; @01c9                               v5 = iconst.i32 0
-;; @01cf                               v6 = bitcast.f32x4 little v2
-;; @01cf                               v7 = bitcast.f32x4 little v2
-;; @01cf                               v8 = fcmp lt v6, v7
-;; @01d1                               v9 = uextend.i64 v5  ; v5 = 0
-;; @01d1                               v10 = global_value.i64 gv4
-;; @01d1                               v11 = iadd v10, v9
-;; @01d1                               store little heap v8, v11
+;; @01c9                               v3 = iconst.i32 0
+;; @01cf                               v4 = bitcast.f32x4 little v2
+;; @01cf                               v5 = bitcast.f32x4 little v2
+;; @01cf                               v6 = fcmp lt v4, v5
+;; @01d1                               v7 = uextend.i64 v3  ; v3 = 0
+;; @01d1                               v8 = global_value.i64 gv4
+;; @01d1                               v9 = iadd v8, v7
+;; @01d1                               store little heap v6, v9
 ;; @01d5                               jump block1
 ;;
 ;;                                 block1:
@@ -840,16 +786,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @01d7                               v3 = global_value.i64 gv3
-;; @01d7                               v4 = load.i64 notrap aligned v3+8
-;; @01d8                               v5 = iconst.i32 0
-;; @01de                               v6 = bitcast.f64x2 little v2
-;; @01de                               v7 = bitcast.f64x2 little v2
-;; @01de                               v8 = fcmp lt v6, v7
-;; @01e0                               v9 = uextend.i64 v5  ; v5 = 0
-;; @01e0                               v10 = global_value.i64 gv4
-;; @01e0                               v11 = iadd v10, v9
-;; @01e0                               store little heap v8, v11
+;; @01d8                               v3 = iconst.i32 0
+;; @01de                               v4 = bitcast.f64x2 little v2
+;; @01de                               v5 = bitcast.f64x2 little v2
+;; @01de                               v6 = fcmp lt v4, v5
+;; @01e0                               v7 = uextend.i64 v3  ; v3 = 0
+;; @01e0                               v8 = global_value.i64 gv4
+;; @01e0                               v9 = iadd v8, v7
+;; @01e0                               store little heap v6, v9
 ;; @01e4                               jump block1
 ;;
 ;;                                 block1:
@@ -868,16 +812,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @01e6                               v3 = global_value.i64 gv3
-;; @01e6                               v4 = load.i64 notrap aligned v3+8
-;; @01e7                               v5 = iconst.i32 0
-;; @01ed                               v6 = bitcast.f32x4 little v2
-;; @01ed                               v7 = bitcast.f32x4 little v2
-;; @01ed                               v8 = fcmp le v6, v7
-;; @01ef                               v9 = uextend.i64 v5  ; v5 = 0
-;; @01ef                               v10 = global_value.i64 gv4
-;; @01ef                               v11 = iadd v10, v9
-;; @01ef                               store little heap v8, v11
+;; @01e7                               v3 = iconst.i32 0
+;; @01ed                               v4 = bitcast.f32x4 little v2
+;; @01ed                               v5 = bitcast.f32x4 little v2
+;; @01ed                               v6 = fcmp le v4, v5
+;; @01ef                               v7 = uextend.i64 v3  ; v3 = 0
+;; @01ef                               v8 = global_value.i64 gv4
+;; @01ef                               v9 = iadd v8, v7
+;; @01ef                               store little heap v6, v9
 ;; @01f3                               jump block1
 ;;
 ;;                                 block1:
@@ -896,16 +838,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @01f5                               v3 = global_value.i64 gv3
-;; @01f5                               v4 = load.i64 notrap aligned v3+8
-;; @01f6                               v5 = iconst.i32 0
-;; @01fc                               v6 = bitcast.f64x2 little v2
-;; @01fc                               v7 = bitcast.f64x2 little v2
-;; @01fc                               v8 = fcmp le v6, v7
-;; @01fe                               v9 = uextend.i64 v5  ; v5 = 0
-;; @01fe                               v10 = global_value.i64 gv4
-;; @01fe                               v11 = iadd v10, v9
-;; @01fe                               store little heap v8, v11
+;; @01f6                               v3 = iconst.i32 0
+;; @01fc                               v4 = bitcast.f64x2 little v2
+;; @01fc                               v5 = bitcast.f64x2 little v2
+;; @01fc                               v6 = fcmp le v4, v5
+;; @01fe                               v7 = uextend.i64 v3  ; v3 = 0
+;; @01fe                               v8 = global_value.i64 gv4
+;; @01fe                               v9 = iadd v8, v7
+;; @01fe                               store little heap v6, v9
 ;; @0202                               jump block1
 ;;
 ;;                                 block1:
@@ -924,16 +864,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0204                               v3 = global_value.i64 gv3
-;; @0204                               v4 = load.i64 notrap aligned v3+8
-;; @0205                               v5 = iconst.i32 0
-;; @020b                               v6 = bitcast.f32x4 little v2
-;; @020b                               v7 = bitcast.f32x4 little v2
-;; @020b                               v8 = fcmp gt v6, v7
-;; @020d                               v9 = uextend.i64 v5  ; v5 = 0
-;; @020d                               v10 = global_value.i64 gv4
-;; @020d                               v11 = iadd v10, v9
-;; @020d                               store little heap v8, v11
+;; @0205                               v3 = iconst.i32 0
+;; @020b                               v4 = bitcast.f32x4 little v2
+;; @020b                               v5 = bitcast.f32x4 little v2
+;; @020b                               v6 = fcmp gt v4, v5
+;; @020d                               v7 = uextend.i64 v3  ; v3 = 0
+;; @020d                               v8 = global_value.i64 gv4
+;; @020d                               v9 = iadd v8, v7
+;; @020d                               store little heap v6, v9
 ;; @0211                               jump block1
 ;;
 ;;                                 block1:
@@ -952,16 +890,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0213                               v3 = global_value.i64 gv3
-;; @0213                               v4 = load.i64 notrap aligned v3+8
-;; @0214                               v5 = iconst.i32 0
-;; @021a                               v6 = bitcast.f64x2 little v2
-;; @021a                               v7 = bitcast.f64x2 little v2
-;; @021a                               v8 = fcmp gt v6, v7
-;; @021c                               v9 = uextend.i64 v5  ; v5 = 0
-;; @021c                               v10 = global_value.i64 gv4
-;; @021c                               v11 = iadd v10, v9
-;; @021c                               store little heap v8, v11
+;; @0214                               v3 = iconst.i32 0
+;; @021a                               v4 = bitcast.f64x2 little v2
+;; @021a                               v5 = bitcast.f64x2 little v2
+;; @021a                               v6 = fcmp gt v4, v5
+;; @021c                               v7 = uextend.i64 v3  ; v3 = 0
+;; @021c                               v8 = global_value.i64 gv4
+;; @021c                               v9 = iadd v8, v7
+;; @021c                               store little heap v6, v9
 ;; @0220                               jump block1
 ;;
 ;;                                 block1:
@@ -980,16 +916,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0222                               v3 = global_value.i64 gv3
-;; @0222                               v4 = load.i64 notrap aligned v3+8
-;; @0223                               v5 = iconst.i32 0
-;; @0229                               v6 = bitcast.f32x4 little v2
-;; @0229                               v7 = bitcast.f32x4 little v2
-;; @0229                               v8 = fcmp ge v6, v7
-;; @022b                               v9 = uextend.i64 v5  ; v5 = 0
-;; @022b                               v10 = global_value.i64 gv4
-;; @022b                               v11 = iadd v10, v9
-;; @022b                               store little heap v8, v11
+;; @0223                               v3 = iconst.i32 0
+;; @0229                               v4 = bitcast.f32x4 little v2
+;; @0229                               v5 = bitcast.f32x4 little v2
+;; @0229                               v6 = fcmp ge v4, v5
+;; @022b                               v7 = uextend.i64 v3  ; v3 = 0
+;; @022b                               v8 = global_value.i64 gv4
+;; @022b                               v9 = iadd v8, v7
+;; @022b                               store little heap v6, v9
 ;; @022f                               jump block1
 ;;
 ;;                                 block1:
@@ -1008,16 +942,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
-;; @0231                               v3 = global_value.i64 gv3
-;; @0231                               v4 = load.i64 notrap aligned v3+8
-;; @0232                               v5 = iconst.i32 0
-;; @0238                               v6 = bitcast.f64x2 little v2
-;; @0238                               v7 = bitcast.f64x2 little v2
-;; @0238                               v8 = fcmp ge v6, v7
-;; @023a                               v9 = uextend.i64 v5  ; v5 = 0
-;; @023a                               v10 = global_value.i64 gv4
-;; @023a                               v11 = iadd v10, v9
-;; @023a                               store little heap v8, v11
+;; @0232                               v3 = iconst.i32 0
+;; @0238                               v4 = bitcast.f64x2 little v2
+;; @0238                               v5 = bitcast.f64x2 little v2
+;; @0238                               v6 = fcmp ge v4, v5
+;; @023a                               v7 = uextend.i64 v3  ; v3 = 0
+;; @023a                               v8 = global_value.i64 gv4
+;; @023a                               v9 = iadd v8, v7
+;; @023a                               store little heap v6, v9
 ;; @023e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/simd.wat
+++ b/tests/disas/simd.wat
@@ -34,18 +34,15 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004d                               v3 = global_value.i64 gv3
-;; @004d                               v4 = load.i64 notrap aligned v3+8
-;; @004e                               v5 = iconst.i32 42
-;; @0050                               v6 = splat.i32x4 v5  ; v5 = 42
-;; @0052                               v7 = extractlane v6, 0
-;; @0055                               jump block1(v7)
+;; @004e                               v3 = iconst.i32 42
+;; @0050                               v4 = splat.i32x4 v3  ; v3 = 42
+;; @0052                               v5 = extractlane v4, 0
+;; @0055                               jump block1(v5)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0055                               return v2
@@ -55,21 +52,18 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0057                               v3 = global_value.i64 gv3
-;; @0057                               v4 = load.i64 notrap aligned v3+8
-;; @0058                               v5 = vconst.i8x16 const0
-;; @006a                               v6 = iconst.i32 99
-;; @006d                               v7 = bitcast.i32x4 little v5  ; v5 = const0
-;; @006d                               v8 = insertlane v7, v6, 1  ; v6 = 99
-;; @0070                               v9 = extractlane v8, 1
-;; @0073                               jump block1(v9)
+;; @0058                               v3 = vconst.i8x16 const0
+;; @006a                               v4 = iconst.i32 99
+;; @006d                               v5 = bitcast.i32x4 little v3  ; v3 = const0
+;; @006d                               v6 = insertlane v5, v4, 1  ; v4 = 99
+;; @0070                               v7 = extractlane v6, 1
+;; @0073                               jump block1(v7)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0073                               return v2
@@ -79,19 +73,16 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     const0 = 0x00000004000000030000000200000001
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0075                               v3 = global_value.i64 gv3
-;; @0075                               v4 = load.i64 notrap aligned v3+8
-;; @0076                               v5 = vconst.i8x16 const0
-;; @0088                               v6 = bitcast.i32x4 little v5  ; v5 = const0
-;; @0088                               v7 = extractlane v6, 3
-;; @008b                               jump block1(v7)
+;; @0076                               v3 = vconst.i8x16 const0
+;; @0088                               v4 = bitcast.i32x4 little v3  ; v3 = const0
+;; @0088                               v5 = extractlane v4, 3
+;; @008b                               jump block1(v5)
 ;;
 ;;                                 block1(v2: i32):
 ;; @008b                               return v2
@@ -101,7 +92,6 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     const0 = 0x00000000000000000000000000000000
@@ -110,10 +100,8 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @008e                               v2 = iconst.i32 0
 ;; @0090                               v3 = vconst.i8x16 const0
-;; @0090                               v4 = global_value.i64 gv3
-;; @0090                               v5 = load.i64 notrap aligned v4+8
-;; @0094                               v6 = splat.i32x4 v2  ; v2 = 0
-;; @0096                               v7 = bitcast.i8x16 little v6
+;; @0094                               v4 = splat.i32x4 v2  ; v2 = 0
+;; @0096                               v5 = bitcast.i8x16 little v4
 ;; @0098                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/simple.wat
+++ b/tests/disas/simple.wat
@@ -22,17 +22,14 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001e                               v4 = global_value.i64 gv3
-;; @001e                               v5 = load.i64 notrap aligned v4+8
-;; @0021                               v6 = iconst.i32 1
-;; @0023                               v7 = iadd v2, v6  ; v6 = 1
-;; @0024                               jump block1(v7)
+;; @0021                               v4 = iconst.i32 1
+;; @0023                               v5 = iadd v2, v4  ; v4 = 1
+;; @0024                               jump block1(v5)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0024                               return v3
@@ -42,34 +39,28 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0026                               v4 = global_value.i64 gv3
-;; @0026                               v5 = load.i64 notrap aligned v4+8
-;; @0029                               v6 = iconst.i32 1
-;; @002b                               v7 = iadd v2, v6  ; v6 = 1
-;; @002c                               return v7
+;; @0029                               v4 = iconst.i32 1
+;; @002b                               v5 = iadd v2, v4  ; v4 = 1
+;; @002c                               return v5
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 fast {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0030                               v3 = iconst.i32 0
-;; @0030                               v4 = global_value.i64 gv3
-;; @0030                               v5 = load.i64 notrap aligned v4+8
 ;; @0032                               jump block2(v3)  ; v3 = 0
 ;;
-;;                                 block2(v7: i32):
-;; @0036                               v8 = iconst.i32 1
-;; @0038                               v9 = iadd v7, v8  ; v8 = 1
-;; @003b                               jump block2(v9)
+;;                                 block2(v5: i32):
+;; @0036                               v6 = iconst.i32 1
+;; @0038                               v7 = iadd v5, v6  ; v6 = 1
+;; @003b                               jump block2(v7)
 ;; }

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -27,14 +27,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32):
-;; @0078                               v9 = global_value.i64 gv3
-;; @0078                               v10 = load.i64 notrap aligned v9+8
 ;; @007b                               jump block1(v5)
 ;;
 ;;                                 block1(v8: i32):
@@ -45,14 +42,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32):
-;; @007d                               v9 = global_value.i64 gv3
-;; @007d                               v10 = load.i64 notrap aligned v9+8
 ;; @0080                               jump block1(v6)
 ;;
 ;;                                 block1(v8: i32):
@@ -63,14 +57,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32):
-;; @0082                               v9 = global_value.i64 gv3
-;; @0082                               v10 = load.i64 notrap aligned v9+8
 ;; @0085                               jump block1(v7)
 ;;
 ;;                                 block1(v8: i32):
@@ -88,14 +79,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0087                               v7 = global_value.i64 gv3
-;; @0087                               v8 = load.i64 notrap aligned v7+8
-;; @0090                               v9 = iconst.i32 0
-;; @0090                               v10 = iconst.i32 1
-;; @0090                               v11 = global_value.i64 gv3
-;; @0090                               v12 = load.i64 notrap aligned readonly v11+56
-;; @0090                               v13 = load.i64 notrap aligned readonly v12+8
-;; @0090                               call_indirect sig0, v13(v11, v9, v10, v3, v4, v5)  ; v9 = 0, v10 = 1
+;; @0090                               v7 = iconst.i32 0
+;; @0090                               v8 = iconst.i32 1
+;; @0090                               v9 = global_value.i64 gv3
+;; @0090                               v10 = load.i64 notrap aligned readonly v9+56
+;; @0090                               v11 = load.i64 notrap aligned readonly v10+8
+;; @0090                               call_indirect sig0, v11(v9, v7, v8, v3, v4, v5)  ; v7 = 0, v8 = 1
 ;; @0094                               jump block1(v2)
 ;;
 ;;                                 block1(v6: i32):
@@ -113,14 +102,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0096                               v7 = global_value.i64 gv3
-;; @0096                               v8 = load.i64 notrap aligned v7+8
-;; @009f                               v9 = iconst.i32 1
-;; @009f                               v10 = iconst.i32 0
-;; @009f                               v11 = global_value.i64 gv3
-;; @009f                               v12 = load.i64 notrap aligned readonly v11+56
-;; @009f                               v13 = load.i64 notrap aligned readonly v12+8
-;; @009f                               call_indirect sig0, v13(v11, v9, v10, v3, v4, v5)  ; v9 = 1, v10 = 0
+;; @009f                               v7 = iconst.i32 1
+;; @009f                               v8 = iconst.i32 0
+;; @009f                               v9 = global_value.i64 gv3
+;; @009f                               v10 = load.i64 notrap aligned readonly v9+56
+;; @009f                               v11 = load.i64 notrap aligned readonly v10+8
+;; @009f                               call_indirect sig0, v11(v9, v7, v8, v3, v4, v5)  ; v7 = 1, v8 = 0
 ;; @00a3                               jump block1(v2)
 ;;
 ;;                                 block1(v6: i32):

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -27,48 +27,46 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v3 -> v0
-;;                                     v16 -> v0
-;;                                     v21 -> v0
-;;                                     v27 -> v0
-;; @0051                               v4 = load.i64 notrap aligned v3+8
-;; @0052                               v5 = iconst.i32 0
-;; @0054                               v6 = iconst.i32 7
-;; @0054                               v7 = icmp uge v5, v6  ; v5 = 0, v6 = 7
-;; @0054                               v8 = uextend.i64 v5  ; v5 = 0
-;; @0054                               v9 = load.i64 notrap aligned v27+72
-;;                                     v28 = iconst.i64 3
-;; @0054                               v10 = ishl v8, v28  ; v28 = 3
-;; @0054                               v11 = iadd v9, v10
-;; @0054                               v12 = iconst.i64 0
-;; @0054                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0054                               v14 = load.r64 table_oob aligned table v13
-;;                                     v2 -> v14
-;; @0054                               v15 = is_null v14
-;; @0054                               brif v15, block2, block3
+;;                                     v14 -> v0
+;;                                     v19 -> v0
+;;                                     v25 -> v0
+;; @0052                               v3 = iconst.i32 0
+;; @0054                               v4 = iconst.i32 7
+;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
+;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
+;; @0054                               v7 = load.i64 notrap aligned v25+72
+;;                                     v26 = iconst.i64 3
+;; @0054                               v8 = ishl v6, v26  ; v26 = 3
+;; @0054                               v9 = iadd v7, v8
+;; @0054                               v10 = iconst.i64 0
+;; @0054                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0054                               v12 = load.r64 table_oob aligned table v11
+;;                                     v2 -> v12
+;; @0054                               v13 = is_null v12
+;; @0054                               brif v13, block2, block3
 ;;
 ;;                                 block3:
-;; @0054                               v17 = load.i64 notrap aligned v16+32
-;; @0054                               v18 = load.i64 notrap aligned v17
-;; @0054                               v19 = load.i64 notrap aligned v17+8
-;; @0054                               v20 = icmp eq v18, v19
-;; @0054                               brif v20, block4, block5
+;; @0054                               v15 = load.i64 notrap aligned v14+32
+;; @0054                               v16 = load.i64 notrap aligned v15
+;; @0054                               v17 = load.i64 notrap aligned v15+8
+;; @0054                               v18 = icmp eq v16, v17
+;; @0054                               brif v18, block4, block5
 ;;
 ;;                                 block5:
-;; @0054                               v24 = load.i64 notrap aligned v14
-;;                                     v29 = iconst.i64 1
-;; @0054                               v25 = iadd v24, v29  ; v29 = 1
-;; @0054                               store notrap aligned v25, v14
-;; @0054                               store.r64 notrap aligned v14, v18
-;;                                     v30 = iconst.i64 8
-;; @0054                               v26 = iadd.i64 v18, v30  ; v30 = 8
-;; @0054                               store notrap aligned v26, v17
+;; @0054                               v22 = load.i64 notrap aligned v12
+;;                                     v27 = iconst.i64 1
+;; @0054                               v23 = iadd v22, v27  ; v27 = 1
+;; @0054                               store notrap aligned v23, v12
+;; @0054                               store.r64 notrap aligned v12, v16
+;;                                     v28 = iconst.i64 8
+;; @0054                               v24 = iadd.i64 v16, v28  ; v28 = 8
+;; @0054                               store notrap aligned v24, v15
 ;; @0054                               jump block2
 ;;
 ;;                                 block4:
-;; @0054                               v22 = load.i64 notrap aligned readonly v21+56
-;; @0054                               v23 = load.i64 notrap aligned readonly v22+400
-;; @0054                               call_indirect sig0, v23(v21, v14)
+;; @0054                               v20 = load.i64 notrap aligned readonly v19+56
+;; @0054                               v21 = load.i64 notrap aligned readonly v20+208
+;; @0054                               call_indirect sig0, v21(v19, v12)
 ;; @0054                               jump block2
 ;;
 ;;                                 block2:
@@ -90,47 +88,45 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v4 -> v0
-;;                                     v16 -> v0
-;;                                     v21 -> v0
-;;                                     v27 -> v0
-;; @0058                               v5 = load.i64 notrap aligned v4+8
-;; @005b                               v6 = iconst.i32 7
-;; @005b                               v7 = icmp uge v2, v6  ; v6 = 7
-;; @005b                               v8 = uextend.i64 v2
-;; @005b                               v9 = load.i64 notrap aligned v27+72
-;;                                     v28 = iconst.i64 3
-;; @005b                               v10 = ishl v8, v28  ; v28 = 3
-;; @005b                               v11 = iadd v9, v10
-;; @005b                               v12 = iconst.i64 0
-;; @005b                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @005b                               v14 = load.r64 table_oob aligned table v13
-;;                                     v3 -> v14
-;; @005b                               v15 = is_null v14
-;; @005b                               brif v15, block2, block3
+;;                                     v14 -> v0
+;;                                     v19 -> v0
+;;                                     v25 -> v0
+;; @005b                               v4 = iconst.i32 7
+;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
+;; @005b                               v6 = uextend.i64 v2
+;; @005b                               v7 = load.i64 notrap aligned v25+72
+;;                                     v26 = iconst.i64 3
+;; @005b                               v8 = ishl v6, v26  ; v26 = 3
+;; @005b                               v9 = iadd v7, v8
+;; @005b                               v10 = iconst.i64 0
+;; @005b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @005b                               v12 = load.r64 table_oob aligned table v11
+;;                                     v3 -> v12
+;; @005b                               v13 = is_null v12
+;; @005b                               brif v13, block2, block3
 ;;
 ;;                                 block3:
-;; @005b                               v17 = load.i64 notrap aligned v16+32
-;; @005b                               v18 = load.i64 notrap aligned v17
-;; @005b                               v19 = load.i64 notrap aligned v17+8
-;; @005b                               v20 = icmp eq v18, v19
-;; @005b                               brif v20, block4, block5
+;; @005b                               v15 = load.i64 notrap aligned v14+32
+;; @005b                               v16 = load.i64 notrap aligned v15
+;; @005b                               v17 = load.i64 notrap aligned v15+8
+;; @005b                               v18 = icmp eq v16, v17
+;; @005b                               brif v18, block4, block5
 ;;
 ;;                                 block5:
-;; @005b                               v24 = load.i64 notrap aligned v14
-;;                                     v29 = iconst.i64 1
-;; @005b                               v25 = iadd v24, v29  ; v29 = 1
-;; @005b                               store notrap aligned v25, v14
-;; @005b                               store.r64 notrap aligned v14, v18
-;;                                     v30 = iconst.i64 8
-;; @005b                               v26 = iadd.i64 v18, v30  ; v30 = 8
-;; @005b                               store notrap aligned v26, v17
+;; @005b                               v22 = load.i64 notrap aligned v12
+;;                                     v27 = iconst.i64 1
+;; @005b                               v23 = iadd v22, v27  ; v27 = 1
+;; @005b                               store notrap aligned v23, v12
+;; @005b                               store.r64 notrap aligned v12, v16
+;;                                     v28 = iconst.i64 8
+;; @005b                               v24 = iadd.i64 v16, v28  ; v28 = 8
+;; @005b                               store notrap aligned v24, v15
 ;; @005b                               jump block2
 ;;
 ;;                                 block4:
-;; @005b                               v22 = load.i64 notrap aligned readonly v21+56
-;; @005b                               v23 = load.i64 notrap aligned readonly v22+400
-;; @005b                               call_indirect sig0, v23(v21, v14)
+;; @005b                               v20 = load.i64 notrap aligned readonly v19+56
+;; @005b                               v21 = load.i64 notrap aligned readonly v20+208
+;; @005b                               call_indirect sig0, v21(v19, v12)
 ;; @005b                               jump block2
 ;;
 ;;                                 block2:

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -27,49 +27,47 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v3 -> v0
-;;                                     v16 -> v0
-;;                                     v21 -> v0
-;;                                     v27 -> v0
-;;                                     v28 -> v0
-;; @0050                               v4 = load.i64 notrap aligned v3+8
-;; @0051                               v5 = iconst.i32 0
-;; @0053                               v6 = load.i32 notrap aligned v27+80
-;; @0053                               v7 = icmp uge v5, v6  ; v5 = 0
-;; @0053                               v8 = uextend.i64 v5  ; v5 = 0
-;; @0053                               v9 = load.i64 notrap aligned v28+72
-;;                                     v29 = iconst.i64 3
-;; @0053                               v10 = ishl v8, v29  ; v29 = 3
-;; @0053                               v11 = iadd v9, v10
-;; @0053                               v12 = iconst.i64 0
-;; @0053                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0053                               v14 = load.r64 table_oob aligned table v13
-;;                                     v2 -> v14
-;; @0053                               v15 = is_null v14
-;; @0053                               brif v15, block2, block3
+;;                                     v14 -> v0
+;;                                     v19 -> v0
+;;                                     v25 -> v0
+;;                                     v26 -> v0
+;; @0051                               v3 = iconst.i32 0
+;; @0053                               v4 = load.i32 notrap aligned v25+80
+;; @0053                               v5 = icmp uge v3, v4  ; v3 = 0
+;; @0053                               v6 = uextend.i64 v3  ; v3 = 0
+;; @0053                               v7 = load.i64 notrap aligned v26+72
+;;                                     v27 = iconst.i64 3
+;; @0053                               v8 = ishl v6, v27  ; v27 = 3
+;; @0053                               v9 = iadd v7, v8
+;; @0053                               v10 = iconst.i64 0
+;; @0053                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0053                               v12 = load.r64 table_oob aligned table v11
+;;                                     v2 -> v12
+;; @0053                               v13 = is_null v12
+;; @0053                               brif v13, block2, block3
 ;;
 ;;                                 block3:
-;; @0053                               v17 = load.i64 notrap aligned v16+32
-;; @0053                               v18 = load.i64 notrap aligned v17
-;; @0053                               v19 = load.i64 notrap aligned v17+8
-;; @0053                               v20 = icmp eq v18, v19
-;; @0053                               brif v20, block4, block5
+;; @0053                               v15 = load.i64 notrap aligned v14+32
+;; @0053                               v16 = load.i64 notrap aligned v15
+;; @0053                               v17 = load.i64 notrap aligned v15+8
+;; @0053                               v18 = icmp eq v16, v17
+;; @0053                               brif v18, block4, block5
 ;;
 ;;                                 block5:
-;; @0053                               v24 = load.i64 notrap aligned v14
-;;                                     v30 = iconst.i64 1
-;; @0053                               v25 = iadd v24, v30  ; v30 = 1
-;; @0053                               store notrap aligned v25, v14
-;; @0053                               store.r64 notrap aligned v14, v18
-;;                                     v31 = iconst.i64 8
-;; @0053                               v26 = iadd.i64 v18, v31  ; v31 = 8
-;; @0053                               store notrap aligned v26, v17
+;; @0053                               v22 = load.i64 notrap aligned v12
+;;                                     v28 = iconst.i64 1
+;; @0053                               v23 = iadd v22, v28  ; v28 = 1
+;; @0053                               store notrap aligned v23, v12
+;; @0053                               store.r64 notrap aligned v12, v16
+;;                                     v29 = iconst.i64 8
+;; @0053                               v24 = iadd.i64 v16, v29  ; v29 = 8
+;; @0053                               store notrap aligned v24, v15
 ;; @0053                               jump block2
 ;;
 ;;                                 block4:
-;; @0053                               v22 = load.i64 notrap aligned readonly v21+56
-;; @0053                               v23 = load.i64 notrap aligned readonly v22+400
-;; @0053                               call_indirect sig0, v23(v21, v14)
+;; @0053                               v20 = load.i64 notrap aligned readonly v19+56
+;; @0053                               v21 = load.i64 notrap aligned readonly v20+208
+;; @0053                               call_indirect sig0, v21(v19, v12)
 ;; @0053                               jump block2
 ;;
 ;;                                 block2:
@@ -92,48 +90,46 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v4 -> v0
-;;                                     v16 -> v0
-;;                                     v21 -> v0
-;;                                     v27 -> v0
-;;                                     v28 -> v0
-;; @0057                               v5 = load.i64 notrap aligned v4+8
-;; @005a                               v6 = load.i32 notrap aligned v27+80
-;; @005a                               v7 = icmp uge v2, v6
-;; @005a                               v8 = uextend.i64 v2
-;; @005a                               v9 = load.i64 notrap aligned v28+72
-;;                                     v29 = iconst.i64 3
-;; @005a                               v10 = ishl v8, v29  ; v29 = 3
-;; @005a                               v11 = iadd v9, v10
-;; @005a                               v12 = iconst.i64 0
-;; @005a                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @005a                               v14 = load.r64 table_oob aligned table v13
-;;                                     v3 -> v14
-;; @005a                               v15 = is_null v14
-;; @005a                               brif v15, block2, block3
+;;                                     v14 -> v0
+;;                                     v19 -> v0
+;;                                     v25 -> v0
+;;                                     v26 -> v0
+;; @005a                               v4 = load.i32 notrap aligned v25+80
+;; @005a                               v5 = icmp uge v2, v4
+;; @005a                               v6 = uextend.i64 v2
+;; @005a                               v7 = load.i64 notrap aligned v26+72
+;;                                     v27 = iconst.i64 3
+;; @005a                               v8 = ishl v6, v27  ; v27 = 3
+;; @005a                               v9 = iadd v7, v8
+;; @005a                               v10 = iconst.i64 0
+;; @005a                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @005a                               v12 = load.r64 table_oob aligned table v11
+;;                                     v3 -> v12
+;; @005a                               v13 = is_null v12
+;; @005a                               brif v13, block2, block3
 ;;
 ;;                                 block3:
-;; @005a                               v17 = load.i64 notrap aligned v16+32
-;; @005a                               v18 = load.i64 notrap aligned v17
-;; @005a                               v19 = load.i64 notrap aligned v17+8
-;; @005a                               v20 = icmp eq v18, v19
-;; @005a                               brif v20, block4, block5
+;; @005a                               v15 = load.i64 notrap aligned v14+32
+;; @005a                               v16 = load.i64 notrap aligned v15
+;; @005a                               v17 = load.i64 notrap aligned v15+8
+;; @005a                               v18 = icmp eq v16, v17
+;; @005a                               brif v18, block4, block5
 ;;
 ;;                                 block5:
-;; @005a                               v24 = load.i64 notrap aligned v14
-;;                                     v30 = iconst.i64 1
-;; @005a                               v25 = iadd v24, v30  ; v30 = 1
-;; @005a                               store notrap aligned v25, v14
-;; @005a                               store.r64 notrap aligned v14, v18
-;;                                     v31 = iconst.i64 8
-;; @005a                               v26 = iadd.i64 v18, v31  ; v31 = 8
-;; @005a                               store notrap aligned v26, v17
+;; @005a                               v22 = load.i64 notrap aligned v12
+;;                                     v28 = iconst.i64 1
+;; @005a                               v23 = iadd v22, v28  ; v28 = 1
+;; @005a                               store notrap aligned v23, v12
+;; @005a                               store.r64 notrap aligned v12, v16
+;;                                     v29 = iconst.i64 8
+;; @005a                               v24 = iadd.i64 v16, v29  ; v29 = 8
+;; @005a                               store notrap aligned v24, v15
 ;; @005a                               jump block2
 ;;
 ;;                                 block4:
-;; @005a                               v22 = load.i64 notrap aligned readonly v21+56
-;; @005a                               v23 = load.i64 notrap aligned readonly v22+400
-;; @005a                               call_indirect sig0, v23(v21, v14)
+;; @005a                               v20 = load.i64 notrap aligned readonly v19+56
+;; @005a                               v21 = load.i64 notrap aligned readonly v20+208
+;; @005a                               call_indirect sig0, v21(v19, v12)
 ;; @005a                               jump block2
 ;;
 ;;                                 block2:

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -29,50 +29,48 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: r64):
-;;                                     v3 -> v0
-;;                                     v22 -> v0
-;;                                     v25 -> v0
-;; @0051                               v4 = load.i64 notrap aligned v3+8
-;; @0052                               v5 = iconst.i32 0
-;; @0056                               v6 = iconst.i32 7
-;; @0056                               v7 = icmp uge v5, v6  ; v5 = 0, v6 = 7
-;; @0056                               v8 = uextend.i64 v5  ; v5 = 0
-;; @0056                               v9 = load.i64 notrap aligned v25+72
-;;                                     v26 = iconst.i64 3
-;; @0056                               v10 = ishl v8, v26  ; v26 = 3
-;; @0056                               v11 = iadd v9, v10
-;; @0056                               v12 = iconst.i64 0
-;; @0056                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0056                               v14 = load.i64 table_oob aligned table v13
-;; @0056                               store notrap aligned table v2, v13
-;; @0056                               v15 = is_null v2
-;; @0056                               brif v15, block3, block2
+;;                                     v20 -> v0
+;;                                     v23 -> v0
+;; @0052                               v3 = iconst.i32 0
+;; @0056                               v4 = iconst.i32 7
+;; @0056                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
+;; @0056                               v6 = uextend.i64 v3  ; v3 = 0
+;; @0056                               v7 = load.i64 notrap aligned v23+72
+;;                                     v24 = iconst.i64 3
+;; @0056                               v8 = ishl v6, v24  ; v24 = 3
+;; @0056                               v9 = iadd v7, v8
+;; @0056                               v10 = iconst.i64 0
+;; @0056                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0056                               v12 = load.i64 table_oob aligned table v11
+;; @0056                               store notrap aligned table v2, v11
+;; @0056                               v13 = is_null v2
+;; @0056                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @0056                               v16 = load.i64 notrap aligned v2
-;;                                     v27 = iconst.i64 1
-;; @0056                               v17 = iadd v16, v27  ; v27 = 1
-;; @0056                               store notrap aligned v17, v2
+;; @0056                               v14 = load.i64 notrap aligned v2
+;;                                     v25 = iconst.i64 1
+;; @0056                               v15 = iadd v14, v25  ; v25 = 1
+;; @0056                               store notrap aligned v15, v2
 ;; @0056                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v28 = iconst.i64 0
-;; @0056                               v18 = icmp.i64 eq v14, v28  ; v28 = 0
-;; @0056                               brif v18, block6, block4
+;;                                     v26 = iconst.i64 0
+;; @0056                               v16 = icmp.i64 eq v12, v26  ; v26 = 0
+;; @0056                               brif v16, block6, block4
 ;;
 ;;                                 block4:
-;; @0056                               v19 = load.i64 notrap aligned v14
-;;                                     v29 = iconst.i64 -1
-;; @0056                               v20 = iadd v19, v29  ; v29 = -1
-;; @0056                               store notrap aligned v20, v14
-;;                                     v30 = iconst.i64 0
-;; @0056                               v21 = icmp eq v20, v30  ; v30 = 0
-;; @0056                               brif v21, block5, block6
+;; @0056                               v17 = load.i64 notrap aligned v12
+;;                                     v27 = iconst.i64 -1
+;; @0056                               v18 = iadd v17, v27  ; v27 = -1
+;; @0056                               store notrap aligned v18, v12
+;;                                     v28 = iconst.i64 0
+;; @0056                               v19 = icmp eq v18, v28  ; v28 = 0
+;; @0056                               brif v19, block5, block6
 ;;
 ;;                                 block5:
-;; @0056                               v23 = load.i64 notrap aligned readonly v22+56
-;; @0056                               v24 = load.i64 notrap aligned readonly v23+392
-;; @0056                               call_indirect sig0, v24(v22, v14)
+;; @0056                               v21 = load.i64 notrap aligned readonly v20+56
+;; @0056                               v22 = load.i64 notrap aligned readonly v21+200
+;; @0056                               call_indirect sig0, v22(v20, v12)
 ;; @0056                               jump block6
 ;;
 ;;                                 block6:
@@ -94,49 +92,47 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: r64):
-;;                                     v4 -> v0
-;;                                     v22 -> v0
-;;                                     v25 -> v0
-;; @005a                               v5 = load.i64 notrap aligned v4+8
-;; @005f                               v6 = iconst.i32 7
-;; @005f                               v7 = icmp uge v2, v6  ; v6 = 7
-;; @005f                               v8 = uextend.i64 v2
-;; @005f                               v9 = load.i64 notrap aligned v25+72
-;;                                     v26 = iconst.i64 3
-;; @005f                               v10 = ishl v8, v26  ; v26 = 3
-;; @005f                               v11 = iadd v9, v10
-;; @005f                               v12 = iconst.i64 0
-;; @005f                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @005f                               v14 = load.i64 table_oob aligned table v13
-;; @005f                               store notrap aligned table v3, v13
-;; @005f                               v15 = is_null v3
-;; @005f                               brif v15, block3, block2
+;;                                     v20 -> v0
+;;                                     v23 -> v0
+;; @005f                               v4 = iconst.i32 7
+;; @005f                               v5 = icmp uge v2, v4  ; v4 = 7
+;; @005f                               v6 = uextend.i64 v2
+;; @005f                               v7 = load.i64 notrap aligned v23+72
+;;                                     v24 = iconst.i64 3
+;; @005f                               v8 = ishl v6, v24  ; v24 = 3
+;; @005f                               v9 = iadd v7, v8
+;; @005f                               v10 = iconst.i64 0
+;; @005f                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @005f                               v12 = load.i64 table_oob aligned table v11
+;; @005f                               store notrap aligned table v3, v11
+;; @005f                               v13 = is_null v3
+;; @005f                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @005f                               v16 = load.i64 notrap aligned v3
-;;                                     v27 = iconst.i64 1
-;; @005f                               v17 = iadd v16, v27  ; v27 = 1
-;; @005f                               store notrap aligned v17, v3
+;; @005f                               v14 = load.i64 notrap aligned v3
+;;                                     v25 = iconst.i64 1
+;; @005f                               v15 = iadd v14, v25  ; v25 = 1
+;; @005f                               store notrap aligned v15, v3
 ;; @005f                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v28 = iconst.i64 0
-;; @005f                               v18 = icmp.i64 eq v14, v28  ; v28 = 0
-;; @005f                               brif v18, block6, block4
+;;                                     v26 = iconst.i64 0
+;; @005f                               v16 = icmp.i64 eq v12, v26  ; v26 = 0
+;; @005f                               brif v16, block6, block4
 ;;
 ;;                                 block4:
-;; @005f                               v19 = load.i64 notrap aligned v14
-;;                                     v29 = iconst.i64 -1
-;; @005f                               v20 = iadd v19, v29  ; v29 = -1
-;; @005f                               store notrap aligned v20, v14
-;;                                     v30 = iconst.i64 0
-;; @005f                               v21 = icmp eq v20, v30  ; v30 = 0
-;; @005f                               brif v21, block5, block6
+;; @005f                               v17 = load.i64 notrap aligned v12
+;;                                     v27 = iconst.i64 -1
+;; @005f                               v18 = iadd v17, v27  ; v27 = -1
+;; @005f                               store notrap aligned v18, v12
+;;                                     v28 = iconst.i64 0
+;; @005f                               v19 = icmp eq v18, v28  ; v28 = 0
+;; @005f                               brif v19, block5, block6
 ;;
 ;;                                 block5:
-;; @005f                               v23 = load.i64 notrap aligned readonly v22+56
-;; @005f                               v24 = load.i64 notrap aligned readonly v23+392
-;; @005f                               call_indirect sig0, v24(v22, v14)
+;; @005f                               v21 = load.i64 notrap aligned readonly v20+56
+;; @005f                               v22 = load.i64 notrap aligned readonly v21+200
+;; @005f                               call_indirect sig0, v22(v20, v12)
 ;; @005f                               jump block6
 ;;
 ;;                                 block6:

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -29,51 +29,49 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: r64):
-;;                                     v3 -> v0
-;;                                     v22 -> v0
-;;                                     v25 -> v0
-;;                                     v26 -> v0
-;; @0050                               v4 = load.i64 notrap aligned v3+8
-;; @0051                               v5 = iconst.i32 0
-;; @0055                               v6 = load.i32 notrap aligned v25+80
-;; @0055                               v7 = icmp uge v5, v6  ; v5 = 0
-;; @0055                               v8 = uextend.i64 v5  ; v5 = 0
-;; @0055                               v9 = load.i64 notrap aligned v26+72
-;;                                     v27 = iconst.i64 3
-;; @0055                               v10 = ishl v8, v27  ; v27 = 3
-;; @0055                               v11 = iadd v9, v10
-;; @0055                               v12 = iconst.i64 0
-;; @0055                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @0055                               v14 = load.i64 table_oob aligned table v13
-;; @0055                               store notrap aligned table v2, v13
-;; @0055                               v15 = is_null v2
-;; @0055                               brif v15, block3, block2
+;;                                     v20 -> v0
+;;                                     v23 -> v0
+;;                                     v24 -> v0
+;; @0051                               v3 = iconst.i32 0
+;; @0055                               v4 = load.i32 notrap aligned v23+80
+;; @0055                               v5 = icmp uge v3, v4  ; v3 = 0
+;; @0055                               v6 = uextend.i64 v3  ; v3 = 0
+;; @0055                               v7 = load.i64 notrap aligned v24+72
+;;                                     v25 = iconst.i64 3
+;; @0055                               v8 = ishl v6, v25  ; v25 = 3
+;; @0055                               v9 = iadd v7, v8
+;; @0055                               v10 = iconst.i64 0
+;; @0055                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0055                               v12 = load.i64 table_oob aligned table v11
+;; @0055                               store notrap aligned table v2, v11
+;; @0055                               v13 = is_null v2
+;; @0055                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @0055                               v16 = load.i64 notrap aligned v2
-;;                                     v28 = iconst.i64 1
-;; @0055                               v17 = iadd v16, v28  ; v28 = 1
-;; @0055                               store notrap aligned v17, v2
+;; @0055                               v14 = load.i64 notrap aligned v2
+;;                                     v26 = iconst.i64 1
+;; @0055                               v15 = iadd v14, v26  ; v26 = 1
+;; @0055                               store notrap aligned v15, v2
 ;; @0055                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v29 = iconst.i64 0
-;; @0055                               v18 = icmp.i64 eq v14, v29  ; v29 = 0
-;; @0055                               brif v18, block6, block4
+;;                                     v27 = iconst.i64 0
+;; @0055                               v16 = icmp.i64 eq v12, v27  ; v27 = 0
+;; @0055                               brif v16, block6, block4
 ;;
 ;;                                 block4:
-;; @0055                               v19 = load.i64 notrap aligned v14
-;;                                     v30 = iconst.i64 -1
-;; @0055                               v20 = iadd v19, v30  ; v30 = -1
-;; @0055                               store notrap aligned v20, v14
-;;                                     v31 = iconst.i64 0
-;; @0055                               v21 = icmp eq v20, v31  ; v31 = 0
-;; @0055                               brif v21, block5, block6
+;; @0055                               v17 = load.i64 notrap aligned v12
+;;                                     v28 = iconst.i64 -1
+;; @0055                               v18 = iadd v17, v28  ; v28 = -1
+;; @0055                               store notrap aligned v18, v12
+;;                                     v29 = iconst.i64 0
+;; @0055                               v19 = icmp eq v18, v29  ; v29 = 0
+;; @0055                               brif v19, block5, block6
 ;;
 ;;                                 block5:
-;; @0055                               v23 = load.i64 notrap aligned readonly v22+56
-;; @0055                               v24 = load.i64 notrap aligned readonly v23+392
-;; @0055                               call_indirect sig0, v24(v22, v14)
+;; @0055                               v21 = load.i64 notrap aligned readonly v20+56
+;; @0055                               v22 = load.i64 notrap aligned readonly v21+200
+;; @0055                               call_indirect sig0, v22(v20, v12)
 ;; @0055                               jump block6
 ;;
 ;;                                 block6:
@@ -96,50 +94,48 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: r64):
-;;                                     v4 -> v0
-;;                                     v22 -> v0
-;;                                     v25 -> v0
-;;                                     v26 -> v0
-;; @0059                               v5 = load.i64 notrap aligned v4+8
-;; @005e                               v6 = load.i32 notrap aligned v25+80
-;; @005e                               v7 = icmp uge v2, v6
-;; @005e                               v8 = uextend.i64 v2
-;; @005e                               v9 = load.i64 notrap aligned v26+72
-;;                                     v27 = iconst.i64 3
-;; @005e                               v10 = ishl v8, v27  ; v27 = 3
-;; @005e                               v11 = iadd v9, v10
-;; @005e                               v12 = iconst.i64 0
-;; @005e                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
-;; @005e                               v14 = load.i64 table_oob aligned table v13
-;; @005e                               store notrap aligned table v3, v13
-;; @005e                               v15 = is_null v3
-;; @005e                               brif v15, block3, block2
+;;                                     v20 -> v0
+;;                                     v23 -> v0
+;;                                     v24 -> v0
+;; @005e                               v4 = load.i32 notrap aligned v23+80
+;; @005e                               v5 = icmp uge v2, v4
+;; @005e                               v6 = uextend.i64 v2
+;; @005e                               v7 = load.i64 notrap aligned v24+72
+;;                                     v25 = iconst.i64 3
+;; @005e                               v8 = ishl v6, v25  ; v25 = 3
+;; @005e                               v9 = iadd v7, v8
+;; @005e                               v10 = iconst.i64 0
+;; @005e                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @005e                               v12 = load.i64 table_oob aligned table v11
+;; @005e                               store notrap aligned table v3, v11
+;; @005e                               v13 = is_null v3
+;; @005e                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @005e                               v16 = load.i64 notrap aligned v3
-;;                                     v28 = iconst.i64 1
-;; @005e                               v17 = iadd v16, v28  ; v28 = 1
-;; @005e                               store notrap aligned v17, v3
+;; @005e                               v14 = load.i64 notrap aligned v3
+;;                                     v26 = iconst.i64 1
+;; @005e                               v15 = iadd v14, v26  ; v26 = 1
+;; @005e                               store notrap aligned v15, v3
 ;; @005e                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v29 = iconst.i64 0
-;; @005e                               v18 = icmp.i64 eq v14, v29  ; v29 = 0
-;; @005e                               brif v18, block6, block4
+;;                                     v27 = iconst.i64 0
+;; @005e                               v16 = icmp.i64 eq v12, v27  ; v27 = 0
+;; @005e                               brif v16, block6, block4
 ;;
 ;;                                 block4:
-;; @005e                               v19 = load.i64 notrap aligned v14
-;;                                     v30 = iconst.i64 -1
-;; @005e                               v20 = iadd v19, v30  ; v30 = -1
-;; @005e                               store notrap aligned v20, v14
-;;                                     v31 = iconst.i64 0
-;; @005e                               v21 = icmp eq v20, v31  ; v31 = 0
-;; @005e                               brif v21, block5, block6
+;; @005e                               v17 = load.i64 notrap aligned v12
+;;                                     v28 = iconst.i64 -1
+;; @005e                               v18 = iadd v17, v28  ; v28 = -1
+;; @005e                               store notrap aligned v18, v12
+;;                                     v29 = iconst.i64 0
+;; @005e                               v19 = icmp eq v18, v29  ; v29 = 0
+;; @005e                               brif v19, block5, block6
 ;;
 ;;                                 block5:
-;; @005e                               v23 = load.i64 notrap aligned readonly v22+56
-;; @005e                               v24 = load.i64 notrap aligned readonly v23+392
-;; @005e                               call_indirect sig0, v24(v22, v14)
+;; @005e                               v21 = load.i64 notrap aligned readonly v20+56
+;; @005e                               v22 = load.i64 notrap aligned readonly v21+200
+;; @005e                               call_indirect sig0, v22(v20, v12)
 ;; @005e                               jump block6
 ;;
 ;;                                 block6:

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -117,13 +117,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v7 -> v0
 ;;                                     v6 -> v2
 ;; @0039                               jump block1
 ;;
@@ -144,68 +142,67 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v8 -> v0
-;;                                     v23 -> v0
-;;                                     v49 -> v0
-;;                                     v58 -> v0
-;;                                     v61 -> v0
-;;                                     v32 -> v2
-;;                                     v33 -> v3
-;;                                     v34 -> v4
-;;                                     v35 -> v5
-;; @0048                               v14 = load.i64 notrap aligned v0+72
-;;                                     v64 = iconst.i8 0
-;; @0048                               v17 = iconst.i64 0
-;;                                     v72 = iconst.i64 8
-;; @0048                               v16 = iadd v14, v72  ; v72 = 8
-;; @0048                               v18 = select_spectre_guard v64, v17, v16  ; v64 = 0, v17 = 0
-;; @0048                               v19 = load.i64 table_oob aligned table v18
-;;                                     v60 = iconst.i64 -2
-;; @0048                               v20 = band v19, v60  ; v60 = -2
-;; @0048                               brif v19, block3(v20), block2
+;;                                     v21 -> v0
+;;                                     v47 -> v0
+;;                                     v56 -> v0
+;;                                     v59 -> v0
+;;                                     v30 -> v2
+;;                                     v31 -> v3
+;;                                     v32 -> v4
+;;                                     v33 -> v5
+;; @0048                               v12 = load.i64 notrap aligned v0+72
+;;                                     v62 = iconst.i8 0
+;; @0048                               v15 = iconst.i64 0
+;;                                     v70 = iconst.i64 8
+;; @0048                               v14 = iadd v12, v70  ; v70 = 8
+;; @0048                               v16 = select_spectre_guard v62, v15, v14  ; v62 = 0, v15 = 0
+;; @0048                               v17 = load.i64 table_oob aligned table v16
+;;                                     v58 = iconst.i64 -2
+;; @0048                               v18 = band v17, v58  ; v58 = -2
+;; @0048                               brif v17, block3(v18), block2
 ;;
 ;;                                 block2 cold:
-;; @005b                               v50 = load.i64 notrap aligned readonly v0+56
-;; @005b                               v51 = load.i64 notrap aligned readonly v50+72
+;; @005b                               v48 = load.i64 notrap aligned readonly v0+56
+;; @005b                               v49 = load.i64 notrap aligned readonly v48+72
 ;; @003c                               v7 = iconst.i32 0
-;;                                     v30 -> v7
-;; @0046                               v10 = iconst.i32 1
-;; @0048                               v26 = call_indirect sig0, v51(v0, v7, v10)  ; v7 = 0, v10 = 1
-;; @0048                               jump block3(v26)
+;;                                     v28 -> v7
+;; @0046                               v8 = iconst.i32 1
+;; @0048                               v24 = call_indirect sig0, v49(v0, v7, v8)  ; v7 = 0, v8 = 1
+;; @0048                               jump block3(v24)
 ;;
-;;                                 block3(v21: i64):
-;; @004a                               v27 = load.i64 null_reference aligned readonly v21+16
-;; @004a                               v28 = load.i64 notrap aligned readonly v21+32
-;; @004a                               v29 = call_indirect sig1, v27(v28, v0, v2, v3, v4, v5)
-;; @005b                               v40 = load.i64 notrap aligned v0+72
-;;                                     v81 = iconst.i8 0
-;;                                     v82 = iconst.i64 0
-;;                                     v80 = iconst.i64 16
-;; @005b                               v42 = iadd v40, v80  ; v80 = 16
-;; @005b                               v44 = select_spectre_guard v81, v82, v42  ; v81 = 0, v82 = 0
-;; @005b                               v45 = load.i64 table_oob aligned table v44
-;;                                     v83 = iconst.i64 -2
-;;                                     v84 = band v45, v83  ; v83 = -2
-;; @005b                               brif v45, block5(v84), block4
+;;                                 block3(v19: i64):
+;; @004a                               v25 = load.i64 null_reference aligned readonly v19+16
+;; @004a                               v26 = load.i64 notrap aligned readonly v19+32
+;; @004a                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
+;; @005b                               v38 = load.i64 notrap aligned v0+72
+;;                                     v79 = iconst.i8 0
+;;                                     v80 = iconst.i64 0
+;;                                     v78 = iconst.i64 16
+;; @005b                               v40 = iadd v38, v78  ; v78 = 16
+;; @005b                               v42 = select_spectre_guard v79, v80, v40  ; v79 = 0, v80 = 0
+;; @005b                               v43 = load.i64 table_oob aligned table v42
+;;                                     v81 = iconst.i64 -2
+;;                                     v82 = band v43, v81  ; v81 = -2
+;; @005b                               brif v43, block5(v82), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v85 = load.i64 notrap aligned readonly v0+56
-;;                                     v86 = load.i64 notrap aligned readonly v85+72
-;;                                     v87 = iconst.i32 0
-;; @0059                               v36 = iconst.i32 2
-;; @005b                               v52 = call_indirect sig0, v86(v0, v87, v36)  ; v87 = 0, v36 = 2
-;; @005b                               jump block5(v52)
+;;                                     v83 = load.i64 notrap aligned readonly v0+56
+;;                                     v84 = load.i64 notrap aligned readonly v83+72
+;;                                     v85 = iconst.i32 0
+;; @0059                               v34 = iconst.i32 2
+;; @005b                               v50 = call_indirect sig0, v84(v0, v85, v34)  ; v85 = 0, v34 = 2
+;; @005b                               jump block5(v50)
 ;;
-;;                                 block5(v47: i64):
-;; @005d                               v53 = load.i64 null_reference aligned readonly v47+16
-;; @005d                               v54 = load.i64 notrap aligned readonly v47+32
-;; @005d                               v55 = call_indirect sig1, v53(v54, v0, v2, v3, v4, v5)
+;;                                 block5(v45: i64):
+;; @005d                               v51 = load.i64 null_reference aligned readonly v45+16
+;; @005d                               v52 = load.i64 notrap aligned readonly v45+32
+;; @005d                               v53 = call_indirect sig1, v51(v52, v0, v2, v3, v4, v5)
 ;; @0066                               jump block1
 ;;
 ;;                                 block1:
-;; @0061                               v57 = iadd.i32 v55, v29
-;;                                     v6 -> v57
-;; @0066                               return v57
+;; @0061                               v55 = iadd.i32 v53, v27
+;;                                     v6 -> v55
+;; @0066                               return v55
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
@@ -221,68 +218,67 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v8 -> v0
-;;                                     v23 -> v0
-;;                                     v49 -> v0
-;;                                     v58 -> v0
-;;                                     v61 -> v0
-;;                                     v32 -> v2
-;;                                     v33 -> v3
-;;                                     v34 -> v4
-;;                                     v35 -> v5
-;; @0075                               v14 = load.i64 notrap aligned v0+72
-;;                                     v64 = iconst.i8 0
-;; @0075                               v17 = iconst.i64 0
-;;                                     v72 = iconst.i64 8
-;; @0075                               v16 = iadd v14, v72  ; v72 = 8
-;; @0075                               v18 = select_spectre_guard v64, v17, v16  ; v64 = 0, v17 = 0
-;; @0075                               v19 = load.i64 table_oob aligned table v18
-;;                                     v60 = iconst.i64 -2
-;; @0075                               v20 = band v19, v60  ; v60 = -2
-;; @0075                               brif v19, block3(v20), block2
+;;                                     v21 -> v0
+;;                                     v47 -> v0
+;;                                     v56 -> v0
+;;                                     v59 -> v0
+;;                                     v30 -> v2
+;;                                     v31 -> v3
+;;                                     v32 -> v4
+;;                                     v33 -> v5
+;; @0075                               v12 = load.i64 notrap aligned v0+72
+;;                                     v62 = iconst.i8 0
+;; @0075                               v15 = iconst.i64 0
+;;                                     v70 = iconst.i64 8
+;; @0075                               v14 = iadd v12, v70  ; v70 = 8
+;; @0075                               v16 = select_spectre_guard v62, v15, v14  ; v62 = 0, v15 = 0
+;; @0075                               v17 = load.i64 table_oob aligned table v16
+;;                                     v58 = iconst.i64 -2
+;; @0075                               v18 = band v17, v58  ; v58 = -2
+;; @0075                               brif v17, block3(v18), block2
 ;;
 ;;                                 block2 cold:
-;; @0087                               v50 = load.i64 notrap aligned readonly v0+56
-;; @0087                               v51 = load.i64 notrap aligned readonly v50+72
+;; @0087                               v48 = load.i64 notrap aligned readonly v0+56
+;; @0087                               v49 = load.i64 notrap aligned readonly v48+72
 ;; @0069                               v7 = iconst.i32 0
-;;                                     v30 -> v7
-;; @0073                               v10 = iconst.i32 1
-;; @0075                               v26 = call_indirect sig1, v51(v0, v7, v10)  ; v7 = 0, v10 = 1
-;; @0075                               jump block3(v26)
+;;                                     v28 -> v7
+;; @0073                               v8 = iconst.i32 1
+;; @0075                               v24 = call_indirect sig1, v49(v0, v7, v8)  ; v7 = 0, v8 = 1
+;; @0075                               jump block3(v24)
 ;;
-;;                                 block3(v21: i64):
-;; @0075                               v27 = load.i64 icall_null aligned readonly v21+16
-;; @0075                               v28 = load.i64 notrap aligned readonly v21+32
-;; @0075                               v29 = call_indirect sig0, v27(v28, v0, v2, v3, v4, v5)
-;; @0087                               v40 = load.i64 notrap aligned v0+72
-;;                                     v81 = iconst.i8 0
-;;                                     v82 = iconst.i64 0
-;;                                     v80 = iconst.i64 16
-;; @0087                               v42 = iadd v40, v80  ; v80 = 16
-;; @0087                               v44 = select_spectre_guard v81, v82, v42  ; v81 = 0, v82 = 0
-;; @0087                               v45 = load.i64 table_oob aligned table v44
-;;                                     v83 = iconst.i64 -2
-;;                                     v84 = band v45, v83  ; v83 = -2
-;; @0087                               brif v45, block5(v84), block4
+;;                                 block3(v19: i64):
+;; @0075                               v25 = load.i64 icall_null aligned readonly v19+16
+;; @0075                               v26 = load.i64 notrap aligned readonly v19+32
+;; @0075                               v27 = call_indirect sig0, v25(v26, v0, v2, v3, v4, v5)
+;; @0087                               v38 = load.i64 notrap aligned v0+72
+;;                                     v79 = iconst.i8 0
+;;                                     v80 = iconst.i64 0
+;;                                     v78 = iconst.i64 16
+;; @0087                               v40 = iadd v38, v78  ; v78 = 16
+;; @0087                               v42 = select_spectre_guard v79, v80, v40  ; v79 = 0, v80 = 0
+;; @0087                               v43 = load.i64 table_oob aligned table v42
+;;                                     v81 = iconst.i64 -2
+;;                                     v82 = band v43, v81  ; v81 = -2
+;; @0087                               brif v43, block5(v82), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v85 = load.i64 notrap aligned readonly v0+56
-;;                                     v86 = load.i64 notrap aligned readonly v85+72
-;;                                     v87 = iconst.i32 0
-;; @0085                               v36 = iconst.i32 2
-;; @0087                               v52 = call_indirect sig1, v86(v0, v87, v36)  ; v87 = 0, v36 = 2
-;; @0087                               jump block5(v52)
+;;                                     v83 = load.i64 notrap aligned readonly v0+56
+;;                                     v84 = load.i64 notrap aligned readonly v83+72
+;;                                     v85 = iconst.i32 0
+;; @0085                               v34 = iconst.i32 2
+;; @0087                               v50 = call_indirect sig1, v84(v0, v85, v34)  ; v85 = 0, v34 = 2
+;; @0087                               jump block5(v50)
 ;;
-;;                                 block5(v47: i64):
-;; @0087                               v53 = load.i64 icall_null aligned readonly v47+16
-;; @0087                               v54 = load.i64 notrap aligned readonly v47+32
-;; @0087                               v55 = call_indirect sig0, v53(v54, v0, v2, v3, v4, v5)
+;;                                 block5(v45: i64):
+;; @0087                               v51 = load.i64 icall_null aligned readonly v45+16
+;; @0087                               v52 = load.i64 notrap aligned readonly v45+32
+;; @0087                               v53 = call_indirect sig0, v51(v52, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
 ;;                                 block1:
-;; @008c                               v57 = iadd.i32 v55, v29
-;;                                     v6 -> v57
-;; @0091                               return v57
+;; @008c                               v55 = iadd.i32 v53, v27
+;;                                     v6 -> v55
+;; @0091                               return v55
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
@@ -297,20 +293,19 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;;                                     v8 -> v0
-;;                                     v10 -> v0
-;;                                     v16 -> v0
-;; @009e                               v11 = load.i64 notrap aligned table v0+96
-;; @00a0                               v12 = load.i64 null_reference aligned readonly v11+16
-;; @00a0                               v13 = load.i64 notrap aligned readonly v11+32
-;; @00a0                               v14 = call_indirect sig0, v12(v13, v0, v2, v3, v4, v5)
-;; @00af                               v17 = load.i64 notrap aligned table v0+112
-;; @00b1                               v18 = load.i64 null_reference aligned readonly v17+16
-;; @00b1                               v19 = load.i64 notrap aligned readonly v17+32
-;; @00b1                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
+;;                                     v14 -> v0
+;; @009e                               v9 = load.i64 notrap aligned table v0+96
+;; @00a0                               v10 = load.i64 null_reference aligned readonly v9+16
+;; @00a0                               v11 = load.i64 notrap aligned readonly v9+32
+;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
+;; @00af                               v15 = load.i64 notrap aligned table v0+112
+;; @00b1                               v16 = load.i64 null_reference aligned readonly v15+16
+;; @00b1                               v17 = load.i64 notrap aligned readonly v15+32
+;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)
 ;; @00ba                               jump block1
 ;;
 ;;                                 block1:
-;; @00b5                               v21 = iadd.i32 v20, v14
-;;                                     v6 -> v21
-;; @00ba                               return v21
+;; @00b5                               v19 = iadd.i32 v18, v12
+;;                                     v6 -> v19
+;; @00ba                               return v19
 ;; }

--- a/tests/disas/unreachable_code.wat
+++ b/tests/disas/unreachable_code.wat
@@ -82,12 +82,9 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0040                               v3 = global_value.i64 gv3
-;; @0040                               v4 = load.i64 notrap aligned v3+8
 ;; @0043                               trap unreachable
 ;; }
 ;;
@@ -95,12 +92,9 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004b                               v3 = global_value.i64 gv3
-;; @004b                               v4 = load.i64 notrap aligned v3+8
 ;; @004c                               jump block2
 ;;
 ;;                                 block2:
@@ -111,14 +105,11 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0056                               v3 = global_value.i64 gv3
-;; @0056                               v4 = load.i64 notrap aligned v3+8
-;; @0061                               v6 = iconst.i32 1
-;; @0063                               brif v6, block6, block13  ; v6 = 1
+;; @0061                               v4 = iconst.i32 1
+;; @0063                               brif v4, block6, block13  ; v4 = 1
 ;;
 ;;                                 block6:
 ;; @006a                               jump block9
@@ -146,18 +137,15 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
 ;;     sig1 = (i64 vmctx, i32 uext) -> i32 uext system_v
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0090                               v2 = global_value.i64 gv3
-;; @0090                               v3 = load.i64 notrap aligned v2+8
-;; @0095                               v6 = iconst.i32 1
-;; @0097                               jump block2(v6)  ; v6 = 1
+;; @0095                               v4 = iconst.i32 1
+;; @0097                               jump block2(v4)  ; v4 = 1
 ;;
-;;                                 block2(v4: i32):
+;;                                 block2(v2: i32):
 ;; @009c                               jump block1
 ;;
 ;;                                 block1:


### PR DESCRIPTION
It recently became necessary to regenerate the expected output of most (all?) of the files in tests/disas. Concretely, we were generating slightly different CLIF than upstream even on modules not involving any WasmFX instructions.

This PR rectifies this situation, making sure that we generate identical CLIF again. This required two changes:

## Global CLIF variable for runtime limits pointer
Since #99, we called the function `wasmtime_cranelift::func_environ::FuncEnvironment::declare_vmruntime_limits_ptr` unconditionally for every compiled function, meaning that every function prelude now contained a definition of the corresponding global variable.

This PR changes this behavior: I restored the original logic for when to call `declare_vmruntime_limits_ptr`. Instead of using the global variable `vmruntime_limits` to access the `VMRuntimeLimits`, we now load this pointer ourselves once per `resume` instruction. Since the load instruction is marked as `readonly`, it should be coalesced into a single load, even if multiple `resume`s appear in the same function.

I've benchmarked this, using a micro-benchmark with 2 resume instructions in the same function, and as expected there is no observable difference in performance.

## Order of libcall declarations
 In `builtin.rs`, we put the declarations of our own libcalls into the middle of the list of all libcalls in the `foreach_builtin_function` macro. This shifted the indices of some existing libcalls, which caused the CLIF to differ when using these. I've moved all the `tc_` libcalls to the end of the list, thus leaving the indices of existing libcalls unchanged. 

As a result, I've replaced all files in tests/disas with the versions from upstream (bytecodealliance/wasmtime@afaf1c73f67c42e638590608579b2b02c7f65ca3, the most recent upstream commit that we've merged)
