### PR TITLE
Rename ContinuationObject and ContinuationReference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,9 +386,9 @@ debug-builtins = ["wasmtime/debug-builtins"]
 # Enables compatibility shims with Wasmtime 13 and prior's CLI.
 old-cli = []
 
-# Until we implement proper reference counting for `VMContXObj` objects,
-# we may use this flag to bypass the creation of VMContXObj objects,
-# directly using the corresponding VMContXRef instead.
+# Until we implement proper reference counting for `VMContObj` objects,
+# we may use this flag to bypass the creation of VMContObj objects,
+# directly using the corresponding VMContRef instead.
 # This is to allow running benchmarks that may create a lot of such objects and
 # may otherwise run out of memory.
 # Note that enabling this is highly unsafe, as it makes it impossible to detect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,8 +386,8 @@ debug-builtins = ["wasmtime/debug-builtins"]
 # Enables compatibility shims with Wasmtime 13 and prior's CLI.
 old-cli = []
 
-# Until we implement proper reference counting for `ContinuationReference` objects,
-# we may use this flag to bypass the creation of ContinuationReference objects,
+# Until we implement proper reference counting for `VMContXObj` objects,
+# we may use this flag to bypass the creation of VMContXObj objects,
 # directly using the corresponding ContinuationObject instead.
 # This is to allow running benchmarks that may create a lot of such objects and
 # may otherwise run out of memory.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -388,7 +388,7 @@ old-cli = []
 
 # Until we implement proper reference counting for `VMContXObj` objects,
 # we may use this flag to bypass the creation of VMContXObj objects,
-# directly using the corresponding ContinuationObject instead.
+# directly using the corresponding VMContXRef instead.
 # This is to allow running benchmarks that may create a lot of such objects and
 # may otherwise run out of memory.
 # Note that enabling this is highly unsafe, as it makes it impossible to detect

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2580,7 +2580,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let tag_index_val = builder.ins().iconst(I32, *tag_index as i64);
             environ.translate_suspend(builder, tag_index_val);
 
-            let contXref = environ.typed_continuations_load_continuation_object(builder);
+            let contXref = environ.typed_continuations_load_continuation_Xreference(builder);
 
             let return_types = environ.tag_returns(*tag_index).to_vec();
             let return_values =
@@ -2598,7 +2598,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
 
             let (original_contref, args) = state.peekn(arg_count + 1).split_last().unwrap();
             let contXref =
-                environ.typed_continuations_cont_ref_get_cont_obj(builder, *original_contref);
+                environ.typed_continuations_cont_ref_get_cont_Xref(builder, *original_contref);
 
             let src_arity_value = builder.ins().iconst(I32, src_arity as i64);
             environ.typed_continuations_store_resume_args(builder, args, src_arity_value, contXref);

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2535,9 +2535,9 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let arg_types = environ.continuation_arguments(*type_index).to_vec();
             let result_types = environ.continuation_returns(*type_index).to_vec();
             let r = state.pop1();
-            let contobj =
+            let contXref =
                 environ.translate_cont_new(builder, state, r, &arg_types, &result_types)?;
-            let contref = environ.typed_continuations_new_cont_ref(builder, contobj);
+            let contref = environ.typed_continuations_new_cont_ref(builder, contXref);
             state.push1(contref);
         }
         Operator::Resume {
@@ -2580,11 +2580,11 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let tag_index_val = builder.ins().iconst(I32, *tag_index as i64);
             environ.translate_suspend(builder, tag_index_val);
 
-            let contobj = environ.typed_continuations_load_continuation_object(builder);
+            let contXref = environ.typed_continuations_load_continuation_object(builder);
 
             let return_types = environ.tag_returns(*tag_index).to_vec();
             let return_values =
-                environ.typed_continuations_load_tag_return_values(builder, contobj, &return_types);
+                environ.typed_continuations_load_tag_return_values(builder, contXref, &return_types);
 
             state.pushn(&return_values);
         }
@@ -2597,13 +2597,13 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let arg_count = src_arity - dst_arity;
 
             let (original_contref, args) = state.peekn(arg_count + 1).split_last().unwrap();
-            let contobj =
+            let contXref =
                 environ.typed_continuations_cont_ref_get_cont_obj(builder, *original_contref);
 
             let src_arity_value = builder.ins().iconst(I32, src_arity as i64);
-            environ.typed_continuations_store_resume_args(builder, args, src_arity_value, contobj);
+            environ.typed_continuations_store_resume_args(builder, args, src_arity_value, contXref);
 
-            let new_contref = environ.typed_continuations_new_cont_ref(builder, contobj);
+            let new_contref = environ.typed_continuations_new_cont_ref(builder, contXref);
 
             state.popn(arg_count + 1);
             state.push1(new_contref);

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2537,8 +2537,8 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let r = state.pop1();
             let contXref =
                 environ.translate_cont_new(builder, state, r, &arg_types, &result_types)?;
-            let contref = environ.typed_continuations_new_cont_ref(builder, contXref);
-            state.push1(contref);
+            let contXobj = environ.typed_continuations_new_cont_Xobj(builder, contXref);
+            state.push1(contXobj);
         }
         Operator::Resume {
             type_index,
@@ -2560,10 +2560,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 .collect::<Vec<(u32, ir::Block)>>();
 
             let arity = environ.continuation_arguments(*type_index).len();
-            let (contref, call_args) = state.peekn(arity + 1).split_last().unwrap();
+            let (contXobj, call_args) = state.peekn(arity + 1).split_last().unwrap();
 
             let cont_return_vals =
-                environ.translate_resume(builder, *type_index, *contref, call_args, &resumetable);
+                environ.translate_resume(builder, *type_index, *contXobj, call_args, &resumetable);
 
             state.popn(arity + 1); // arguments + continuation
             state.pushn(&cont_return_vals);
@@ -2596,17 +2596,17 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let dst_arity = environ.continuation_arguments(*dst_index).len();
             let arg_count = src_arity - dst_arity;
 
-            let (original_contref, args) = state.peekn(arg_count + 1).split_last().unwrap();
+            let (original_contXobj, args) = state.peekn(arg_count + 1).split_last().unwrap();
             let contXref =
-                environ.typed_continuations_cont_ref_get_cont_Xref(builder, *original_contref);
+                environ.typed_continuations_cont_Xobj_get_cont_Xref(builder, *original_contXobj);
 
             let src_arity_value = builder.ins().iconst(I32, src_arity as i64);
             environ.typed_continuations_store_resume_args(builder, args, src_arity_value, contXref);
 
-            let new_contref = environ.typed_continuations_new_cont_ref(builder, contXref);
+            let new_contXobj = environ.typed_continuations_new_cont_Xobj(builder, contXref);
 
             state.popn(arg_count + 1);
-            state.push1(new_contref);
+            state.push1(new_contXobj);
         }
         Operator::ResumeThrow {
             type_index: _,

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2535,10 +2535,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let arg_types = environ.continuation_arguments(*type_index).to_vec();
             let result_types = environ.continuation_returns(*type_index).to_vec();
             let r = state.pop1();
-            let contXref =
+            let contref =
                 environ.translate_cont_new(builder, state, r, &arg_types, &result_types)?;
-            let contXobj = environ.typed_continuations_new_cont_Xobj(builder, contXref);
-            state.push1(contXobj);
+            let contobj = environ.typed_continuations_new_cont_obj(builder, contref);
+            state.push1(contobj);
         }
         Operator::Resume {
             type_index,
@@ -2560,10 +2560,10 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 .collect::<Vec<(u32, ir::Block)>>();
 
             let arity = environ.continuation_arguments(*type_index).len();
-            let (contXobj, call_args) = state.peekn(arity + 1).split_last().unwrap();
+            let (contobj, call_args) = state.peekn(arity + 1).split_last().unwrap();
 
             let cont_return_vals =
-                environ.translate_resume(builder, *type_index, *contXobj, call_args, &resumetable);
+                environ.translate_resume(builder, *type_index, *contobj, call_args, &resumetable);
 
             state.popn(arity + 1); // arguments + continuation
             state.pushn(&cont_return_vals);
@@ -2580,11 +2580,11 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let tag_index_val = builder.ins().iconst(I32, *tag_index as i64);
             environ.translate_suspend(builder, tag_index_val);
 
-            let contXref = environ.typed_continuations_load_continuation_Xreference(builder);
+            let contref = environ.typed_continuations_load_continuation_reference(builder);
 
             let return_types = environ.tag_returns(*tag_index).to_vec();
             let return_values =
-                environ.typed_continuations_load_tag_return_values(builder, contXref, &return_types);
+                environ.typed_continuations_load_tag_return_values(builder, contref, &return_types);
 
             state.pushn(&return_values);
         }
@@ -2596,17 +2596,17 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let dst_arity = environ.continuation_arguments(*dst_index).len();
             let arg_count = src_arity - dst_arity;
 
-            let (original_contXobj, args) = state.peekn(arg_count + 1).split_last().unwrap();
-            let contXref =
-                environ.typed_continuations_cont_Xobj_get_cont_Xref(builder, *original_contXobj);
+            let (original_contobj, args) = state.peekn(arg_count + 1).split_last().unwrap();
+            let contref =
+                environ.typed_continuations_cont_obj_get_cont_ref(builder, *original_contobj);
 
             let src_arity_value = builder.ins().iconst(I32, src_arity as i64);
-            environ.typed_continuations_store_resume_args(builder, args, src_arity_value, contXref);
+            environ.typed_continuations_store_resume_args(builder, args, src_arity_value, contref);
 
-            let new_contXobj = environ.typed_continuations_new_cont_Xobj(builder, contXref);
+            let new_contobj = environ.typed_continuations_new_cont_obj(builder, contref);
 
             state.popn(arg_count + 1);
-            state.push1(new_contXobj);
+            state.push1(new_contobj);
         }
         Operator::ResumeThrow {
             type_index: _,

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -682,9 +682,9 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// TODO
     fn tag_returns(&self, tag_index: u32) -> &[wasmtime_types::WasmValType];
 
-    /// Returns a pointer to the currently running continuation object.
+    /// Returns a pointer to the currently running continuation Xreference.
     /// Traps if not currently running inside a continuation.
-    fn typed_continuations_load_continuation_object(
+    fn typed_continuations_load_continuation_Xreference(
         &mut self,
         builder: &mut FunctionBuilder,
     ) -> ir::Value;
@@ -697,7 +697,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     ) -> ir::Value;
 
     /// TODO
-    fn typed_continuations_cont_ref_get_cont_obj(
+    fn typed_continuations_cont_ref_get_cont_Xref(
         &mut self,
         builder: &mut FunctionBuilder,
         contref: ir::Value,

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -624,7 +624,7 @@ pub trait FuncEnvironment: TargetEnvironment {
         &mut self,
         builder: &mut FunctionBuilder,
         type_index: u32,
-        contXobj: ir::Value,
+        contobj: ir::Value,
         resume_args: &[ir::Value],
         resumetable: &[(u32, ir::Block)],
     ) -> Vec<ir::Value>;
@@ -655,7 +655,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn typed_continuations_load_tag_return_values(
         &mut self,
         builder: &mut FunctionBuilder,
-        contXref: ir::Value,
+        contref: ir::Value,
         valtypes: &[wasmtime_types::WasmValType],
     ) -> std::vec::Vec<ir::Value>;
 
@@ -673,7 +673,7 @@ pub trait FuncEnvironment: TargetEnvironment {
         builder: &mut FunctionBuilder,
         values: &[ir::Value],
         remaining_arg_count: ir::Value,
-        contXref: ir::Value,
+        contref: ir::Value,
     );
 
     /// TODO
@@ -682,25 +682,25 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// TODO
     fn tag_returns(&self, tag_index: u32) -> &[wasmtime_types::WasmValType];
 
-    /// Returns a pointer to the currently running continuation Xreference.
+    /// Returns a pointer to the currently running continuation reference.
     /// Traps if not currently running inside a continuation.
-    fn typed_continuations_load_continuation_Xreference(
+    fn typed_continuations_load_continuation_reference(
         &mut self,
         builder: &mut FunctionBuilder,
     ) -> ir::Value;
 
     /// TODO
-    fn typed_continuations_new_cont_Xobj(
+    fn typed_continuations_new_cont_obj(
         &mut self,
         builder: &mut FunctionBuilder,
-        contXref_addr: ir::Value,
+        contref_addr: ir::Value,
     ) -> ir::Value;
 
     /// TODO
-    fn typed_continuations_cont_Xobj_get_cont_Xref(
+    fn typed_continuations_cont_obj_get_cont_ref(
         &mut self,
         builder: &mut FunctionBuilder,
-        contXobj: ir::Value,
+        contobj: ir::Value,
     ) -> ir::Value;
 
     /// Returns whether the CLIF `x86_blendv` instruction should be used for the

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -624,7 +624,7 @@ pub trait FuncEnvironment: TargetEnvironment {
         &mut self,
         builder: &mut FunctionBuilder,
         type_index: u32,
-        contref: ir::Value,
+        contXobj: ir::Value,
         resume_args: &[ir::Value],
         resumetable: &[(u32, ir::Block)],
     ) -> Vec<ir::Value>;
@@ -690,17 +690,17 @@ pub trait FuncEnvironment: TargetEnvironment {
     ) -> ir::Value;
 
     /// TODO
-    fn typed_continuations_new_cont_ref(
+    fn typed_continuations_new_cont_Xobj(
         &mut self,
         builder: &mut FunctionBuilder,
         contXref_addr: ir::Value,
     ) -> ir::Value;
 
     /// TODO
-    fn typed_continuations_cont_ref_get_cont_Xref(
+    fn typed_continuations_cont_Xobj_get_cont_Xref(
         &mut self,
         builder: &mut FunctionBuilder,
-        contref: ir::Value,
+        contXobj: ir::Value,
     ) -> ir::Value;
 
     /// Returns whether the CLIF `x86_blendv` instruction should be used for the

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -655,7 +655,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn typed_continuations_load_tag_return_values(
         &mut self,
         builder: &mut FunctionBuilder,
-        contobj: ir::Value,
+        contXref: ir::Value,
         valtypes: &[wasmtime_types::WasmValType],
     ) -> std::vec::Vec<ir::Value>;
 
@@ -673,7 +673,7 @@ pub trait FuncEnvironment: TargetEnvironment {
         builder: &mut FunctionBuilder,
         values: &[ir::Value],
         remaining_arg_count: ir::Value,
-        contobj: ir::Value,
+        contXref: ir::Value,
     );
 
     /// TODO
@@ -693,7 +693,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn typed_continuations_new_cont_ref(
         &mut self,
         builder: &mut FunctionBuilder,
-        contobj_addr: ir::Value,
+        contXref_addr: ir::Value,
     ) -> ir::Value;
 
     /// TODO

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -126,20 +126,20 @@ pub const STACK_CHAIN_MAIN_STACK_DISCRIMINANT: usize = 1;
 /// `wasmtime_runtime::continuation::StackChain`.
 pub const STACK_CHAIN_CONTINUATION_DISCRIMINANT: usize = 2;
 
-/// Encodes the life cycle of a `ContinuationObject`.
+/// Encodes the life cycle of a `VMContXRef`.
 #[derive(PartialEq)]
 #[repr(i32)]
 pub enum State {
-    /// The `ContinuationObject` has been created, but `resume` has never been
+    /// The `VMContXRef` has been created, but `resume` has never been
     /// called on it. During this stage, we may add arguments using `cont.bind`.
     Allocated,
-    /// `resume` has been invoked at least once on the `ContinuationObject`,
+    /// `resume` has been invoked at least once on the `VMContXRef`,
     /// meaning that the function passed to `cont.new` has started executing.
     /// Note that this state does not indicate whether the execution of this
     /// function is currently suspended or not.
     Invoked,
     /// The function originally passed to `cont.new` has returned normally.
-    /// Note that there is no guarantee that a ContinuationObject will ever
+    /// Note that there is no guarantee that a VMContXRef will ever
     /// reach this status, as it may stay suspended until being dropped.
     Returned,
 }
@@ -278,7 +278,7 @@ pub mod offsets {
         pub const LENGTH: usize = offset_of!(Payloads, length);
     }
 
-    /// Offsets of fields in `wasmtime_runtime::continuation::ContinuationObject`.
+    /// Offsets of fields in `wasmtime_runtime::continuation::VMContXRef`.
     /// We uses tests there to ensure these values are correct.
     pub mod vm_cont_Xref {
         use crate::Payloads;

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -280,7 +280,7 @@ pub mod offsets {
 
     /// Offsets of fields in `wasmtime_runtime::continuation::ContinuationObject`.
     /// We uses tests there to ensure these values are correct.
-    pub mod vm_cont_ref {
+    pub mod vm_cont_Xref {
         use crate::Payloads;
 
         /// Offset of `limits` field

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -126,20 +126,20 @@ pub const STACK_CHAIN_MAIN_STACK_DISCRIMINANT: usize = 1;
 /// `wasmtime_runtime::continuation::StackChain`.
 pub const STACK_CHAIN_CONTINUATION_DISCRIMINANT: usize = 2;
 
-/// Encodes the life cycle of a `VMContXRef`.
+/// Encodes the life cycle of a `VMContRef`.
 #[derive(PartialEq)]
 #[repr(i32)]
 pub enum State {
-    /// The `VMContXRef` has been created, but `resume` has never been
+    /// The `VMContRef` has been created, but `resume` has never been
     /// called on it. During this stage, we may add arguments using `cont.bind`.
     Allocated,
-    /// `resume` has been invoked at least once on the `VMContXRef`,
+    /// `resume` has been invoked at least once on the `VMContRef`,
     /// meaning that the function passed to `cont.new` has started executing.
     /// Note that this state does not indicate whether the execution of this
     /// function is currently suspended or not.
     Invoked,
     /// The function originally passed to `cont.new` has returned normally.
-    /// Note that there is no guarantee that a VMContXRef will ever
+    /// Note that there is no guarantee that a VMContRef will ever
     /// reach this status, as it may stay suspended until being dropped.
     Returned,
 }
@@ -278,9 +278,9 @@ pub mod offsets {
         pub const LENGTH: usize = offset_of!(Payloads, length);
     }
 
-    /// Offsets of fields in `wasmtime_runtime::continuation::VMContXRef`.
+    /// Offsets of fields in `wasmtime_runtime::continuation::VMContRef`.
     /// We uses tests there to ensure these values are correct.
-    pub mod vm_cont_Xref {
+    pub mod vm_cont_ref {
         use crate::Payloads;
 
         /// Offset of `limits` field

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -280,7 +280,7 @@ pub mod offsets {
 
     /// Offsets of fields in `wasmtime_runtime::continuation::ContinuationObject`.
     /// We uses tests there to ensure these values are correct.
-    pub mod continuation_object {
+    pub mod vm_cont_ref {
         use crate::Payloads;
 
         /// Offset of `limits` field

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2863,12 +2863,12 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     }
 
     /// TODO
-    fn typed_continuations_cont_ref_get_cont_Xref(
+    fn typed_continuations_cont_Xobj_get_cont_Xref(
         &mut self,
         builder: &mut FunctionBuilder,
         contref: ir::Value,
     ) -> ir::Value {
-        wasmfx_impl::typed_continuations_cont_ref_get_cont_Xref(self, builder, contref)
+        wasmfx_impl::typed_continuations_cont_Xobj_get_cont_Xref(self, builder, contref)
     }
 
     /// TODO
@@ -2905,12 +2905,12 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         wasmfx_impl::typed_continuations_load_continuation_Xreference(self, builder)
     }
 
-    fn typed_continuations_new_cont_ref(
+    fn typed_continuations_new_cont_Xobj(
         &mut self,
         builder: &mut FunctionBuilder,
         contXref_addr: ir::Value,
     ) -> ir::Value {
-        wasmfx_impl::typed_continuations_new_cont_ref(self, builder, contXref_addr)
+        wasmfx_impl::typed_continuations_new_cont_Xobj(self, builder, contXref_addr)
     }
 
     fn use_x86_blendv_for_relaxed_laneselect(&self, ty: Type) -> bool {

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2808,11 +2808,11 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         &mut self,
         builder: &mut FunctionBuilder,
         type_index: u32,
-        contref: ir::Value,
+        contXobj: ir::Value,
         resume_args: &[ir::Value],
         resumetable: &[(u32, ir::Block)],
     ) -> Vec<ir::Value> {
-        wasmfx_impl::translate_resume(self, builder, type_index, contref, resume_args, resumetable)
+        wasmfx_impl::translate_resume(self, builder, type_index, contXobj, resume_args, resumetable)
     }
 
     fn translate_resume_throw(
@@ -2866,9 +2866,9 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn typed_continuations_cont_Xobj_get_cont_Xref(
         &mut self,
         builder: &mut FunctionBuilder,
-        contref: ir::Value,
+        contXobj: ir::Value,
     ) -> ir::Value {
-        wasmfx_impl::typed_continuations_cont_Xobj_get_cont_Xref(self, builder, contref)
+        wasmfx_impl::typed_continuations_cont_Xobj_get_cont_Xref(self, builder, contXobj)
     }
 
     /// TODO

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2856,10 +2856,10 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn typed_continuations_load_tag_return_values(
         &mut self,
         builder: &mut FunctionBuilder,
-        contobj: ir::Value,
+        contXref: ir::Value,
         valtypes: &[WasmValType],
     ) -> Vec<ir::Value> {
-        wasmfx_impl::typed_continuations_load_tag_return_values(self, builder, contobj, valtypes)
+        wasmfx_impl::typed_continuations_load_tag_return_values(self, builder, contXref, valtypes)
     }
 
     /// TODO
@@ -2877,14 +2877,14 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         builder: &mut FunctionBuilder,
         values: &[ir::Value],
         remaining_arg_count: ir::Value,
-        contobj: ir::Value,
+        contXref: ir::Value,
     ) {
         wasmfx_impl::typed_continuations_store_resume_args(
             self,
             builder,
             values,
             remaining_arg_count,
-            contobj,
+            contXref,
         )
     }
 
@@ -2908,9 +2908,9 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn typed_continuations_new_cont_ref(
         &mut self,
         builder: &mut FunctionBuilder,
-        contobj_addr: ir::Value,
+        contXref_addr: ir::Value,
     ) -> ir::Value {
-        wasmfx_impl::typed_continuations_new_cont_ref(self, builder, contobj_addr)
+        wasmfx_impl::typed_continuations_new_cont_ref(self, builder, contXref_addr)
     }
 
     fn use_x86_blendv_for_relaxed_laneselect(&self, ty: Type) -> bool {

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2863,12 +2863,12 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     }
 
     /// TODO
-    fn typed_continuations_cont_ref_get_cont_obj(
+    fn typed_continuations_cont_ref_get_cont_Xref(
         &mut self,
         builder: &mut FunctionBuilder,
         contref: ir::Value,
     ) -> ir::Value {
-        wasmfx_impl::typed_continuations_cont_ref_get_cont_obj(self, builder, contref)
+        wasmfx_impl::typed_continuations_cont_ref_get_cont_Xref(self, builder, contref)
     }
 
     /// TODO
@@ -2898,11 +2898,11 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         wasmfx_impl::typed_continuations_store_payloads(self, builder, valtypes, values)
     }
 
-    fn typed_continuations_load_continuation_object(
+    fn typed_continuations_load_continuation_Xreference(
         &mut self,
         builder: &mut FunctionBuilder,
     ) -> ir::Value {
-        wasmfx_impl::typed_continuations_load_continuation_object(self, builder)
+        wasmfx_impl::typed_continuations_load_continuation_Xreference(self, builder)
     }
 
     fn typed_continuations_new_cont_ref(

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2808,11 +2808,11 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         &mut self,
         builder: &mut FunctionBuilder,
         type_index: u32,
-        contXobj: ir::Value,
+        contobj: ir::Value,
         resume_args: &[ir::Value],
         resumetable: &[(u32, ir::Block)],
     ) -> Vec<ir::Value> {
-        wasmfx_impl::translate_resume(self, builder, type_index, contXobj, resume_args, resumetable)
+        wasmfx_impl::translate_resume(self, builder, type_index, contobj, resume_args, resumetable)
     }
 
     fn translate_resume_throw(
@@ -2856,19 +2856,19 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn typed_continuations_load_tag_return_values(
         &mut self,
         builder: &mut FunctionBuilder,
-        contXref: ir::Value,
+        contref: ir::Value,
         valtypes: &[WasmValType],
     ) -> Vec<ir::Value> {
-        wasmfx_impl::typed_continuations_load_tag_return_values(self, builder, contXref, valtypes)
+        wasmfx_impl::typed_continuations_load_tag_return_values(self, builder, contref, valtypes)
     }
 
     /// TODO
-    fn typed_continuations_cont_Xobj_get_cont_Xref(
+    fn typed_continuations_cont_obj_get_cont_ref(
         &mut self,
         builder: &mut FunctionBuilder,
-        contXobj: ir::Value,
+        contobj: ir::Value,
     ) -> ir::Value {
-        wasmfx_impl::typed_continuations_cont_Xobj_get_cont_Xref(self, builder, contXobj)
+        wasmfx_impl::typed_continuations_cont_obj_get_cont_ref(self, builder, contobj)
     }
 
     /// TODO
@@ -2877,14 +2877,14 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         builder: &mut FunctionBuilder,
         values: &[ir::Value],
         remaining_arg_count: ir::Value,
-        contXref: ir::Value,
+        contref: ir::Value,
     ) {
         wasmfx_impl::typed_continuations_store_resume_args(
             self,
             builder,
             values,
             remaining_arg_count,
-            contXref,
+            contref,
         )
     }
 
@@ -2898,19 +2898,19 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         wasmfx_impl::typed_continuations_store_payloads(self, builder, valtypes, values)
     }
 
-    fn typed_continuations_load_continuation_Xreference(
+    fn typed_continuations_load_continuation_reference(
         &mut self,
         builder: &mut FunctionBuilder,
     ) -> ir::Value {
-        wasmfx_impl::typed_continuations_load_continuation_Xreference(self, builder)
+        wasmfx_impl::typed_continuations_load_continuation_reference(self, builder)
     }
 
-    fn typed_continuations_new_cont_Xobj(
+    fn typed_continuations_new_cont_obj(
         &mut self,
         builder: &mut FunctionBuilder,
-        contXref_addr: ir::Value,
+        contref_addr: ir::Value,
     ) -> ir::Value {
-        wasmfx_impl::typed_continuations_new_cont_Xobj(self, builder, contXref_addr)
+        wasmfx_impl::typed_continuations_new_cont_obj(self, builder, contref_addr)
     }
 
     fn use_x86_blendv_for_relaxed_laneselect(&self, ty: Type) -> bool {

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -11,7 +11,7 @@ use cranelift_wasm::{FuncTranslationState, WasmResult, WasmValType};
 use wasmtime_environ::PtrSize;
 
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_cont_ref_get_cont_obj;
+pub(crate) use shared::typed_continuations_cont_ref_get_cont_Xref;
 #[allow(unused_imports)]
 pub(crate) use shared::typed_continuations_new_cont_ref;
 
@@ -201,7 +201,7 @@ pub(crate) fn translate_resume<'a>(
     // Prelude: Push the continuation arguments.
     {
         let resumee_fiber =
-            shared::typed_continuations_cont_ref_get_cont_obj(env, builder, resumee_ref);
+            shared::typed_continuations_cont_ref_get_cont_Xref(env, builder, resumee_ref);
         if resume_args.len() > 0 {
             let nargs = builder.ins().iconst(I64, resume_args.len() as i64);
 

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -11,9 +11,9 @@ use cranelift_wasm::{FuncTranslationState, WasmResult, WasmValType};
 use wasmtime_environ::PtrSize;
 
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_cont_Xobj_get_cont_Xref;
+pub(crate) use shared::typed_continuations_cont_obj_get_cont_ref;
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_new_cont_Xobj;
+pub(crate) use shared::typed_continuations_new_cont_obj;
 
 fn typed_continuations_load_payloads<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
@@ -43,7 +43,7 @@ fn typed_continuations_load_payloads<'a>(
 pub(crate) fn typed_continuations_load_tag_return_values<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    contXref: ir::Value,
+    contref: ir::Value,
     valtypes: &[WasmValType],
 ) -> Vec<ir::Value> {
     let _memflags = ir::MemFlags::trusted();
@@ -57,7 +57,7 @@ pub(crate) fn typed_continuations_load_tag_return_values<'a>(
             env,
             let args_ptr =
                 tc_baseline_continuation_arguments_ptr(
-                contXref,
+                contref,
                 nargs
             )
         );
@@ -79,7 +79,7 @@ pub(crate) fn typed_continuations_load_tag_return_values<'a>(
         debug_assert!(valtypes.len() == args.len());
 
         // Clear the arguments buffer
-        call_builtin!(builder, env, tc_baseline_clear_arguments(contXref));
+        call_builtin!(builder, env, tc_baseline_clear_arguments(contref));
 
         return args;
     }
@@ -93,7 +93,7 @@ pub(crate) fn typed_continuations_store_resume_args<'a>(
     builder: &mut FunctionBuilder,
     values: &[ir::Value],
     _remaining_arg_count: ir::Value,
-    contXref: ir::Value,
+    contref: ir::Value,
 ) {
     if values.len() > 0 {
         // Retrieve the pointer to the arguments buffer.
@@ -103,7 +103,7 @@ pub(crate) fn typed_continuations_store_resume_args<'a>(
             env,
             let args_ptr =
                 tc_baseline_continuation_arguments_ptr(
-                contXref,
+                contref,
                 nargs
             )
         );
@@ -140,7 +140,7 @@ pub(crate) fn typed_continuations_store_payloads<'a>(
     }
 }
 
-pub(crate) fn typed_continuations_load_continuation_Xreference<'a>(
+pub(crate) fn typed_continuations_load_continuation_reference<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
 ) -> ir::Value {
@@ -201,7 +201,7 @@ pub(crate) fn translate_resume<'a>(
     // Prelude: Push the continuation arguments.
     {
         let resumee_fiber =
-            shared::typed_continuations_cont_Xobj_get_cont_Xref(env, builder, resumee_ref);
+            shared::typed_continuations_cont_obj_get_cont_ref(env, builder, resumee_ref);
         if resume_args.len() > 0 {
             let nargs = builder.ins().iconst(I64, resume_args.len() as i64);
 
@@ -302,8 +302,8 @@ pub(crate) fn translate_resume<'a>(
         // entirely.
         let mut args = typed_continuations_load_payloads(env, builder, &param_types);
 
-        // Create and push the continuation Xobject.
-        let resumee_ref = shared::typed_continuations_new_cont_Xobj(env, builder, resumee_fiber);
+        // Create and push the continuation object.
+        let resumee_ref = shared::typed_continuations_new_cont_obj(env, builder, resumee_fiber);
         args.push(resumee_ref);
 
         // Finally, emit the jump to `label`.
@@ -369,7 +369,7 @@ pub(crate) fn translate_resume<'a>(
         call_builtin!(
             builder,
             env,
-            tc_baseline_drop_continuation_Xobject(resumee_fiber)
+            tc_baseline_drop_continuation_object(resumee_fiber)
         );
 
         return values;
@@ -387,9 +387,9 @@ pub(crate) fn translate_cont_new<'a>(
     // Load the builtin continuation allocation function.
     let nargs = builder.ins().iconst(I64, arg_types.len() as i64);
     let nreturns = builder.ins().iconst(I64, return_types.len() as i64);
-    call_builtin!(builder, env, let contXobj = tc_baseline_cont_new(func, nargs, nreturns));
+    call_builtin!(builder, env, let contobj = tc_baseline_cont_new(func, nargs, nreturns));
 
-    Ok(contXobj)
+    Ok(contobj)
 }
 
 pub(crate) fn translate_suspend<'a>(

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -50,7 +50,7 @@ fn typed_continuations_load_payloads<'a>(
 pub(crate) fn typed_continuations_load_tag_return_values<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    contobj: ir::Value,
+    contXref: ir::Value,
     valtypes: &[WasmValType],
 ) -> Vec<ir::Value> {
     let _memflags = ir::MemFlags::trusted();
@@ -65,7 +65,7 @@ pub(crate) fn typed_continuations_load_tag_return_values<'a>(
         let vmctx = env.vmctx_val(&mut builder.cursor());
         let call_inst = builder
             .ins()
-            .call(continuation_arguments_ptr, &[vmctx, contobj, nargs]);
+            .call(continuation_arguments_ptr, &[vmctx, contXref, nargs]);
         let args_ptr = *builder.func.dfg.inst_results(call_inst).first().unwrap();
 
         // Load arguments.
@@ -88,7 +88,7 @@ pub(crate) fn typed_continuations_load_tag_return_values<'a>(
         let clear_arguments = env
             .builtin_functions
             .tc_baseline_clear_arguments(&mut builder.func);
-        builder.ins().call(clear_arguments, &[vmctx, contobj]);
+        builder.ins().call(clear_arguments, &[vmctx, contXref]);
 
         return args;
     }
@@ -102,7 +102,7 @@ pub(crate) fn typed_continuations_store_resume_args<'a>(
     builder: &mut FunctionBuilder,
     values: &[ir::Value],
     _remaining_arg_count: ir::Value,
-    contobj: ir::Value,
+    contXref: ir::Value,
 ) {
     if values.len() > 0 {
         // Retrieve the pointer to the arguments buffer.
@@ -113,7 +113,7 @@ pub(crate) fn typed_continuations_store_resume_args<'a>(
         let vmctx = env.vmctx_val(&mut builder.cursor());
         let call_inst = builder
             .ins()
-            .call(continuation_arguments_ptr, &[vmctx, contobj, nargs]);
+            .call(continuation_arguments_ptr, &[vmctx, contXref, nargs]);
         let args_ptr = *builder.func.dfg.inst_results(call_inst).first().unwrap();
 
         // Store arguments.

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -11,9 +11,9 @@ use cranelift_wasm::{FuncTranslationState, WasmResult, WasmValType};
 use wasmtime_environ::PtrSize;
 
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_cont_ref_get_cont_Xref;
+pub(crate) use shared::typed_continuations_cont_Xobj_get_cont_Xref;
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_new_cont_ref;
+pub(crate) use shared::typed_continuations_new_cont_Xobj;
 
 fn typed_continuations_load_payloads<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
@@ -201,7 +201,7 @@ pub(crate) fn translate_resume<'a>(
     // Prelude: Push the continuation arguments.
     {
         let resumee_fiber =
-            shared::typed_continuations_cont_ref_get_cont_Xref(env, builder, resumee_ref);
+            shared::typed_continuations_cont_Xobj_get_cont_Xref(env, builder, resumee_ref);
         if resume_args.len() > 0 {
             let nargs = builder.ins().iconst(I64, resume_args.len() as i64);
 
@@ -302,8 +302,8 @@ pub(crate) fn translate_resume<'a>(
         // entirely.
         let mut args = typed_continuations_load_payloads(env, builder, &param_types);
 
-        // Create and push the continuation reference.
-        let resumee_ref = shared::typed_continuations_new_cont_ref(env, builder, resumee_fiber);
+        // Create and push the continuation Xobject.
+        let resumee_ref = shared::typed_continuations_new_cont_Xobj(env, builder, resumee_fiber);
         args.push(resumee_ref);
 
         // Finally, emit the jump to `label`.
@@ -369,7 +369,7 @@ pub(crate) fn translate_resume<'a>(
         call_builtin!(
             builder,
             env,
-            tc_baseline_drop_continuation_reference(resumee_fiber)
+            tc_baseline_drop_continuation_Xobject(resumee_fiber)
         );
 
         return values;

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -303,8 +303,8 @@ pub(crate) fn translate_resume<'a>(
         let mut args = typed_continuations_load_payloads(env, builder, &param_types);
 
         // Create and push the continuation object.
-        let resumee_ref = shared::typed_continuations_new_cont_obj(env, builder, resumee_fiber);
-        args.push(resumee_ref);
+        let resumee_obj = shared::typed_continuations_new_cont_obj(env, builder, resumee_fiber);
+        args.push(resumee_obj);
 
         // Finally, emit the jump to `label`.
         builder.ins().jump(label, &args);

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -140,7 +140,7 @@ pub(crate) fn typed_continuations_store_payloads<'a>(
     }
 }
 
-pub(crate) fn typed_continuations_load_continuation_object<'a>(
+pub(crate) fn typed_continuations_load_continuation_Xreference<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
 ) -> ir::Value {

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -152,7 +152,7 @@ pub(crate) fn translate_resume<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     type_index: u32,
-    resumee_ref: ir::Value,
+    resumee_obj: ir::Value,
     resume_args: &[ir::Value],
     resumetable: &[(u32, ir::Block)],
 ) -> Vec<ir::Value> {
@@ -201,7 +201,7 @@ pub(crate) fn translate_resume<'a>(
     // Prelude: Push the continuation arguments.
     {
         let resumee_fiber =
-            shared::typed_continuations_cont_obj_get_cont_ref(env, builder, resumee_ref);
+            shared::typed_continuations_cont_obj_get_cont_ref(env, builder, resumee_obj);
         if resume_args.len() > 0 {
             let nargs = builder.ins().iconst(I64, resume_args.len() as i64);
 
@@ -387,9 +387,9 @@ pub(crate) fn translate_cont_new<'a>(
     // Load the builtin continuation allocation function.
     let nargs = builder.ins().iconst(I64, arg_types.len() as i64);
     let nreturns = builder.ins().iconst(I64, return_types.len() as i64);
-    call_builtin!(builder, env, let contobj = tc_baseline_cont_new(func, nargs, nreturns));
+    call_builtin!(builder, env, let contref = tc_baseline_cont_new(func, nargs, nreturns));
 
-    Ok(contobj)
+    Ok(contref)
 }
 
 pub(crate) fn translate_suspend<'a>(

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -387,9 +387,9 @@ pub(crate) fn translate_cont_new<'a>(
     // Load the builtin continuation allocation function.
     let nargs = builder.ins().iconst(I64, arg_types.len() as i64);
     let nreturns = builder.ins().iconst(I64, return_types.len() as i64);
-    call_builtin!(builder, env, let contref = tc_baseline_cont_new(func, nargs, nreturns));
+    call_builtin!(builder, env, let contXobj = tc_baseline_cont_new(func, nargs, nreturns));
 
-    Ok(contref)
+    Ok(contXobj)
 }
 
 pub(crate) fn translate_suspend<'a>(

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -369,7 +369,7 @@ pub(crate) fn translate_resume<'a>(
         call_builtin!(
             builder,
             env,
-            tc_baseline_drop_continuation_object(resumee_fiber)
+            tc_baseline_drop_continuation_reference(resumee_fiber)
         );
 
         return values;

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -1284,7 +1284,7 @@ pub(crate) fn translate_resume<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     type_index: u32,
-    contref: ir::Value,
+    contXobj: ir::Value,
     resume_args: &[ir::Value],
     resumetable: &[(u32, ir::Block)],
 ) -> Vec<ir::Value> {
@@ -1300,7 +1300,7 @@ pub(crate) fn translate_resume<'a>(
 
     let (resume_contXref, parent_stack_chain) = {
         let resume_contXref =
-            shared::typed_continuations_cont_Xobj_get_cont_Xref(env, builder, contref);
+            shared::typed_continuations_cont_Xobj_get_cont_Xref(env, builder, contXobj);
 
         if resume_args.len() > 0 {
             // We store the arguments in the `VMContXRef` to be resumed.
@@ -1500,9 +1500,9 @@ pub(crate) fn translate_resume<'a>(
 
         // Create and push the continuation Xobject. We only create
         // them here because we don't need them when forwarding.
-        let contref = env.typed_continuations_new_cont_Xobj(builder, resume_contXref);
+        let contXobj = env.typed_continuations_new_cont_Xobj(builder, resume_contXref);
 
-        args.push(contref);
+        args.push(contXobj);
 
         // Now jump to the actual user-defined block handling
         // this tag, as given by the resumetable.

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -11,9 +11,9 @@ use cranelift_wasm::{FuncTranslationState, WasmResult, WasmValType};
 use wasmtime_environ::PtrSize;
 
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_cont_Xobj_get_cont_Xref;
+pub(crate) use shared::typed_continuations_cont_obj_get_cont_ref;
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_new_cont_Xobj;
+pub(crate) use shared::typed_continuations_new_cont_obj;
 
 #[macro_use]
 pub(crate) mod typed_continuation_helpers {
@@ -289,7 +289,7 @@ pub(crate) mod typed_continuation_helpers {
     }
 
     #[derive(Copy, Clone)]
-    pub struct VMContXRef {
+    pub struct VMContRef {
         address: ir::Value,
         pointer_type: ir::Type,
     }
@@ -324,29 +324,29 @@ pub(crate) mod typed_continuation_helpers {
         pointer_type: ir::Type,
     }
 
-    impl VMContXRef {
-        pub fn new(address: ir::Value, pointer_type: ir::Type) -> VMContXRef {
-            VMContXRef {
+    impl VMContRef {
+        pub fn new(address: ir::Value, pointer_type: ir::Type) -> VMContRef {
+            VMContRef {
                 address,
                 pointer_type,
             }
         }
 
         pub fn args(&self) -> Payloads {
-            let offset = wasmtime_continuations::offsets::vm_cont_Xref::ARGS;
+            let offset = wasmtime_continuations::offsets::vm_cont_ref::ARGS;
             Payloads::new(self.address, offset as i32, self.pointer_type)
         }
 
         pub fn tag_return_values(&self) -> Payloads {
-            let offset = wasmtime_continuations::offsets::vm_cont_Xref::TAG_RETURN_VALUES;
+            let offset = wasmtime_continuations::offsets::vm_cont_ref::TAG_RETURN_VALUES;
             Payloads::new(self.address, offset as i32, self.pointer_type)
         }
 
-        /// Loads the value of the `state` field of the VMContXRef,
+        /// Loads the value of the `state` field of the VMContRef,
         /// which is represented using the `State` enum.
         fn load_state(&self, builder: &mut FunctionBuilder) -> ir::Value {
             let mem_flags = ir::MemFlags::trusted();
-            let offset = wasmtime_continuations::offsets::vm_cont_Xref::STATE as i32;
+            let offset = wasmtime_continuations::offsets::vm_cont_ref::STATE as i32;
 
             // Let's make sure that we still represent the State enum as i32.
             debug_assert!(mem::size_of::<wasmtime_continuations::State>() == mem::size_of::<i32>());
@@ -354,14 +354,14 @@ pub(crate) mod typed_continuation_helpers {
             builder.ins().load(I32, mem_flags, self.address, offset)
         }
 
-        /// Sets the value of the `state` field of the `VMContXRef`,
+        /// Sets the value of the `state` field of the `VMContRef`,
         pub fn set_state(
             &self,
             builder: &mut FunctionBuilder,
             state: wasmtime_continuations::State,
         ) {
             let mem_flags = ir::MemFlags::trusted();
-            let offset = wasmtime_continuations::offsets::vm_cont_Xref::STATE as i32;
+            let offset = wasmtime_continuations::offsets::vm_cont_ref::STATE as i32;
 
             // Let's make sure that we still represent the State enum as i32.
             debug_assert!(mem::size_of::<wasmtime_continuations::State>() == mem::size_of::<i32>());
@@ -370,11 +370,11 @@ pub(crate) mod typed_continuation_helpers {
             builder.ins().store(mem_flags, v, self.address, offset);
         }
 
-        /// Checks whether the `VMContXRef` is invoked (i.e., `resume`
+        /// Checks whether the `VMContRef` is invoked (i.e., `resume`
         /// was called at least once on the object).
         pub fn is_invoked(&self, builder: &mut FunctionBuilder) -> ir::Value {
             // TODO(frank-emrich) In the future, we may get rid of the State field
-            // in `VMContXRef` and try to infer the state by other means.
+            // in `VMContRef` and try to infer the state by other means.
             // For example, we may alllocate the `ContinuationFiber` lazily, doing
             // so only at the point when a continuation is actualy invoked, meaning
             // that we can use the null-ness of the `fiber` field as an indicator
@@ -386,7 +386,7 @@ pub(crate) mod typed_continuation_helpers {
                 .icmp_imm(IntCC::Equal, actual_state, invoked as i64)
         }
 
-        /// Checks whether the `VMContXRef` has returned (i.e., the
+        /// Checks whether the `VMContRef` has returned (i.e., the
         /// function used as continuation has returned normally).
         pub fn has_returned(&self, builder: &mut FunctionBuilder) -> ir::Value {
             let actual_state = self.load_state(builder);
@@ -419,7 +419,7 @@ pub(crate) mod typed_continuation_helpers {
             builder: &mut FunctionBuilder,
             new_stack_chain: &StackChain,
         ) {
-            let offset = wasmtime_continuations::offsets::vm_cont_Xref::PARENT_CHAIN as i32;
+            let offset = wasmtime_continuations::offsets::vm_cont_ref::PARENT_CHAIN as i32;
             new_stack_chain.store(env, builder, self.address, offset)
         }
     }
@@ -573,7 +573,7 @@ pub(crate) mod typed_continuation_helpers {
                 emit_debug_println!(
                     env,
                     builder,
-                    "[ensure_capacity] contXref/base {:p}, buffer is {:p}",
+                    "[ensure_capacity] contref/base {:p}, buffer is {:p}",
                     self.base,
                     data
                 );
@@ -791,14 +791,14 @@ pub(crate) mod typed_continuation_helpers {
         }
 
         /// Similar to `store_stack_chain`, but instead of storing an arbitrary
-        /// `StackChain`, stores StackChain::Continuation(contXref)`.
+        /// `StackChain`, stores StackChain::Continuation(contref)`.
         pub fn set_active_continuation<'a>(
             &self,
             env: &mut crate::func_environ::FuncEnvironment<'a>,
             builder: &mut FunctionBuilder,
-            contXref: ir::Value,
+            contref: ir::Value,
         ) {
-            let chain = StackChain::from_continuation(builder, contXref, self.pointer_type);
+            let chain = StackChain::from_continuation(builder, contref, self.pointer_type);
             self.store_stack_chain(env, builder, &chain)
         }
 
@@ -821,10 +821,10 @@ pub(crate) mod typed_continuation_helpers {
     }
 
     impl StackChain {
-        /// Creates a `Self` corressponding to `StackChain::Continuation(contXref)`.
+        /// Creates a `Self` corressponding to `StackChain::Continuation(contref)`.
         pub fn from_continuation(
             builder: &mut FunctionBuilder,
-            contXref: ir::Value,
+            contref: ir::Value,
             pointer_type: ir::Type,
         ) -> StackChain {
             debug_assert_eq!(STACK_CHAIN_POINTER_COUNT, 2);
@@ -832,7 +832,7 @@ pub(crate) mod typed_continuation_helpers {
             let discriminant = builder.ins().iconst(pointer_type, discriminant as i64);
             StackChain {
                 discriminant,
-                payload: contXref,
+                payload: contref,
                 pointer_type,
             }
         }
@@ -921,7 +921,7 @@ pub(crate) mod typed_continuation_helpers {
         }
 
         /// If `self` corresponds to a `StackChain::Continuation`, return the
-        /// pointer to the `VMContXRef` stored in the variant.
+        /// pointer to the `VMContRef` stored in the variant.
         /// If `self` corresponds to `StackChain::MainStack`, trap with the
         /// given `trap_code`.
         /// Calling this if `self` corresponds to `StackChain::Absent` indicates
@@ -960,7 +960,7 @@ pub(crate) mod typed_continuation_helpers {
         /// Returns a pointer to the associated `StackLimits` object (i.e., in
         /// the former case, the pointer directly stored in the variant, or in
         /// the latter case a pointer to the `StackLimits` data within the
-        /// `VMContXRef`.
+        /// `VMContRef`.
         pub fn get_stack_limits_ptr<'a>(
             &self,
             env: &mut crate::func_environ::FuncEnvironment<'a>,
@@ -976,15 +976,15 @@ pub(crate) mod typed_continuation_helpers {
             let ptr = self.payload;
 
             // `obj` is now a pointer to the beginning of either
-            // 1. A `VMContXRef` object (in the case of a
+            // 1. A `VMContRef` object (in the case of a
             // StackChain::Continuation)
             // 2. A StackLimits object (in the case of
             // StackChain::MainStack)
             //
-            // Since a `VMContXRef` starts with an (inlined) StackLimits
+            // Since a `VMContRef` starts with an (inlined) StackLimits
             // object at offset 0, we actually have in both cases that `ptr` is
             // now the address of the beginning of a StackLimits object.
-            debug_assert_eq!(o::vm_cont_Xref::LIMITS, 0);
+            debug_assert_eq!(o::vm_cont_ref::LIMITS, 0);
             ptr
         }
 
@@ -1067,9 +1067,9 @@ fn typed_continuations_load_return_values<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     valtypes: &[WasmValType],
-    contXref: ir::Value,
+    contref: ir::Value,
 ) -> std::vec::Vec<ir::Value> {
-    let co = tc::VMContXRef::new(contXref, env.pointer_type());
+    let co = tc::VMContRef::new(contref, env.pointer_type());
     let mut values = vec![];
 
     if valtypes.len() > 0 {
@@ -1094,13 +1094,13 @@ fn typed_continuations_load_return_values<'a>(
 fn typed_continuations_forward_tag_return_values<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    parent_contXref: ir::Value,
-    child_contXref: ir::Value,
+    parent_contref: ir::Value,
+    child_contref: ir::Value,
 ) {
     call_builtin!(
         builder,
         env,
-        tc_cont_Xref_forward_tag_return_values_buffer(parent_contXref, child_contXref)
+        tc_cont_ref_forward_tag_return_values_buffer(parent_contref, child_contref)
     );
 }
 
@@ -1133,14 +1133,14 @@ fn typed_continuations_load_payloads<'a>(
 pub(crate) fn typed_continuations_load_tag_return_values<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    contXref: ir::Value,
+    contref: ir::Value,
     valtypes: &[WasmValType],
 ) -> Vec<ir::Value> {
     let memflags = ir::MemFlags::trusted();
     let mut values = vec![];
 
     if valtypes.len() > 0 {
-        let co = tc::VMContXRef::new(contXref, env.pointer_type());
+        let co = tc::VMContRef::new(contref, env.pointer_type());
         let tag_return_values = co.tag_return_values();
 
         let payload_ptr = tag_return_values.get_data(builder);
@@ -1172,7 +1172,7 @@ pub(crate) fn typed_continuations_store_resume_args<'a>(
     builder: &mut FunctionBuilder,
     values: &[ir::Value],
     remaining_arg_count: ir::Value,
-    contXref: ir::Value,
+    contref: ir::Value,
 ) {
     if values.len() > 0 {
         let use_args_block = builder.create_block();
@@ -1180,7 +1180,7 @@ pub(crate) fn typed_continuations_store_resume_args<'a>(
         let store_data_block = builder.create_block();
         builder.append_block_param(store_data_block, env.pointer_type());
 
-        let co = tc::VMContXRef::new(contXref, env.pointer_type());
+        let co = tc::VMContRef::new(contref, env.pointer_type());
         let is_invoked = co.is_invoked(builder);
         builder
             .ins()
@@ -1204,7 +1204,7 @@ pub(crate) fn typed_continuations_store_resume_args<'a>(
 
             // Unlike for the args buffer (where we know the maximum
             // required capacity at the time of creation of the
-            // `VMContXRef`), tag return buffers are re-used and may
+            // `VMContRef`), tag return buffers are re-used and may
             // be too small.
             tag_return_values.ensure_capacity(env, builder, remaining_arg_count);
 
@@ -1252,7 +1252,7 @@ pub(crate) fn typed_continuations_store_payloads<'a>(
     }
 }
 
-pub(crate) fn typed_continuations_load_continuation_Xreference<'a>(
+pub(crate) fn typed_continuations_load_continuation_reference<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
 ) -> ir::Value {
@@ -1284,7 +1284,7 @@ pub(crate) fn translate_resume<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     type_index: u32,
-    contXobj: ir::Value,
+    contobj: ir::Value,
     resume_args: &[ir::Value],
     resumetable: &[(u32, ir::Block)],
 ) -> Vec<ir::Value> {
@@ -1298,19 +1298,19 @@ pub(crate) fn translate_resume<'a>(
 
     // Preamble: Part of previously active block
 
-    let (resume_contXref, parent_stack_chain) = {
-        let resume_contXref =
-            shared::typed_continuations_cont_Xobj_get_cont_Xref(env, builder, contXobj);
+    let (resume_contref, parent_stack_chain) = {
+        let resume_contref =
+            shared::typed_continuations_cont_obj_get_cont_ref(env, builder, contobj);
 
         if resume_args.len() > 0 {
-            // We store the arguments in the `VMContXRef` to be resumed.
+            // We store the arguments in the `VMContRef` to be resumed.
             let count = builder.ins().iconst(I32, resume_args.len() as i64);
             typed_continuations_store_resume_args(
                 env,
                 builder,
                 resume_args,
                 count,
-                resume_contXref,
+                resume_contref,
             );
         }
 
@@ -1318,45 +1318,45 @@ pub(crate) fn translate_resume<'a>(
         let original_stack_chain =
             tc::VMContext::new(vmctx, env.pointer_type()).load_stack_chain(env, builder);
         original_stack_chain.assert_not_absent(env, builder);
-        tc::VMContXRef::new(resume_contXref, env.pointer_type()).set_parent_stack_chain(
+        tc::VMContRef::new(resume_contref, env.pointer_type()).set_parent_stack_chain(
             env,
             builder,
             &original_stack_chain,
         );
 
         builder.ins().jump(resume_block, &[]);
-        (resume_contXref, original_stack_chain)
+        (resume_contref, original_stack_chain)
     };
 
     // Resume block: actually resume the fiber corresponding to the
-    // `VMContXRef` given as a parameter to the block. This
+    // `VMContRef` given as a parameter to the block. This
     // parameterisation is necessary to enable forwarding, requiring us
-    // to resume objects other than `original_contXref`.
-    // We make the `VMContXRef` that was actually resumed available via
-    // `resumed_contXref`, so that subsequent blocks can refer to it.
+    // to resume objects other than `original_contref`.
+    // We make the `VMContRef` that was actually resumed available via
+    // `resumed_contref`, so that subsequent blocks can refer to it.
     let (resume_result, vm_runtime_limits_ptr) = {
         builder.switch_to_block(resume_block);
 
-        // We mark `resume_contXref` as the currently running one
+        // We mark `resume_contref` as the currently running one
         let vmctx = tc::VMContext::new(vmctx, env.pointer_type());
-        vmctx.set_active_continuation(env, builder, resume_contXref);
+        vmctx.set_active_continuation(env, builder, resume_contref);
 
-        // Note that the resume_contXref libcall a few lines further below
+        // Note that the resume_contref libcall a few lines further below
         // manipulates the stack limits as follows:
         // 1. Copy stack_limit, last_wasm_entry_sp and last_wasm_exit* values from
         // VMRuntimeLimits into the currently active continuation (i.e., the
         // one that will become the parent of the to-be-resumed one)
         //
         // 2. Copy `stack_limit` and `last_wasm_entry_sp` in the
-        // `StackLimits` of `resume_contXref` into the `VMRuntimeLimits`.
+        // `StackLimits` of `resume_contref` into the `VMRuntimeLimits`.
         //
         // See the comment on `wasmtime_continuations::StackChain` for a
         // description of the invariants that we maintain for the various stack
         // limits.
         let parent_stacks_limit_pointer = parent_stack_chain.get_stack_limits_ptr(env, builder);
 
-        // We mark `resume_contXref` to be invoked
-        let co = tc::VMContXRef::new(resume_contXref, env.pointer_type());
+        // We mark `resume_contref` to be invoked
+        let co = tc::VMContRef::new(resume_contref, env.pointer_type());
         co.set_state(builder, wasmtime_continuations::State::Invoked);
 
         call_builtin!(
@@ -1364,7 +1364,7 @@ pub(crate) fn translate_resume<'a>(
             env,
             let result =
                 tc_resume(
-                resume_contXref,
+                resume_contref,
                 parent_stacks_limit_pointer)
         );
 
@@ -1375,7 +1375,7 @@ pub(crate) fn translate_resume<'a>(
             result
         );
 
-        // Now the parent contXref (or main stack) is active again
+        // Now the parent contref (or main stack) is active again
         vmctx.store_stack_chain(env, builder, &parent_stack_chain);
 
         // The `result` is a value of type wasmtime_continuations::SwitchDirection,
@@ -1421,7 +1421,7 @@ pub(crate) fn translate_resume<'a>(
 
         // We store parts of the VMRuntimeLimits into the continuation that just suspended.
         let suspended_chain =
-            tc::StackChain::from_continuation(builder, resume_contXref, env.pointer_type());
+            tc::StackChain::from_continuation(builder, resume_contref, env.pointer_type());
         suspended_chain.load_limits_from_vmcontext(env, builder, vm_runtime_limits_ptr);
 
         // Afterwards (!), restore parts of the VMRuntimeLimits from the
@@ -1491,18 +1491,18 @@ pub(crate) fn translate_resume<'a>(
         let mut args = typed_continuations_load_payloads(env, builder, &param_types);
 
         // We have an actual handling block for this tag, rather than just
-        // forwarding. Detatch the `VMContXRef` by setting its parent
+        // forwarding. Detatch the `VMContRef` by setting its parent
         // link to `StackChain::Absent`.
         let pointer_type = env.pointer_type();
         let chain = tc::StackChain::absent(builder, pointer_type);
-        tc::VMContXRef::new(resume_contXref, pointer_type)
+        tc::VMContRef::new(resume_contref, pointer_type)
             .set_parent_stack_chain(env, builder, &chain);
 
-        // Create and push the continuation Xobject. We only create
+        // Create and push the continuation object. We only create
         // them here because we don't need them when forwarding.
-        let contXobj = env.typed_continuations_new_cont_Xobj(builder, resume_contXref);
+        let contobj = env.typed_continuations_new_cont_obj(builder, resume_contref);
 
-        args.push(contXobj);
+        args.push(contobj);
 
         // Now jump to the actual user-defined block handling
         // this tag, as given by the resumetable.
@@ -1521,7 +1521,7 @@ pub(crate) fn translate_resume<'a>(
     {
         builder.switch_to_block(forwarding_block);
 
-        let parent_contXref = parent_stack_chain.unwrap_continuation_or_trap(
+        let parent_contref = parent_stack_chain.unwrap_continuation_or_trap(
             env,
             builder,
             ir::TrapCode::UnhandledTag,
@@ -1534,14 +1534,14 @@ pub(crate) fn translate_resume<'a>(
 
         // "Tag return values" (i.e., values provided by cont.bind or
         // resume to the continuation) are actually stored in
-        // `VMContXRef`s, and we need to move them down the chain
-        // back to the `VMContXRef` where we originally
+        // `VMContRef`s, and we need to move them down the chain
+        // back to the `VMContRef` where we originally
         // suspended.
         typed_continuations_forward_tag_return_values(
             env,
             builder,
-            parent_contXref,
-            resume_contXref,
+            parent_contref,
+            resume_contref,
         );
 
         // We create a back edge to the resume block.
@@ -1577,18 +1577,18 @@ pub(crate) fn translate_resume<'a>(
         // parent of the returned continuation (which is now active).
         parent_stack_chain.write_limits_to_vmcontext(env, builder, vm_runtime_limits_ptr);
 
-        let co = tc::VMContXRef::new(resume_contXref, env.pointer_type());
+        let co = tc::VMContRef::new(resume_contref, env.pointer_type());
         co.set_state(builder, wasmtime_continuations::State::Returned);
 
         // Load and push the results.
         let returns = env.continuation_returns(type_index).to_vec();
         let values =
-            typed_continuations_load_return_values(env, builder, &returns, resume_contXref);
+            typed_continuations_load_return_values(env, builder, &returns, resume_contref);
 
-        // The continuation has returned and all `VMContXObjs`
+        // The continuation has returned and all `VMContObjs`
         // to it should have been be invalidated. We may safely deallocate
         // it.
-        shared::typed_continuations_drop_cont_Xref(env, builder, resume_contXref);
+        shared::typed_continuations_drop_cont_ref(env, builder, resume_contref);
 
         return values;
     }

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -1588,7 +1588,7 @@ pub(crate) fn translate_resume<'a>(
         // The continuation has returned and all `ContinuationReferences`
         // to it should have been be invalidated. We may safely deallocate
         // it.
-        shared::typed_continuations_drop_cont_obj(env, builder, resume_contXref);
+        shared::typed_continuations_drop_cont_Xref(env, builder, resume_contXref);
 
         return values;
     }

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -1585,7 +1585,7 @@ pub(crate) fn translate_resume<'a>(
         let values =
             typed_continuations_load_return_values(env, builder, &returns, resume_contXref);
 
-        // The continuation has returned and all `ContinuationReferences`
+        // The continuation has returned and all `VMContXObjs`
         // to it should have been be invalidated. We may safely deallocate
         // it.
         shared::typed_continuations_drop_cont_Xref(env, builder, resume_contXref);

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -1108,12 +1108,12 @@ fn typed_continuations_forward_tag_return_values<'a>(
     parent_contXref: ir::Value,
     child_contXref: ir::Value,
 ) {
-    let cont_obj_forward_tag_return_values_buffer = env
+    let cont_Xref_forward_tag_return_values_buffer = env
         .builtin_functions
-        .tc_cont_obj_forward_tag_return_values_buffer(&mut builder.func);
+        .tc_cont_Xref_forward_tag_return_values_buffer(&mut builder.func);
     let vmctx = env.vmctx_val(&mut builder.cursor());
     builder.ins().call(
-        cont_obj_forward_tag_return_values_buffer,
+        cont_Xref_forward_tag_return_values_buffer,
         &[vmctx, parent_contXref, child_contXref],
     );
 }

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -11,9 +11,9 @@ use cranelift_wasm::{FuncTranslationState, WasmResult, WasmValType};
 use wasmtime_environ::PtrSize;
 
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_cont_ref_get_cont_Xref;
+pub(crate) use shared::typed_continuations_cont_Xobj_get_cont_Xref;
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_new_cont_ref;
+pub(crate) use shared::typed_continuations_new_cont_Xobj;
 
 #[macro_use]
 pub(crate) mod typed_continuation_helpers {
@@ -1300,7 +1300,7 @@ pub(crate) fn translate_resume<'a>(
 
     let (resume_contXref, parent_stack_chain) = {
         let resume_contXref =
-            shared::typed_continuations_cont_ref_get_cont_Xref(env, builder, contref);
+            shared::typed_continuations_cont_Xobj_get_cont_Xref(env, builder, contref);
 
         if resume_args.len() > 0 {
             // We store the arguments in the `VMContRef` to be resumed.
@@ -1498,9 +1498,9 @@ pub(crate) fn translate_resume<'a>(
         tc::VMContRef::new(resume_contXref, pointer_type)
             .set_parent_stack_chain(env, builder, &chain);
 
-        // Create and push the continuation reference. We only create
+        // Create and push the continuation Xobject. We only create
         // them here because we don't need them when forwarding.
-        let contref = env.typed_continuations_new_cont_ref(builder, resume_contXref);
+        let contref = env.typed_continuations_new_cont_Xobj(builder, resume_contXref);
 
         args.push(contref);
 

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -11,7 +11,7 @@ use cranelift_wasm::{FuncTranslationState, WasmResult, WasmValType};
 use wasmtime_environ::PtrSize;
 
 #[allow(unused_imports)]
-pub(crate) use shared::typed_continuations_cont_ref_get_cont_obj;
+pub(crate) use shared::typed_continuations_cont_ref_get_cont_Xref;
 #[allow(unused_imports)]
 pub(crate) use shared::typed_continuations_new_cont_ref;
 
@@ -333,12 +333,12 @@ pub(crate) mod typed_continuation_helpers {
         }
 
         pub fn args(&self) -> Payloads {
-            let offset = wasmtime_continuations::offsets::vm_cont_ref::ARGS;
+            let offset = wasmtime_continuations::offsets::vm_cont_Xref::ARGS;
             Payloads::new(self.address, offset as i32, self.pointer_type)
         }
 
         pub fn tag_return_values(&self) -> Payloads {
-            let offset = wasmtime_continuations::offsets::vm_cont_ref::TAG_RETURN_VALUES;
+            let offset = wasmtime_continuations::offsets::vm_cont_Xref::TAG_RETURN_VALUES;
             Payloads::new(self.address, offset as i32, self.pointer_type)
         }
 
@@ -346,7 +346,7 @@ pub(crate) mod typed_continuation_helpers {
         /// which is represented using the `State` enum.
         fn load_state(&self, builder: &mut FunctionBuilder) -> ir::Value {
             let mem_flags = ir::MemFlags::trusted();
-            let offset = wasmtime_continuations::offsets::vm_cont_ref::STATE as i32;
+            let offset = wasmtime_continuations::offsets::vm_cont_Xref::STATE as i32;
 
             // Let's make sure that we still represent the State enum as i32.
             debug_assert!(mem::size_of::<wasmtime_continuations::State>() == mem::size_of::<i32>());
@@ -361,7 +361,7 @@ pub(crate) mod typed_continuation_helpers {
             state: wasmtime_continuations::State,
         ) {
             let mem_flags = ir::MemFlags::trusted();
-            let offset = wasmtime_continuations::offsets::vm_cont_ref::STATE as i32;
+            let offset = wasmtime_continuations::offsets::vm_cont_Xref::STATE as i32;
 
             // Let's make sure that we still represent the State enum as i32.
             debug_assert!(mem::size_of::<wasmtime_continuations::State>() == mem::size_of::<i32>());
@@ -419,7 +419,7 @@ pub(crate) mod typed_continuation_helpers {
             builder: &mut FunctionBuilder,
             new_stack_chain: &StackChain,
         ) {
-            let offset = wasmtime_continuations::offsets::vm_cont_ref::PARENT_CHAIN as i32;
+            let offset = wasmtime_continuations::offsets::vm_cont_Xref::PARENT_CHAIN as i32;
             new_stack_chain.store(env, builder, self.address, offset)
         }
     }
@@ -984,7 +984,7 @@ pub(crate) mod typed_continuation_helpers {
             // Since a `VMContRef` starts with an (inlined) StackLimits
             // object at offset 0, we actually have in both cases that `ptr` is
             // now the address of the beginning of a StackLimits object.
-            debug_assert_eq!(o::vm_cont_ref::LIMITS, 0);
+            debug_assert_eq!(o::vm_cont_Xref::LIMITS, 0);
             ptr
         }
 
@@ -1252,7 +1252,7 @@ pub(crate) fn typed_continuations_store_payloads<'a>(
     }
 }
 
-pub(crate) fn typed_continuations_load_continuation_object<'a>(
+pub(crate) fn typed_continuations_load_continuation_Xreference<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
 ) -> ir::Value {
@@ -1300,7 +1300,7 @@ pub(crate) fn translate_resume<'a>(
 
     let (resume_contXref, parent_stack_chain) = {
         let resume_contXref =
-            shared::typed_continuations_cont_ref_get_cont_obj(env, builder, contref);
+            shared::typed_continuations_cont_ref_get_cont_Xref(env, builder, contref);
 
         if resume_args.len() > 0 {
             // We store the arguments in the `VMContRef` to be resumed.

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -371,7 +371,7 @@ pub(crate) mod typed_continuation_helpers {
         }
 
         /// Checks whether the `VMContRef` is invoked (i.e., `resume`
-        /// was called at least once on the object).
+        /// was called at least once on the continuation).
         pub fn is_invoked(&self, builder: &mut FunctionBuilder) -> ir::Value {
             // TODO(frank-emrich) In the future, we may get rid of the State field
             // in `VMContRef` and try to infer the state by other means.
@@ -976,9 +976,9 @@ pub(crate) mod typed_continuation_helpers {
             let ptr = self.payload;
 
             // `obj` is now a pointer to the beginning of either
-            // 1. A `VMContRef` object (in the case of a
+            // 1. A `VMContRef` struct (in the case of a
             // StackChain::Continuation)
-            // 2. A StackLimits object (in the case of
+            // 2. A StackLimits struct (in the case of
             // StackChain::MainStack)
             //
             // Since a `VMContRef` starts with an (inlined) StackLimits

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -1305,13 +1305,7 @@ pub(crate) fn translate_resume<'a>(
         if resume_args.len() > 0 {
             // We store the arguments in the `VMContRef` to be resumed.
             let count = builder.ins().iconst(I32, resume_args.len() as i64);
-            typed_continuations_store_resume_args(
-                env,
-                builder,
-                resume_args,
-                count,
-                resume_contref,
-            );
+            typed_continuations_store_resume_args(env, builder, resume_args, count, resume_contref);
         }
 
         // Make the currently running continuation (if any) the parent of the one we are about to resume.
@@ -1537,12 +1531,7 @@ pub(crate) fn translate_resume<'a>(
         // `VMContRef`s, and we need to move them down the chain
         // back to the `VMContRef` where we originally
         // suspended.
-        typed_continuations_forward_tag_return_values(
-            env,
-            builder,
-            parent_contref,
-            resume_contref,
-        );
+        typed_continuations_forward_tag_return_values(env, builder, parent_contref, resume_contref);
 
         // We create a back edge to the resume block.
         // Note that both `resume_cotobj` and `parent_stack_chain` remain unchanged:
@@ -1582,8 +1571,7 @@ pub(crate) fn translate_resume<'a>(
 
         // Load and push the results.
         let returns = env.continuation_returns(type_index).to_vec();
-        let values =
-            typed_continuations_load_return_values(env, builder, &returns, resume_contref);
+        let values = typed_continuations_load_return_values(env, builder, &returns, resume_contref);
 
         // The continuation has returned and all `VMContObjs`
         // to it should have been be invalidated. We may safely deallocate

--- a/crates/cranelift/src/wasmfx/shared.rs
+++ b/crates/cranelift/src/wasmfx/shared.rs
@@ -15,7 +15,7 @@ pub(crate) fn typed_continuations_cont_ref_get_cont_obj<'a>(
     } else {
         let cont_ref_get_cont_obj = env
             .builtin_functions
-            .tc_cont_ref_get_cont_obj(&mut builder.func);
+            .tc_cont_ref_get_cont_Xref(&mut builder.func);
         let vmctx = env.vmctx_val(&mut builder.cursor());
         let call_inst = builder.ins().call(cont_ref_get_cont_obj, &[vmctx, contref]);
         let result = *builder.func.dfg.inst_results(call_inst).first().unwrap();

--- a/crates/cranelift/src/wasmfx/shared.rs
+++ b/crates/cranelift/src/wasmfx/shared.rs
@@ -10,7 +10,7 @@ pub(crate) fn typed_continuations_cont_ref_get_cont_obj<'a>(
     contref: ir::Value,
 ) -> ir::Value {
     if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
-        // The "contref" is a contobj already
+        // The "contref" is a contXref already
         return contref;
     } else {
         let cont_ref_get_cont_obj = env
@@ -26,14 +26,14 @@ pub(crate) fn typed_continuations_cont_ref_get_cont_obj<'a>(
 pub(crate) fn typed_continuations_new_cont_ref<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    contobj_addr: ir::Value,
+    contXref_addr: ir::Value,
 ) -> ir::Value {
     if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
-        return contobj_addr;
+        return contXref_addr;
     } else {
         let new_cont_ref = env.builtin_functions.tc_new_cont_ref(&mut builder.func);
         let vmctx = env.vmctx_val(&mut builder.cursor());
-        let call_inst = builder.ins().call(new_cont_ref, &[vmctx, contobj_addr]);
+        let call_inst = builder.ins().call(new_cont_ref, &[vmctx, contXref_addr]);
         let result = *builder.func.dfg.inst_results(call_inst).first().unwrap();
         return result;
     }
@@ -43,9 +43,9 @@ pub(crate) fn typed_continuations_new_cont_ref<'a>(
 pub(crate) fn typed_continuations_drop_cont_obj<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    contobj: ir::Value,
+    contXref: ir::Value,
 ) {
     let cont_drop_obj = env.builtin_functions.tc_drop_cont_obj(&mut builder.func);
     let vmctx = env.vmctx_val(&mut builder.cursor());
-    builder.ins().call(cont_drop_obj, &[vmctx, contobj]);
+    builder.ins().call(cont_drop_obj, &[vmctx, contXref]);
 }

--- a/crates/cranelift/src/wasmfx/shared.rs
+++ b/crates/cranelift/src/wasmfx/shared.rs
@@ -50,10 +50,10 @@ pub(crate) fn typed_continuations_new_cont_ref<'a>(
 }
 
 /// TODO
-pub(crate) fn typed_continuations_drop_cont_obj<'a>(
+pub(crate) fn typed_continuations_drop_cont_Xref<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     contXref: ir::Value,
 ) {
-    call_builtin!(builder, env, tc_drop_cont_obj(contXref));
+    call_builtin!(builder, env, tc_drop_cont_Xref(contXref));
 }

--- a/crates/cranelift/src/wasmfx/shared.rs
+++ b/crates/cranelift/src/wasmfx/shared.rs
@@ -22,38 +22,38 @@ macro_rules! call_builtin {
 pub(crate) use call_builtin;
 
 /// TODO
-pub(crate) fn typed_continuations_cont_Xobj_get_cont_Xref<'a>(
+pub(crate) fn typed_continuations_cont_obj_get_cont_ref<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    contXobj: ir::Value,
+    contobj: ir::Value,
 ) -> ir::Value {
     if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
-        // The "contXobj" is a contXref already
-        return contXobj;
+        // The "contobj" is a contref already
+        return contobj;
     } else {
-        call_builtin!(builder, env, let result = tc_cont_Xobj_get_cont_Xref(contXobj));
+        call_builtin!(builder, env, let result = tc_cont_obj_get_cont_ref(contobj));
         return result;
     }
 }
 
-pub(crate) fn typed_continuations_new_cont_Xobj<'a>(
+pub(crate) fn typed_continuations_new_cont_obj<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    contXref_addr: ir::Value,
+    contref_addr: ir::Value,
 ) -> ir::Value {
     if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
-        return contXref_addr;
+        return contref_addr;
     } else {
-        call_builtin!(builder, env, let result = tc_new_cont_Xobj(contXref_addr));
+        call_builtin!(builder, env, let result = tc_new_cont_obj(contref_addr));
         return result;
     }
 }
 
 /// TODO
-pub(crate) fn typed_continuations_drop_cont_Xref<'a>(
+pub(crate) fn typed_continuations_drop_cont_ref<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    contXref: ir::Value,
+    contref: ir::Value,
 ) {
-    call_builtin!(builder, env, tc_drop_cont_Xref(contXref));
+    call_builtin!(builder, env, tc_drop_cont_ref(contref));
 }

--- a/crates/cranelift/src/wasmfx/shared.rs
+++ b/crates/cranelift/src/wasmfx/shared.rs
@@ -25,13 +25,13 @@ pub(crate) use call_builtin;
 pub(crate) fn typed_continuations_cont_Xobj_get_cont_Xref<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    contref: ir::Value,
+    contXobj: ir::Value,
 ) -> ir::Value {
     if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
-        // The "contref" is a contXref already
-        return contref;
+        // The "contXobj" is a contXref already
+        return contXobj;
     } else {
-        call_builtin!(builder, env, let result = tc_cont_Xobj_get_cont_Xref(contref));
+        call_builtin!(builder, env, let result = tc_cont_Xobj_get_cont_Xref(contXobj));
         return result;
     }
 }

--- a/crates/cranelift/src/wasmfx/shared.rs
+++ b/crates/cranelift/src/wasmfx/shared.rs
@@ -22,7 +22,7 @@ macro_rules! call_builtin {
 pub(crate) use call_builtin;
 
 /// TODO
-pub(crate) fn typed_continuations_cont_ref_get_cont_obj<'a>(
+pub(crate) fn typed_continuations_cont_ref_get_cont_Xref<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     contref: ir::Value,

--- a/crates/cranelift/src/wasmfx/shared.rs
+++ b/crates/cranelift/src/wasmfx/shared.rs
@@ -22,7 +22,7 @@ macro_rules! call_builtin {
 pub(crate) use call_builtin;
 
 /// TODO
-pub(crate) fn typed_continuations_cont_ref_get_cont_Xref<'a>(
+pub(crate) fn typed_continuations_cont_Xobj_get_cont_Xref<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     contref: ir::Value,
@@ -31,12 +31,12 @@ pub(crate) fn typed_continuations_cont_ref_get_cont_Xref<'a>(
         // The "contref" is a contXref already
         return contref;
     } else {
-        call_builtin!(builder, env, let result = tc_cont_ref_get_cont_Xref(contref));
+        call_builtin!(builder, env, let result = tc_cont_Xobj_get_cont_Xref(contref));
         return result;
     }
 }
 
-pub(crate) fn typed_continuations_new_cont_ref<'a>(
+pub(crate) fn typed_continuations_new_cont_Xobj<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     contXref_addr: ir::Value,
@@ -44,7 +44,7 @@ pub(crate) fn typed_continuations_new_cont_ref<'a>(
     if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
         return contXref_addr;
     } else {
-        call_builtin!(builder, env, let result = tc_new_cont_ref(contXref_addr));
+        call_builtin!(builder, env, let result = tc_new_cont_Xobj(contXref_addr));
         return result;
     }
 }

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -96,12 +96,12 @@ macro_rules! foreach_builtin_function {
             tc_resume(vmctx: vmctx, contXref: pointer, parent_stack_limits: pointer) -> i64;
             // Suspends a continuation.
             tc_suspend(vmctx: vmctx, tag: i32);
-            // Returns the continuation Xreference corresponding to the given continuation reference.
-            tc_cont_ref_get_cont_Xref(vmctx: vmctx, contref: pointer) -> pointer;
+            // Returns the continuation Xreference corresponding to the given continuation Xobject.
+            tc_cont_Xobj_get_cont_Xref(vmctx: vmctx, contref: pointer) -> pointer;
             // Drops the given continuation Xreference. Currently unused.
             //cont_Xref_drop(vmctx: vmctx, contXref: pointer);
-            // Creates a new continuation reference.
-            tc_new_cont_ref(vmctx: vmctx, contXref: pointer) -> pointer;
+            // Creates a new continuation Xobject.
+            tc_new_cont_Xobj(vmctx: vmctx, contXref: pointer) -> pointer;
 
 
             // Sets the tag return values of `child_contXref` to those of `parent_contXref`.
@@ -136,7 +136,7 @@ macro_rules! foreach_builtin_function {
             // Baseline cont.new
             tc_baseline_cont_new(vmctx: vmctx, r: pointer, param_count: i64, result_count: i64) -> pointer;
             // Baseline continuation drop
-            tc_baseline_drop_continuation_reference(vmctx: vmctx, r: pointer);
+            tc_baseline_drop_continuation_Xobject(vmctx: vmctx, r: pointer);
             // Baseline continuation arguments pointer
             tc_baseline_continuation_arguments_ptr(vmctx: vmctx, r: pointer, nargs: i64) -> pointer;
             // Baseline continuation values pointer

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -97,7 +97,7 @@ macro_rules! foreach_builtin_function {
             // Suspends a continuation.
             tc_suspend(vmctx: vmctx, tag: i32);
             // Returns the continuation Xreference corresponding to the given continuation Xobject.
-            tc_cont_Xobj_get_cont_Xref(vmctx: vmctx, contref: pointer) -> pointer;
+            tc_cont_Xobj_get_cont_Xref(vmctx: vmctx, contXobj: pointer) -> pointer;
             // Drops the given continuation Xreference. Currently unused.
             //cont_Xref_drop(vmctx: vmctx, contXref: pointer);
             // Creates a new continuation Xobject.

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -128,7 +128,7 @@ macro_rules! foreach_builtin_function {
 
             // TC baseline
             // Baseline resume
-            tc_baseline_resume(vmctx: vmctx, contref: pointer) -> i32;
+            tc_baseline_resume(vmctx: vmctx, contobj: pointer) -> i32;
             // Baseline suspend
             tc_baseline_suspend(vmctx: vmctx, tag: i32);
             // Like suspend, but forwards handling.
@@ -136,7 +136,7 @@ macro_rules! foreach_builtin_function {
             // Baseline cont.new
             tc_baseline_cont_new(vmctx: vmctx, r: pointer, param_count: i64, result_count: i64) -> pointer;
             // Baseline continuation drop
-            tc_baseline_drop_continuation_object(vmctx: vmctx, r: pointer);
+            tc_baseline_drop_continuation_reference(vmctx: vmctx, r: pointer);
             // Baseline continuation arguments pointer
             tc_baseline_continuation_arguments_ptr(vmctx: vmctx, r: pointer, nargs: i64) -> pointer;
             // Baseline continuation values pointer

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -93,25 +93,25 @@ macro_rules! foreach_builtin_function {
             tc_cont_new(vmctx: vmctx, r: pointer, param_count: i32, result_count: i32) -> pointer;
             // Resumes a continuation. The result value is of type
             // wasmtime_continuations::SwitchDirection.
-            tc_resume(vmctx: vmctx, contobj: pointer, parent_stack_limits: pointer) -> i64;
+            tc_resume(vmctx: vmctx, contXref: pointer, parent_stack_limits: pointer) -> i64;
             // Suspends a continuation.
             tc_suspend(vmctx: vmctx, tag: i32);
             // Returns the continuation object corresponding to the given continuation reference.
             tc_cont_ref_get_cont_obj(vmctx: vmctx, contref: pointer) -> pointer;
             // Drops the given continuation object. Currently unused.
-            //cont_obj_drop(vmctx: vmctx, contobj: pointer);
+            //cont_obj_drop(vmctx: vmctx, contXref: pointer);
             // Creates a new continuation reference.
-            tc_new_cont_ref(vmctx: vmctx, contobj: pointer) -> pointer;
+            tc_new_cont_ref(vmctx: vmctx, contXref: pointer) -> pointer;
 
 
-            // Sets the tag return values of `child_contobj` to those of `parent_contobj`.
+            // Sets the tag return values of `child_contXref` to those of `parent_contXref`.
             // This is implemented by exchanging the pointers to the underlying buffers.
-            // `child_contobj` must not currently have a tag return value buffer.
-            // `parent_contobj` may or may not have one.
-            tc_cont_obj_forward_tag_return_values_buffer(vmctx: vmctx, parent_contobj: pointer, child_contobj : pointer);
+            // `child_contXref` must not currently have a tag return value buffer.
+            // `parent_contXref` may or may not have one.
+            tc_cont_obj_forward_tag_return_values_buffer(vmctx: vmctx, parent_contXref: pointer, child_contXref : pointer);
 
             // TODO
-            tc_drop_cont_obj(vmctx: vmctx, contobj: pointer);
+            tc_drop_cont_obj(vmctx: vmctx, contXref: pointer);
 
             // General-purpose allocation. Only used by typed-continuations
             // code at the moment.
@@ -128,7 +128,7 @@ macro_rules! foreach_builtin_function {
 
             // TC baseline
             // Baseline resume
-            tc_baseline_resume(vmctx: vmctx, contobj: pointer) -> i32;
+            tc_baseline_resume(vmctx: vmctx, contXref: pointer) -> i32;
             // Baseline suspend
             tc_baseline_suspend(vmctx: vmctx, tag: i32);
             // Like suspend, but forwards handling.

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -99,7 +99,7 @@ macro_rules! foreach_builtin_function {
             // Returns the continuation object corresponding to the given continuation reference.
             tc_cont_ref_get_cont_obj(vmctx: vmctx, contref: pointer) -> pointer;
             // Drops the given continuation object. Currently unused.
-            //cont_obj_drop(vmctx: vmctx, contXref: pointer);
+            //cont_Xref_drop(vmctx: vmctx, contXref: pointer);
             // Creates a new continuation reference.
             tc_new_cont_ref(vmctx: vmctx, contXref: pointer) -> pointer;
 
@@ -108,7 +108,7 @@ macro_rules! foreach_builtin_function {
             // This is implemented by exchanging the pointers to the underlying buffers.
             // `child_contXref` must not currently have a tag return value buffer.
             // `parent_contXref` may or may not have one.
-            tc_cont_obj_forward_tag_return_values_buffer(vmctx: vmctx, parent_contXref: pointer, child_contXref : pointer);
+            tc_cont_Xref_forward_tag_return_values_buffer(vmctx: vmctx, parent_contXref: pointer, child_contXref : pointer);
 
             // TODO
             tc_drop_cont_obj(vmctx: vmctx, contXref: pointer);

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -128,7 +128,7 @@ macro_rules! foreach_builtin_function {
 
             // TC baseline
             // Baseline resume
-            tc_baseline_resume(vmctx: vmctx, contobj: pointer) -> i32;
+            tc_baseline_resume(vmctx: vmctx, contref: pointer) -> i32;
             // Baseline suspend
             tc_baseline_suspend(vmctx: vmctx, tag: i32);
             // Like suspend, but forwards handling.

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -93,25 +93,25 @@ macro_rules! foreach_builtin_function {
             tc_cont_new(vmctx: vmctx, r: pointer, param_count: i32, result_count: i32) -> pointer;
             // Resumes a continuation. The result value is of type
             // wasmtime_continuations::SwitchDirection.
-            tc_resume(vmctx: vmctx, contXref: pointer, parent_stack_limits: pointer) -> i64;
+            tc_resume(vmctx: vmctx, contref: pointer, parent_stack_limits: pointer) -> i64;
             // Suspends a continuation.
             tc_suspend(vmctx: vmctx, tag: i32);
-            // Returns the continuation Xreference corresponding to the given continuation Xobject.
-            tc_cont_Xobj_get_cont_Xref(vmctx: vmctx, contXobj: pointer) -> pointer;
-            // Drops the given continuation Xreference. Currently unused.
-            //cont_Xref_drop(vmctx: vmctx, contXref: pointer);
-            // Creates a new continuation Xobject.
-            tc_new_cont_Xobj(vmctx: vmctx, contXref: pointer) -> pointer;
+            // Returns the continuation reference corresponding to the given continuation object.
+            tc_cont_obj_get_cont_ref(vmctx: vmctx, contobj: pointer) -> pointer;
+            // Drops the given continuation reference. Currently unused.
+            //cont_ref_drop(vmctx: vmctx, contref: pointer);
+            // Creates a new continuation object.
+            tc_new_cont_obj(vmctx: vmctx, contref: pointer) -> pointer;
 
 
-            // Sets the tag return values of `child_contXref` to those of `parent_contXref`.
+            // Sets the tag return values of `child_contref` to those of `parent_contref`.
             // This is implemented by exchanging the pointers to the underlying buffers.
-            // `child_contXref` must not currently have a tag return value buffer.
-            // `parent_contXref` may or may not have one.
-            tc_cont_Xref_forward_tag_return_values_buffer(vmctx: vmctx, parent_contXref: pointer, child_contXref : pointer);
+            // `child_contref` must not currently have a tag return value buffer.
+            // `parent_contref` may or may not have one.
+            tc_cont_ref_forward_tag_return_values_buffer(vmctx: vmctx, parent_contref: pointer, child_contref : pointer);
 
             // TODO
-            tc_drop_cont_Xref(vmctx: vmctx, contXref: pointer);
+            tc_drop_cont_ref(vmctx: vmctx, contref: pointer);
 
             // General-purpose allocation. Only used by typed-continuations
             // code at the moment.
@@ -128,7 +128,7 @@ macro_rules! foreach_builtin_function {
 
             // TC baseline
             // Baseline resume
-            tc_baseline_resume(vmctx: vmctx, contXref: pointer) -> i32;
+            tc_baseline_resume(vmctx: vmctx, contref: pointer) -> i32;
             // Baseline suspend
             tc_baseline_suspend(vmctx: vmctx, tag: i32);
             // Like suspend, but forwards handling.
@@ -136,7 +136,7 @@ macro_rules! foreach_builtin_function {
             // Baseline cont.new
             tc_baseline_cont_new(vmctx: vmctx, r: pointer, param_count: i64, result_count: i64) -> pointer;
             // Baseline continuation drop
-            tc_baseline_drop_continuation_Xobject(vmctx: vmctx, r: pointer);
+            tc_baseline_drop_continuation_object(vmctx: vmctx, r: pointer);
             // Baseline continuation arguments pointer
             tc_baseline_continuation_arguments_ptr(vmctx: vmctx, r: pointer, nargs: i64) -> pointer;
             // Baseline continuation values pointer

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -97,7 +97,7 @@ macro_rules! foreach_builtin_function {
             // Suspends a continuation.
             tc_suspend(vmctx: vmctx, tag: i32);
             // Returns the continuation object corresponding to the given continuation reference.
-            tc_cont_ref_get_cont_obj(vmctx: vmctx, contref: pointer) -> pointer;
+            tc_cont_ref_get_cont_Xref(vmctx: vmctx, contref: pointer) -> pointer;
             // Drops the given continuation object. Currently unused.
             //cont_Xref_drop(vmctx: vmctx, contXref: pointer);
             // Creates a new continuation reference.

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -111,7 +111,7 @@ macro_rules! foreach_builtin_function {
             tc_cont_Xref_forward_tag_return_values_buffer(vmctx: vmctx, parent_contXref: pointer, child_contXref : pointer);
 
             // TODO
-            tc_drop_cont_obj(vmctx: vmctx, contXref: pointer);
+            tc_drop_cont_Xref(vmctx: vmctx, contXref: pointer);
 
             // General-purpose allocation. Only used by typed-continuations
             // code at the moment.

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -96,9 +96,9 @@ macro_rules! foreach_builtin_function {
             tc_resume(vmctx: vmctx, contXref: pointer, parent_stack_limits: pointer) -> i64;
             // Suspends a continuation.
             tc_suspend(vmctx: vmctx, tag: i32);
-            // Returns the continuation object corresponding to the given continuation reference.
+            // Returns the continuation Xreference corresponding to the given continuation reference.
             tc_cont_ref_get_cont_Xref(vmctx: vmctx, contref: pointer) -> pointer;
-            // Drops the given continuation object. Currently unused.
+            // Drops the given continuation Xreference. Currently unused.
             //cont_Xref_drop(vmctx: vmctx, contXref: pointer);
             // Creates a new continuation reference.
             tc_new_cont_ref(vmctx: vmctx, contXref: pointer) -> pointer;

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -194,7 +194,7 @@ pub struct ContinuationReference(pub Option<*mut VMContRef>);
 
 /// TODO
 #[inline(always)]
-pub fn cont_ref_get_cont_Xref(
+pub fn cont_Xobj_get_cont_Xref(
     contref: *mut ContinuationReference,
 ) -> Result<*mut VMContRef, TrapReason> {
     //FIXME rename to indicate that this invalidates the cont ref
@@ -257,7 +257,7 @@ pub fn cont_Xref_forward_tag_return_values_buffer(
 
 /// TODO
 #[inline(always)]
-pub fn new_cont_ref(contXref: *mut VMContRef) -> *mut ContinuationReference {
+pub fn new_cont_Xobj(contXref: *mut VMContRef) -> *mut ContinuationReference {
     // If this is enabled, we should never call this function.
     assert!(!cfg!(
         feature = "unsafe_disable_continuation_linearity_check"
@@ -345,7 +345,7 @@ pub fn cont_new(
     });
 
     // TODO(dhil): we need memory clean up of
-    // continuation reference objects.
+    // continuation Xobject objects.
     let pointer = Box::into_raw(contXref);
     debug_println!("Created contXref @ {:p}", pointer);
     Ok(pointer)
@@ -551,7 +551,7 @@ pub mod baseline {
         });
 
         // TODO(dhil): we need memory clean up of
-        // continuation reference objects.
+        // continuation Xobject objects.
         debug_assert!(!contref.fiber.stack().top().unwrap().is_null());
         Ok(Box::into_raw(contref))
     }
@@ -640,9 +640,9 @@ pub mod baseline {
         Ok(())
     }
 
-    /// Deallocates a gives continuation reference.
+    /// Deallocates a gives continuation Xobject.
     #[inline(always)]
-    pub fn drop_continuation_reference(_instance: &mut Instance, contref: *mut VMContRef) {
+    pub fn drop_continuation_Xobject(_instance: &mut Instance, contref: *mut VMContRef) {
         // Note that continuation Xreferences do not own their parents, so
         // we let the parent object leak.
         let contref: Box<VMContRef> = unsafe { Box::from_raw(contref) };
@@ -651,14 +651,14 @@ pub mod baseline {
         let _: Vec<u128> = contref.values;
     }
 
-    /// Clears the argument buffer on a given continuation reference.
+    /// Clears the argument buffer on a given continuation Xobject.
     #[inline(always)]
     pub fn clear_arguments(_instance: &mut Instance, contref: &mut VMContRef) {
         contref.args.clear();
     }
 
     /// Returns the pointer to the argument buffer of a given
-    /// continuation reference.
+    /// continuation Xobject.
     #[inline(always)]
     pub fn get_arguments_ptr(
         _instance: &mut Instance,
@@ -677,7 +677,7 @@ pub mod baseline {
     }
 
     /// Returns the pointer to the (return) values buffer of a given
-    /// continuation reference.
+    /// continuation Xobject.
     #[inline(always)]
     pub fn get_values_ptr(_instance: &mut Instance, contref: &mut VMContRef) -> *mut u128 {
         contref.values.as_mut_ptr()
@@ -783,8 +783,8 @@ pub mod baseline {
 
     #[inline(always)]
     #[allow(missing_docs)]
-    pub fn drop_continuation_reference(_instance: &mut Instance, _cont: *mut VMContRef) {
-        panic!("attempt to execute continuation::baseline::drop_continuation_reference without `typed_continuation_baseline_implementation` toggled!")
+    pub fn drop_continuation_Xobject(_instance: &mut Instance, _cont: *mut VMContRef) {
+        panic!("attempt to execute continuation::baseline::drop_continuation_Xobject without `typed_continuation_baseline_implementation` toggled!")
     }
 
     #[inline(always)]

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -186,17 +186,15 @@ pub struct VMContXRef {
 }
 
 /// M:1 Many-to-one mapping. A single ContinuationObject may be
-/// referenced by multiple ContinuationReference, though, only one
-/// ContinuationReference may hold a non-null reference to the object
+/// referenced by multiple VMContXObj, though, only one
+/// VMContXObj may hold a non-null reference to the object
 /// at a given time.
 #[repr(C)]
-pub struct ContinuationReference(pub Option<*mut VMContXRef>);
+pub struct VMContXObj(pub Option<*mut VMContXRef>);
 
 /// TODO
 #[inline(always)]
-pub fn cont_Xobj_get_cont_Xref(
-    contXobj: *mut ContinuationReference,
-) -> Result<*mut VMContXRef, TrapReason> {
+pub fn cont_Xobj_get_cont_Xref(contXobj: *mut VMContXObj) -> Result<*mut VMContXRef, TrapReason> {
     //FIXME rename to indicate that this invalidates the cont ref
 
     // If this is enabled, we should never call this function.
@@ -209,7 +207,7 @@ pub fn cont_Xobj_get_cont_Xref(
             .as_mut()
             .ok_or_else(|| {
                 TrapReason::user_without_backtrace(anyhow::anyhow!(
-                    "Attempt to dereference null ContinuationReference!"
+                    "Attempt to dereference null VMContXObj!"
                 ))
             })?
             .0
@@ -221,7 +219,7 @@ pub fn cont_Xobj_get_cont_Xref(
         // we always read from a non-null reference.
         Some(contXref) => {
             unsafe {
-                *contXobj = ContinuationReference(None);
+                *contXobj = VMContXObj(None);
             }
             Ok(contXref.cast::<VMContXRef>())
         }
@@ -257,13 +255,13 @@ pub fn cont_Xref_forward_tag_return_values_buffer(
 
 /// TODO
 #[inline(always)]
-pub fn new_cont_Xobj(contXref: *mut VMContXRef) -> *mut ContinuationReference {
+pub fn new_cont_Xobj(contXref: *mut VMContXRef) -> *mut VMContXObj {
     // If this is enabled, we should never call this function.
     assert!(!cfg!(
         feature = "unsafe_disable_continuation_linearity_check"
     ));
 
-    let contXobj = Box::new(ContinuationReference(Some(contXref)));
+    let contXobj = Box::new(VMContXObj(Some(contXref)));
     Box::into_raw(contXobj)
 }
 

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -194,7 +194,7 @@ pub struct ContinuationReference(pub Option<*mut VMContRef>);
 
 /// TODO
 #[inline(always)]
-pub fn cont_ref_get_cont_obj(
+pub fn cont_ref_get_cont_Xref(
     contref: *mut ContinuationReference,
 ) -> Result<*mut VMContRef, TrapReason> {
     //FIXME rename to indicate that this invalidates the cont ref
@@ -270,7 +270,7 @@ pub fn new_cont_ref(contXref: *mut VMContRef) -> *mut ContinuationReference {
 /// TODO
 #[inline(always)]
 pub fn drop_cont_obj(contXref: *mut VMContRef) {
-    // Note that continuation objects do not own their parents, hence we ignore
+    // Note that continuation Xreferences do not own their parents, hence we ignore
     // parent fields here.
 
     let contXref: Box<VMContRef> = unsafe { Box::from_raw(contXref) };
@@ -643,7 +643,7 @@ pub mod baseline {
     /// Deallocates a gives continuation reference.
     #[inline(always)]
     pub fn drop_continuation_reference(_instance: &mut Instance, contref: *mut VMContRef) {
-        // Note that continuation objects do not own their parents, so
+        // Note that continuation Xreferences do not own their parents, so
         // we let the parent object leak.
         let contref: Box<VMContRef> = unsafe { Box::from_raw(contref) };
         let _: Box<ContinuationFiber> = contref.fiber;
@@ -841,28 +841,19 @@ fn offset_and_size_constants() {
 
     assert_eq!(
         memoffset::offset_of!(VMContRef, limits),
-        continuation_object::LIMITS
+        vm_cont_Xref::LIMITS
     );
     assert_eq!(
         memoffset::offset_of!(VMContRef, parent_chain),
-        continuation_object::PARENT_CHAIN
+        vm_cont_Xref::PARENT_CHAIN
     );
-    assert_eq!(
-        memoffset::offset_of!(VMContRef, fiber),
-        continuation_object::FIBER
-    );
-    assert_eq!(
-        memoffset::offset_of!(VMContRef, args),
-        continuation_object::ARGS
-    );
+    assert_eq!(memoffset::offset_of!(VMContRef, fiber), vm_cont_Xref::FIBER);
+    assert_eq!(memoffset::offset_of!(VMContRef, args), vm_cont_Xref::ARGS);
     assert_eq!(
         memoffset::offset_of!(VMContRef, tag_return_values),
-        continuation_object::TAG_RETURN_VALUES
+        vm_cont_Xref::TAG_RETURN_VALUES
     );
-    assert_eq!(
-        memoffset::offset_of!(VMContRef, state),
-        continuation_object::STATE
-    );
+    assert_eq!(memoffset::offset_of!(VMContRef, state), vm_cont_Xref::STATE);
 
     assert_eq!(
         std::mem::size_of::<ContinuationFiber>(),

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -269,7 +269,7 @@ pub fn new_cont_ref(contXref: *mut VMContRef) -> *mut ContinuationReference {
 
 /// TODO
 #[inline(always)]
-pub fn drop_cont_obj(contXref: *mut VMContRef) {
+pub fn drop_cont_Xref(contXref: *mut VMContRef) {
     // Note that continuation Xreferences do not own their parents, hence we ignore
     // parent fields here.
 

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -87,8 +87,7 @@ pub enum StackChain {
     /// Represents the main stack.
     MainStack(*mut StackLimits) = wasmtime_continuations::STACK_CHAIN_MAIN_STACK_DISCRIMINANT,
     /// Represents a continuation's stack.
-    Continuation(*mut VMContRef) =
-        wasmtime_continuations::STACK_CHAIN_CONTINUATION_DISCRIMINANT,
+    Continuation(*mut VMContRef) = wasmtime_continuations::STACK_CHAIN_CONTINUATION_DISCRIMINANT,
 }
 
 impl StackChain {
@@ -230,7 +229,7 @@ pub fn cont_ref_get_cont_obj(
 }
 
 /// TODO
-pub fn cont_obj_forward_tag_return_values_buffer(
+pub fn cont_Xref_forward_tag_return_values_buffer(
     parent: *mut VMContRef,
     child: *mut VMContRef,
 ) -> Result<(), TrapReason> {

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -343,7 +343,7 @@ pub fn cont_new(
     });
 
     // TODO(dhil): we need memory clean up of
-    // continuation object objects.
+    // continuation reference objects.
     let pointer = Box::into_raw(contref);
     debug_println!("Created contref @ {:p}", pointer);
     Ok(pointer)

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -769,12 +769,12 @@ fn tc_cont_new(
 
 fn tc_resume(
     instance: &mut Instance,
-    contobj: *mut u8,
+    contXref: *mut u8,
     parent_stack_limits: *mut u8,
 ) -> Result<u64, TrapReason> {
     crate::continuation::resume(
         instance,
-        contobj.cast::<crate::continuation::VMContRef>(),
+        contXref.cast::<crate::continuation::VMContRef>(),
         parent_stack_limits.cast::<crate::continuation::StackLimits>(),
     )
     .map(|reason| reason.into())
@@ -784,8 +784,8 @@ fn tc_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason>
     crate::continuation::suspend(instance, tag_index)
 }
 
-fn tc_new_cont_ref(_instance: &mut Instance, contobj: *mut u8) -> *mut u8 {
-    crate::continuation::new_cont_ref(contobj.cast::<crate::continuation::VMContRef>())
+fn tc_new_cont_ref(_instance: &mut Instance, contXref: *mut u8) -> *mut u8 {
+    crate::continuation::new_cont_ref(contXref.cast::<crate::continuation::VMContRef>())
         .cast::<u8>()
 }
 
@@ -801,17 +801,17 @@ fn tc_cont_ref_get_cont_obj(
 
 fn tc_cont_obj_forward_tag_return_values_buffer(
     _instance: &mut Instance,
-    parent_contobj: *mut u8,
-    child_contobj: *mut u8,
+    parent_contXref: *mut u8,
+    child_contXref: *mut u8,
 ) -> Result<(), TrapReason> {
     crate::continuation::cont_obj_forward_tag_return_values_buffer(
-        parent_contobj.cast::<crate::continuation::VMContRef>(),
-        child_contobj.cast::<crate::continuation::VMContRef>(),
+        parent_contXref.cast::<crate::continuation::VMContRef>(),
+        child_contXref.cast::<crate::continuation::VMContRef>(),
     )
 }
 
-fn tc_drop_cont_obj(_instance: &mut Instance, contobj: *mut u8) {
-    crate::continuation::drop_cont_obj(contobj.cast::<crate::continuation::VMContRef>())
+fn tc_drop_cont_obj(_instance: &mut Instance, contXref: *mut u8) {
+    crate::continuation::drop_cont_obj(contXref.cast::<crate::continuation::VMContRef>())
 }
 
 fn tc_allocate(_instance: &mut Instance, size: u64, align: u64) -> Result<*mut u8, TrapReason> {

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -769,12 +769,12 @@ fn tc_cont_new(
 
 fn tc_resume(
     instance: &mut Instance,
-    contXref: *mut u8,
+    contref: *mut u8,
     parent_stack_limits: *mut u8,
 ) -> Result<u64, TrapReason> {
     crate::continuation::resume(
         instance,
-        contXref.cast::<crate::continuation::VMContXRef>(),
+        contref.cast::<crate::continuation::VMContRef>(),
         parent_stack_limits.cast::<crate::continuation::StackLimits>(),
     )
     .map(|reason| reason.into())
@@ -784,34 +784,33 @@ fn tc_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason>
     crate::continuation::suspend(instance, tag_index)
 }
 
-fn tc_new_cont_Xobj(_instance: &mut Instance, contXref: *mut u8) -> *mut u8 {
-    crate::continuation::new_cont_Xobj(contXref.cast::<crate::continuation::VMContXRef>())
-        .cast::<u8>()
+fn tc_new_cont_obj(_instance: &mut Instance, contref: *mut u8) -> *mut u8 {
+    crate::continuation::new_cont_obj(contref.cast::<crate::continuation::VMContRef>()).cast::<u8>()
 }
 
-fn tc_cont_Xobj_get_cont_Xref(
+fn tc_cont_obj_get_cont_ref(
     _instance: &mut Instance,
-    contXobj: *mut u8,
+    contobj: *mut u8,
 ) -> Result<*mut u8, TrapReason> {
-    let ans = crate::continuation::cont_Xobj_get_cont_Xref(
-        contXobj.cast::<crate::continuation::VMContXObj>(),
+    let ans = crate::continuation::cont_obj_get_cont_ref(
+        contobj.cast::<crate::continuation::VMContObj>(),
     )?;
     Ok(ans.cast::<u8>())
 }
 
-fn tc_cont_Xref_forward_tag_return_values_buffer(
+fn tc_cont_ref_forward_tag_return_values_buffer(
     _instance: &mut Instance,
-    parent_contXref: *mut u8,
-    child_contXref: *mut u8,
+    parent_contref: *mut u8,
+    child_contref: *mut u8,
 ) -> Result<(), TrapReason> {
-    crate::continuation::cont_Xref_forward_tag_return_values_buffer(
-        parent_contXref.cast::<crate::continuation::VMContXRef>(),
-        child_contXref.cast::<crate::continuation::VMContXRef>(),
+    crate::continuation::cont_ref_forward_tag_return_values_buffer(
+        parent_contref.cast::<crate::continuation::VMContRef>(),
+        child_contref.cast::<crate::continuation::VMContRef>(),
     )
 }
 
-fn tc_drop_cont_Xref(_instance: &mut Instance, contXref: *mut u8) {
-    crate::continuation::drop_cont_Xref(contXref.cast::<crate::continuation::VMContXRef>())
+fn tc_drop_cont_ref(_instance: &mut Instance, contref: *mut u8) {
+    crate::continuation::drop_cont_ref(contref.cast::<crate::continuation::VMContRef>())
 }
 
 fn tc_allocate(_instance: &mut Instance, size: u64, align: u64) -> Result<*mut u8, TrapReason> {
@@ -892,10 +891,10 @@ fn tc_baseline_cont_new(
     Ok(ans_ptr)
 }
 
-fn tc_baseline_resume(instance: &mut Instance, contXobj: *mut u8) -> Result<u32, TrapReason> {
-    let contXobj_ptr = contXobj.cast::<crate::continuation::baseline::VMContXRef>();
-    assert!(contXobj_ptr as usize == contXobj as usize);
-    crate::continuation::baseline::resume(instance, unsafe { &mut *(contXobj_ptr) })
+fn tc_baseline_resume(instance: &mut Instance, contobj: *mut u8) -> Result<u32, TrapReason> {
+    let contobj_ptr = contobj.cast::<crate::continuation::baseline::VMContRef>();
+    assert!(contobj_ptr as usize == contobj as usize);
+    crate::continuation::baseline::resume(instance, unsafe { &mut *(contobj_ptr) })
 }
 
 fn tc_baseline_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason> {
@@ -908,46 +907,46 @@ fn tc_baseline_forward(
     subcont: *mut u8,
 ) -> Result<(), TrapReason> {
     crate::continuation::baseline::forward(instance, tag_index, unsafe {
-        &mut *subcont.cast::<crate::continuation::baseline::VMContXRef>()
+        &mut *subcont.cast::<crate::continuation::baseline::VMContRef>()
     })
 }
 
-fn tc_baseline_drop_continuation_Xobject(instance: &mut Instance, contXobj: *mut u8) {
-    crate::continuation::baseline::drop_continuation_Xobject(
+fn tc_baseline_drop_continuation_object(instance: &mut Instance, contobj: *mut u8) {
+    crate::continuation::baseline::drop_continuation_object(
         instance,
-        contXobj.cast::<crate::continuation::baseline::VMContXRef>(),
+        contobj.cast::<crate::continuation::baseline::VMContRef>(),
     )
 }
 
 fn tc_baseline_continuation_arguments_ptr(
     instance: &mut Instance,
-    contXobj: *mut u8,
+    contobj: *mut u8,
     nargs: u64,
 ) -> *mut u8 {
-    let contXobj_ptr = contXobj.cast::<crate::continuation::baseline::VMContXRef>();
-    assert!(contXobj_ptr as usize == contXobj as usize);
+    let contobj_ptr = contobj.cast::<crate::continuation::baseline::VMContRef>();
+    assert!(contobj_ptr as usize == contobj as usize);
     let ans = crate::continuation::baseline::get_arguments_ptr(
         instance,
-        unsafe { &mut *(contXobj_ptr) },
+        unsafe { &mut *(contobj_ptr) },
         nargs as usize,
     );
     return ans.cast::<u8>();
 }
 
-fn tc_baseline_continuation_values_ptr(instance: &mut Instance, contXobj: *mut u8) -> *mut u8 {
-    let contXobj_ptr = contXobj.cast::<crate::continuation::baseline::VMContXRef>();
-    assert!(contXobj_ptr as usize == contXobj as usize);
+fn tc_baseline_continuation_values_ptr(instance: &mut Instance, contobj: *mut u8) -> *mut u8 {
+    let contobj_ptr = contobj.cast::<crate::continuation::baseline::VMContRef>();
+    assert!(contobj_ptr as usize == contobj as usize);
     let ans =
-        crate::continuation::baseline::get_values_ptr(instance, unsafe { &mut *(contXobj_ptr) });
+        crate::continuation::baseline::get_values_ptr(instance, unsafe { &mut *(contobj_ptr) });
     let ans_ptr = ans.cast::<u8>();
     assert!(ans as usize == ans_ptr as usize);
     return ans_ptr;
 }
 
-fn tc_baseline_clear_arguments(instance: &mut Instance, contXobj: *mut u8) {
-    let contXobj_ptr = contXobj.cast::<crate::continuation::baseline::VMContXRef>();
-    assert!(contXobj_ptr as usize == contXobj as usize);
-    crate::continuation::baseline::clear_arguments(instance, unsafe { &mut *(contXobj_ptr) });
+fn tc_baseline_clear_arguments(instance: &mut Instance, contobj: *mut u8) {
+    let contobj_ptr = contobj.cast::<crate::continuation::baseline::VMContRef>();
+    assert!(contobj_ptr as usize == contobj as usize);
+    crate::continuation::baseline::clear_arguments(instance, unsafe { &mut *(contobj_ptr) });
 }
 
 fn tc_baseline_get_payloads_ptr(instance: &mut Instance, nargs: u64) -> *mut u8 {

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -774,7 +774,7 @@ fn tc_resume(
 ) -> Result<u64, TrapReason> {
     crate::continuation::resume(
         instance,
-        contXref.cast::<crate::continuation::VMContRef>(),
+        contXref.cast::<crate::continuation::VMContXRef>(),
         parent_stack_limits.cast::<crate::continuation::StackLimits>(),
     )
     .map(|reason| reason.into())
@@ -785,7 +785,7 @@ fn tc_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason>
 }
 
 fn tc_new_cont_Xobj(_instance: &mut Instance, contXref: *mut u8) -> *mut u8 {
-    crate::continuation::new_cont_Xobj(contXref.cast::<crate::continuation::VMContRef>())
+    crate::continuation::new_cont_Xobj(contXref.cast::<crate::continuation::VMContXRef>())
         .cast::<u8>()
 }
 
@@ -805,13 +805,13 @@ fn tc_cont_Xref_forward_tag_return_values_buffer(
     child_contXref: *mut u8,
 ) -> Result<(), TrapReason> {
     crate::continuation::cont_Xref_forward_tag_return_values_buffer(
-        parent_contXref.cast::<crate::continuation::VMContRef>(),
-        child_contXref.cast::<crate::continuation::VMContRef>(),
+        parent_contXref.cast::<crate::continuation::VMContXRef>(),
+        child_contXref.cast::<crate::continuation::VMContXRef>(),
     )
 }
 
 fn tc_drop_cont_Xref(_instance: &mut Instance, contXref: *mut u8) {
-    crate::continuation::drop_cont_Xref(contXref.cast::<crate::continuation::VMContRef>())
+    crate::continuation::drop_cont_Xref(contXref.cast::<crate::continuation::VMContXRef>())
 }
 
 fn tc_allocate(_instance: &mut Instance, size: u64, align: u64) -> Result<*mut u8, TrapReason> {
@@ -893,7 +893,7 @@ fn tc_baseline_cont_new(
 }
 
 fn tc_baseline_resume(instance: &mut Instance, contref: *mut u8) -> Result<u32, TrapReason> {
-    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContRef>();
+    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContXRef>();
     assert!(contref_ptr as usize == contref as usize);
     crate::continuation::baseline::resume(instance, unsafe { &mut *(contref_ptr) })
 }
@@ -908,14 +908,14 @@ fn tc_baseline_forward(
     subcont: *mut u8,
 ) -> Result<(), TrapReason> {
     crate::continuation::baseline::forward(instance, tag_index, unsafe {
-        &mut *subcont.cast::<crate::continuation::baseline::VMContRef>()
+        &mut *subcont.cast::<crate::continuation::baseline::VMContXRef>()
     })
 }
 
 fn tc_baseline_drop_continuation_Xobject(instance: &mut Instance, contref: *mut u8) {
     crate::continuation::baseline::drop_continuation_Xobject(
         instance,
-        contref.cast::<crate::continuation::baseline::VMContRef>(),
+        contref.cast::<crate::continuation::baseline::VMContXRef>(),
     )
 }
 
@@ -924,7 +924,7 @@ fn tc_baseline_continuation_arguments_ptr(
     contref: *mut u8,
     nargs: u64,
 ) -> *mut u8 {
-    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContRef>();
+    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContXRef>();
     assert!(contref_ptr as usize == contref as usize);
     let ans = crate::continuation::baseline::get_arguments_ptr(
         instance,
@@ -935,7 +935,7 @@ fn tc_baseline_continuation_arguments_ptr(
 }
 
 fn tc_baseline_continuation_values_ptr(instance: &mut Instance, contref: *mut u8) -> *mut u8 {
-    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContRef>();
+    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContXRef>();
     assert!(contref_ptr as usize == contref as usize);
     let ans =
         crate::continuation::baseline::get_values_ptr(instance, unsafe { &mut *(contref_ptr) });
@@ -945,7 +945,7 @@ fn tc_baseline_continuation_values_ptr(instance: &mut Instance, contref: *mut u8
 }
 
 fn tc_baseline_clear_arguments(instance: &mut Instance, contref: *mut u8) {
-    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContRef>();
+    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContXRef>();
     assert!(contref_ptr as usize == contref as usize);
     crate::continuation::baseline::clear_arguments(instance, unsafe { &mut *(contref_ptr) });
 }

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -891,10 +891,10 @@ fn tc_baseline_cont_new(
     Ok(ans_ptr)
 }
 
-fn tc_baseline_resume(instance: &mut Instance, contobj: *mut u8) -> Result<u32, TrapReason> {
-    let contobj_ptr = contobj.cast::<crate::continuation::baseline::VMContRef>();
-    assert!(contobj_ptr as usize == contobj as usize);
-    crate::continuation::baseline::resume(instance, unsafe { &mut *(contobj_ptr) })
+fn tc_baseline_resume(instance: &mut Instance, contref: *mut u8) -> Result<u32, TrapReason> {
+    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContRef>();
+    assert!(contref_ptr as usize == contref as usize);
+    crate::continuation::baseline::resume(instance, unsafe { &mut *(contref_ptr) })
 }
 
 fn tc_baseline_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason> {
@@ -911,42 +911,42 @@ fn tc_baseline_forward(
     })
 }
 
-fn tc_baseline_drop_continuation_object(instance: &mut Instance, contobj: *mut u8) {
-    crate::continuation::baseline::drop_continuation_object(
+fn tc_baseline_drop_continuation_reference(instance: &mut Instance, contref: *mut u8) {
+    crate::continuation::baseline::drop_continuation_reference(
         instance,
-        contobj.cast::<crate::continuation::baseline::VMContRef>(),
+        contref.cast::<crate::continuation::baseline::VMContRef>(),
     )
 }
 
 fn tc_baseline_continuation_arguments_ptr(
     instance: &mut Instance,
-    contobj: *mut u8,
+    contref: *mut u8,
     nargs: u64,
 ) -> *mut u8 {
-    let contobj_ptr = contobj.cast::<crate::continuation::baseline::VMContRef>();
-    assert!(contobj_ptr as usize == contobj as usize);
+    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContRef>();
+    assert!(contref_ptr as usize == contref as usize);
     let ans = crate::continuation::baseline::get_arguments_ptr(
         instance,
-        unsafe { &mut *(contobj_ptr) },
+        unsafe { &mut *(contref_ptr) },
         nargs as usize,
     );
     return ans.cast::<u8>();
 }
 
-fn tc_baseline_continuation_values_ptr(instance: &mut Instance, contobj: *mut u8) -> *mut u8 {
-    let contobj_ptr = contobj.cast::<crate::continuation::baseline::VMContRef>();
-    assert!(contobj_ptr as usize == contobj as usize);
+fn tc_baseline_continuation_values_ptr(instance: &mut Instance, contref: *mut u8) -> *mut u8 {
+    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContRef>();
+    assert!(contref_ptr as usize == contref as usize);
     let ans =
-        crate::continuation::baseline::get_values_ptr(instance, unsafe { &mut *(contobj_ptr) });
+        crate::continuation::baseline::get_values_ptr(instance, unsafe { &mut *(contref_ptr) });
     let ans_ptr = ans.cast::<u8>();
     assert!(ans as usize == ans_ptr as usize);
     return ans_ptr;
 }
 
-fn tc_baseline_clear_arguments(instance: &mut Instance, contobj: *mut u8) {
-    let contobj_ptr = contobj.cast::<crate::continuation::baseline::VMContRef>();
-    assert!(contobj_ptr as usize == contobj as usize);
-    crate::continuation::baseline::clear_arguments(instance, unsafe { &mut *(contobj_ptr) });
+fn tc_baseline_clear_arguments(instance: &mut Instance, contref: *mut u8) {
+    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContRef>();
+    assert!(contref_ptr as usize == contref as usize);
+    crate::continuation::baseline::clear_arguments(instance, unsafe { &mut *(contref_ptr) });
 }
 
 fn tc_baseline_get_payloads_ptr(instance: &mut Instance, nargs: u64) -> *mut u8 {

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -793,7 +793,7 @@ fn tc_cont_ref_get_cont_Xref(
     _instance: &mut Instance,
     contref: *mut u8,
 ) -> Result<*mut u8, TrapReason> {
-    let ans = crate::continuation::cont_ref_get_cont_obj(
+    let ans = crate::continuation::cont_ref_get_cont_Xref(
         contref.cast::<crate::continuation::ContinuationReference>(),
     )?;
     Ok(ans.cast::<u8>())

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -789,7 +789,7 @@ fn tc_new_cont_ref(_instance: &mut Instance, contXref: *mut u8) -> *mut u8 {
         .cast::<u8>()
 }
 
-fn tc_cont_ref_get_cont_obj(
+fn tc_cont_ref_get_cont_Xref(
     _instance: &mut Instance,
     contref: *mut u8,
 ) -> Result<*mut u8, TrapReason> {

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -791,10 +791,10 @@ fn tc_new_cont_Xobj(_instance: &mut Instance, contXref: *mut u8) -> *mut u8 {
 
 fn tc_cont_Xobj_get_cont_Xref(
     _instance: &mut Instance,
-    contref: *mut u8,
+    contXobj: *mut u8,
 ) -> Result<*mut u8, TrapReason> {
     let ans = crate::continuation::cont_Xobj_get_cont_Xref(
-        contref.cast::<crate::continuation::ContinuationReference>(),
+        contXobj.cast::<crate::continuation::ContinuationReference>(),
     )?;
     Ok(ans.cast::<u8>())
 }
@@ -892,10 +892,10 @@ fn tc_baseline_cont_new(
     Ok(ans_ptr)
 }
 
-fn tc_baseline_resume(instance: &mut Instance, contref: *mut u8) -> Result<u32, TrapReason> {
-    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContXRef>();
-    assert!(contref_ptr as usize == contref as usize);
-    crate::continuation::baseline::resume(instance, unsafe { &mut *(contref_ptr) })
+fn tc_baseline_resume(instance: &mut Instance, contXobj: *mut u8) -> Result<u32, TrapReason> {
+    let contXobj_ptr = contXobj.cast::<crate::continuation::baseline::VMContXRef>();
+    assert!(contXobj_ptr as usize == contXobj as usize);
+    crate::continuation::baseline::resume(instance, unsafe { &mut *(contXobj_ptr) })
 }
 
 fn tc_baseline_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason> {
@@ -912,42 +912,42 @@ fn tc_baseline_forward(
     })
 }
 
-fn tc_baseline_drop_continuation_Xobject(instance: &mut Instance, contref: *mut u8) {
+fn tc_baseline_drop_continuation_Xobject(instance: &mut Instance, contXobj: *mut u8) {
     crate::continuation::baseline::drop_continuation_Xobject(
         instance,
-        contref.cast::<crate::continuation::baseline::VMContXRef>(),
+        contXobj.cast::<crate::continuation::baseline::VMContXRef>(),
     )
 }
 
 fn tc_baseline_continuation_arguments_ptr(
     instance: &mut Instance,
-    contref: *mut u8,
+    contXobj: *mut u8,
     nargs: u64,
 ) -> *mut u8 {
-    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContXRef>();
-    assert!(contref_ptr as usize == contref as usize);
+    let contXobj_ptr = contXobj.cast::<crate::continuation::baseline::VMContXRef>();
+    assert!(contXobj_ptr as usize == contXobj as usize);
     let ans = crate::continuation::baseline::get_arguments_ptr(
         instance,
-        unsafe { &mut *(contref_ptr) },
+        unsafe { &mut *(contXobj_ptr) },
         nargs as usize,
     );
     return ans.cast::<u8>();
 }
 
-fn tc_baseline_continuation_values_ptr(instance: &mut Instance, contref: *mut u8) -> *mut u8 {
-    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContXRef>();
-    assert!(contref_ptr as usize == contref as usize);
+fn tc_baseline_continuation_values_ptr(instance: &mut Instance, contXobj: *mut u8) -> *mut u8 {
+    let contXobj_ptr = contXobj.cast::<crate::continuation::baseline::VMContXRef>();
+    assert!(contXobj_ptr as usize == contXobj as usize);
     let ans =
-        crate::continuation::baseline::get_values_ptr(instance, unsafe { &mut *(contref_ptr) });
+        crate::continuation::baseline::get_values_ptr(instance, unsafe { &mut *(contXobj_ptr) });
     let ans_ptr = ans.cast::<u8>();
     assert!(ans as usize == ans_ptr as usize);
     return ans_ptr;
 }
 
-fn tc_baseline_clear_arguments(instance: &mut Instance, contref: *mut u8) {
-    let contref_ptr = contref.cast::<crate::continuation::baseline::VMContXRef>();
-    assert!(contref_ptr as usize == contref as usize);
-    crate::continuation::baseline::clear_arguments(instance, unsafe { &mut *(contref_ptr) });
+fn tc_baseline_clear_arguments(instance: &mut Instance, contXobj: *mut u8) {
+    let contXobj_ptr = contXobj.cast::<crate::continuation::baseline::VMContXRef>();
+    assert!(contXobj_ptr as usize == contXobj as usize);
+    crate::continuation::baseline::clear_arguments(instance, unsafe { &mut *(contXobj_ptr) });
 }
 
 fn tc_baseline_get_payloads_ptr(instance: &mut Instance, nargs: u64) -> *mut u8 {

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -784,16 +784,16 @@ fn tc_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason>
     crate::continuation::suspend(instance, tag_index)
 }
 
-fn tc_new_cont_ref(_instance: &mut Instance, contXref: *mut u8) -> *mut u8 {
-    crate::continuation::new_cont_ref(contXref.cast::<crate::continuation::VMContRef>())
+fn tc_new_cont_Xobj(_instance: &mut Instance, contXref: *mut u8) -> *mut u8 {
+    crate::continuation::new_cont_Xobj(contXref.cast::<crate::continuation::VMContRef>())
         .cast::<u8>()
 }
 
-fn tc_cont_ref_get_cont_Xref(
+fn tc_cont_Xobj_get_cont_Xref(
     _instance: &mut Instance,
     contref: *mut u8,
 ) -> Result<*mut u8, TrapReason> {
-    let ans = crate::continuation::cont_ref_get_cont_Xref(
+    let ans = crate::continuation::cont_Xobj_get_cont_Xref(
         contref.cast::<crate::continuation::ContinuationReference>(),
     )?;
     Ok(ans.cast::<u8>())
@@ -912,8 +912,8 @@ fn tc_baseline_forward(
     })
 }
 
-fn tc_baseline_drop_continuation_reference(instance: &mut Instance, contref: *mut u8) {
-    crate::continuation::baseline::drop_continuation_reference(
+fn tc_baseline_drop_continuation_Xobject(instance: &mut Instance, contref: *mut u8) {
+    crate::continuation::baseline::drop_continuation_Xobject(
         instance,
         contref.cast::<crate::continuation::baseline::VMContRef>(),
     )

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -794,7 +794,7 @@ fn tc_cont_Xobj_get_cont_Xref(
     contXobj: *mut u8,
 ) -> Result<*mut u8, TrapReason> {
     let ans = crate::continuation::cont_Xobj_get_cont_Xref(
-        contXobj.cast::<crate::continuation::ContinuationReference>(),
+        contXobj.cast::<crate::continuation::VMContXObj>(),
     )?;
     Ok(ans.cast::<u8>())
 }

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -810,8 +810,8 @@ fn tc_cont_Xref_forward_tag_return_values_buffer(
     )
 }
 
-fn tc_drop_cont_obj(_instance: &mut Instance, contXref: *mut u8) {
-    crate::continuation::drop_cont_obj(contXref.cast::<crate::continuation::VMContRef>())
+fn tc_drop_cont_Xref(_instance: &mut Instance, contXref: *mut u8) {
+    crate::continuation::drop_cont_Xref(contXref.cast::<crate::continuation::VMContRef>())
 }
 
 fn tc_allocate(_instance: &mut Instance, size: u64, align: u64) -> Result<*mut u8, TrapReason> {

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -799,12 +799,12 @@ fn tc_cont_ref_get_cont_obj(
     Ok(ans.cast::<u8>())
 }
 
-fn tc_cont_obj_forward_tag_return_values_buffer(
+fn tc_cont_Xref_forward_tag_return_values_buffer(
     _instance: &mut Instance,
     parent_contXref: *mut u8,
     child_contXref: *mut u8,
 ) -> Result<(), TrapReason> {
-    crate::continuation::cont_obj_forward_tag_return_values_buffer(
+    crate::continuation::cont_Xref_forward_tag_return_values_buffer(
         parent_contXref.cast::<crate::continuation::VMContRef>(),
         child_contXref.cast::<crate::continuation::VMContRef>(),
     )

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -774,7 +774,7 @@ fn tc_resume(
 ) -> Result<u64, TrapReason> {
     crate::continuation::resume(
         instance,
-        contobj.cast::<crate::continuation::ContinuationObject>(),
+        contobj.cast::<crate::continuation::VMContRef>(),
         parent_stack_limits.cast::<crate::continuation::StackLimits>(),
     )
     .map(|reason| reason.into())
@@ -785,7 +785,7 @@ fn tc_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason>
 }
 
 fn tc_new_cont_ref(_instance: &mut Instance, contobj: *mut u8) -> *mut u8 {
-    crate::continuation::new_cont_ref(contobj.cast::<crate::continuation::ContinuationObject>())
+    crate::continuation::new_cont_ref(contobj.cast::<crate::continuation::VMContRef>())
         .cast::<u8>()
 }
 
@@ -805,13 +805,13 @@ fn tc_cont_obj_forward_tag_return_values_buffer(
     child_contobj: *mut u8,
 ) -> Result<(), TrapReason> {
     crate::continuation::cont_obj_forward_tag_return_values_buffer(
-        parent_contobj.cast::<crate::continuation::ContinuationObject>(),
-        child_contobj.cast::<crate::continuation::ContinuationObject>(),
+        parent_contobj.cast::<crate::continuation::VMContRef>(),
+        child_contobj.cast::<crate::continuation::VMContRef>(),
     )
 }
 
 fn tc_drop_cont_obj(_instance: &mut Instance, contobj: *mut u8) {
-    crate::continuation::drop_cont_obj(contobj.cast::<crate::continuation::ContinuationObject>())
+    crate::continuation::drop_cont_obj(contobj.cast::<crate::continuation::VMContRef>())
 }
 
 fn tc_allocate(_instance: &mut Instance, size: u64, align: u64) -> Result<*mut u8, TrapReason> {

--- a/crates/wasmtime/src/runtime/trampoline/global.rs
+++ b/crates/wasmtime/src/runtime/trampoline/global.rs
@@ -24,7 +24,7 @@ impl Drop for VMHostGlobalContext {
                     // Nothing to drop.
                 }
                 HeapType::Cont | HeapType::NoCont => {
-                    // We may have to drop the dynamic continuation Xobject here.
+                    // We may have to drop the dynamic continuation object here.
                     todo!("Drop for VMHostGlobalContext with content of type HeapType::Cont and HeapType::NoCont not yet implemented")
                 }
                 HeapType::Extern => unsafe { ptr::drop_in_place(self.global.as_externref_mut()) },

--- a/crates/wasmtime/src/runtime/trampoline/global.rs
+++ b/crates/wasmtime/src/runtime/trampoline/global.rs
@@ -24,7 +24,7 @@ impl Drop for VMHostGlobalContext {
                     // Nothing to drop.
                 }
                 HeapType::Cont | HeapType::NoCont => {
-                    // We may have to drop the dynamic continuation reference here.
+                    // We may have to drop the dynamic continuation Xobject here.
                     todo!("Drop for VMHostGlobalContext with content of type HeapType::Cont and HeapType::NoCont not yet implemented")
                 }
                 HeapType::Extern => unsafe { ptr::drop_in_place(self.global.as_externref_mut()) },

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -420,14 +420,14 @@ pub enum HeapType {
 
     /// The `cont` heap type represents a reference to any kind of continuation.
     ///
-    /// This is the top type for the continuation Xobjects type hierarchy, and is
-    /// therefore a supertype of every continuation Xobject.
+    /// This is the top type for the continuation objects type hierarchy, and is
+    /// therefore a supertype of every continuation object.
     Cont,
 
-    /// The `nocont` heap type represents the null continuation Xobject.
+    /// The `nocont` heap type represents the null continuation object.
     ///
-    /// This is the bottom type for the continuation Xobjects type hierarchy, and
-    /// therefore `nocont` is a subtype of all continuation Xobject types.
+    /// This is the bottom type for the continuation objects type hierarchy, and
+    /// therefore `nocont` is a subtype of all continuation object types.
     NoCont,
 }
 
@@ -509,7 +509,7 @@ impl HeapType {
 
         match self {
             // TODO(dhil): We need to check whether Concrete points to
-            // a continuation Xobject in order to correct deduce the
+            // a continuation object in order to correct deduce the
             // top type.
             HeapType::Func | HeapType::Concrete(_) | HeapType::NoFunc => HeapType::Func,
             HeapType::Extern => HeapType::Extern,

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -420,14 +420,14 @@ pub enum HeapType {
 
     /// The `cont` heap type represents a reference to any kind of continuation.
     ///
-    /// This is the top type for the continuation references type hierarchy, and is
-    /// therefore a supertype of every continuation reference.
+    /// This is the top type for the continuation Xobjects type hierarchy, and is
+    /// therefore a supertype of every continuation Xobject.
     Cont,
 
-    /// The `nocont` heap type represents the null continuation reference.
+    /// The `nocont` heap type represents the null continuation Xobject.
     ///
-    /// This is the bottom type for the continuation references type hierarchy, and
-    /// therefore `nocont` is a subtype of all continuation reference types.
+    /// This is the bottom type for the continuation Xobjects type hierarchy, and
+    /// therefore `nocont` is a subtype of all continuation Xobject types.
     NoCont,
 }
 
@@ -509,7 +509,7 @@ impl HeapType {
 
         match self {
             // TODO(dhil): We need to check whether Concrete points to
-            // a continuation reference in order to correct deduce the
+            // a continuation Xobject in order to correct deduce the
             // top type.
             HeapType::Func | HeapType::Concrete(_) | HeapType::NoFunc => HeapType::Func,
             HeapType::Extern => HeapType::Extern,

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -231,7 +231,7 @@ fn match_heap(expected: WasmHeapType, actual: WasmHeapType, desc: &str) -> Resul
             // TODO(dhil): We should really check that Concrete
             // points to a continuation type.
             if let H::Concrete(_idx) = actual {
-                println!("TODO(dhil): [match_heap] has matched an Concrete against a Cont, however, we haven't checked that Concrete points to a continuation Xobject. Tread carefully, here may be bugs!");
+                println!("TODO(dhil): [match_heap] has matched an Concrete against a Cont, however, we haven't checked that Concrete points to a continuation object. Tread carefully, here may be bugs!");
             }
             true
         }

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -231,7 +231,7 @@ fn match_heap(expected: WasmHeapType, actual: WasmHeapType, desc: &str) -> Resul
             // TODO(dhil): We should really check that Concrete
             // points to a continuation type.
             if let H::Concrete(_idx) = actual {
-                println!("TODO(dhil): [match_heap] has matched an Concrete against a Cont, however, we haven't checked that Concrete points to a continuation reference. Tread carefully, here may be bugs!");
+                println!("TODO(dhil): [match_heap] has matched an Concrete against a Cont, however, we haven't checked that Concrete points to a continuation Xobject. Tread carefully, here may be bugs!");
             }
             true
         }

--- a/tests/misc_testsuite/typed-continuations/cont_bind4.wast
+++ b/tests/misc_testsuite/typed-continuations/cont_bind4.wast
@@ -1,5 +1,5 @@
 ;; Testing that the creation of the necessary payload buffers works as expect,
-;; even when the same continuation Xreference is suspended multiple times
+;; even when the same continuation reference is suspended multiple times
 
 (module
   (type $unit_to_int (func (result i32)))

--- a/tests/misc_testsuite/typed-continuations/cont_bind4.wast
+++ b/tests/misc_testsuite/typed-continuations/cont_bind4.wast
@@ -1,5 +1,5 @@
 ;; Testing that the creation of the necessary payload buffers works as expect,
-;; even when the same continuation object is suspended multiple times
+;; even when the same continuation Xreference is suspended multiple times
 
 (module
   (type $unit_to_int (func (result i32)))


### PR DESCRIPTION
This PR renames `ContinuationObject` to `VMContRef` and `ContinuationReference` to `VMContObj`.

This was mostly just a search-replace job, but also involved renaming lots of variables named things like `contref` or `contobj` (and various variations thereof), as well as replacing mentions of "continuation object" in text.

The baseline implementation remains mostly unchanged since it was already using that nomenclature, only some minor changes at the boundaries/when interacting with functions defined in both implementations (e.g., `typed_continuations_load_continuation_reference`) were necessary.

This resolves #104.