### PR TITLE
Initiate execution of continuations without use of closures

### DIFF
--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -1,7 +1,7 @@
 //! Continuations TODO
 
-use crate::fibre::{Fiber, FiberStack, Suspend};
-use crate::vmcontext::{VMFuncRef, VMOpaqueContext, ValRaw};
+use crate::fibre::{Fiber, FiberStack};
+use crate::vmcontext::{VMFuncRef, ValRaw};
 use crate::{Instance, TrapReason};
 use std::cell::UnsafeCell;
 use std::cmp;

--- a/crates/runtime/src/fibre/unix/x86_64.rs
+++ b/crates/runtime/src/fibre/unix/x86_64.rs
@@ -83,9 +83,10 @@ asm_func!(
 // such that invoking wasmtime_fibre_switch on the stack actually runs the
 // desired computation.
 //
-// Concretely, switching to the stack prepare by `wasmtime_fibre_init` function
-// evokes that we enter `wasmtime_fibre_start`, which then in turn calls
-// `fiber_start` with the arguments above.
+// Concretely, switching to the stack prepare by the `wasmtime_fibre_init`
+// function evokes that we enter `wasmtime_fibre_start`, which then in turn
+// calls `fiber_start` with a subset of the arguments above (namely: func_ref,
+// caller_vmctx, args_ptr, args_capacity).
 //
 // The layout of the FiberStack near the top of stack (TOS) *after* running this
 // function is as follows:

--- a/crates/runtime/src/fibre/unix/x86_64.rs
+++ b/crates/runtime/src/fibre/unix/x86_64.rs
@@ -134,7 +134,7 @@ asm_func!(
         add rax, 0x10
         mov -0x20[rdi], rax
 
-        // Install remaing arguments
+        // Install remaining arguments
         mov -0x28[rdi], rsi   // loaded into rbx during switch
         mov -0x30[rdi], rdx   // loaded into r12 during switch
         mov -0x38[rdi], rcx   // loaded into r13 during switch

--- a/crates/runtime/src/fibre/unix/x86_64.rs
+++ b/crates/runtime/src/fibre/unix/x86_64.rs
@@ -253,11 +253,12 @@ asm_func!(
         // already loaded into registers by the switch function. The
         // `wasmtime_fibre_init` routine arranged the various values to be
         // materialized into the registers used here. Our job is to then move
-        // the values into the ABI-defined registers and call the entry-point.
+        // the values into the ABI-defined registers and call the entry-point
+        // (i.e., the fiber_start function).
         // Note that `call` is used here to leave this frame on the stack so we
         // can use the dwarf info here for unwinding.
         //
-        // Note that the next three instructions amount to calling fiber_start
+        // Note that the next 5 instructions amount to calling fiber_start
         // with the following arguments:
         // 1. TOS
         // 2. func_ref

--- a/crates/runtime/src/fibre/unix/x86_64.rs
+++ b/crates/runtime/src/fibre/unix/x86_64.rs
@@ -274,7 +274,7 @@ asm_func!(
         mov rsi, rbx // func_ref
         mov rdx, r12 // caller_vmctx
         mov rcx, r13 // args_ptr
-        mov r8, r13  // args_capacity
+        mov r8, r14  // args_capacity
         call {fiber_start}
 
         // We should never get here and purposely emit an invalid instruction.


### PR DESCRIPTION
Currently, we inherit the following behavior from the `wasmtime_fiber` crate:
The toplevel function executed inside a `Fiber` is a Rust closure. However, this flexibility is not required for our use case: The function we want to run inside a continuation is always the array call trampoline of a wasm function.

This PR specializes our module `wasmtime_runtime::fibre` to our particular use case, getting rid of the involved closures. Instead, all the required data is passed around explicitly in function arguments, instead of being implicitly stored in a closure. This has the following advantages:
1. We do not need to allocate a `Box` holding the closure anymore.
2. The function `wasmtime_runtime::fibre::unix::fiber_start`, which is the Rust entry point for execution inside a Fiber, is no longer parameterized over a closure type `F`. Thus, we can call it directly from `wasmtime_fibre_start`, instead of needing to pass it around.
3. Since the internal layout of closures is not specified by Rust, their usage stands in the way of replacing `wasmtime_runtime::fibre::unix::fiber_start` with generated code eventually.

In a sense, what this PR does is some kind of manual closure conversion: Instead of creating a closure in `wasmtime_runtime::continuation::cont_new` and passing it to `Fiber::new`, we pass all of the necessary environment to `Fiber::new`. It is then stored on the Fiber stack by `wasmtime_fibre_init`,  where it is read off and passed to `fiber_start` when `resume`-ing a continuation for the first time. 