### PR TITLE
Restore continuation table functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.206.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "leb128",
 ]
@@ -3262,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.206.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "anyhow",
  "indexmap 2.0.0",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "wasm-mutate"
 version = "0.206.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "egg",
  "log",
@@ -3290,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "wasm-smith"
 version = "0.206.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.206.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "ahash",
  "bitflags 2.4.1",
@@ -3374,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.206.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "anyhow",
  "wasmparser 0.206.0",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "206.0.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "bumpalo",
  "leb128",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "wat"
 version = "1.206.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "wast 206.0.0",
 ]
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.206.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.206.0"
-source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0#ae5a5a75fc989651405f7a6b916542c7475294d1"
+source = "git+https://github.com/wasmfx/wasmfx-tools?tag=v1.206.0+rev2#85373c0218225fbbb2c1dcd798a726c44b644604"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,15 +234,15 @@ rustix = "0.38.31"
 wit-bindgen = { git = "https://github.com/wasmfx/wit-bindgenfx", tag = "wit-bindgenfx-cli-0.22.0", default-features = false }
 
 # wasm-tools family:
-wasmparser    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0" }
-wat           = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0" }
-wast          = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0" }
-wasmprinter   = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0" }
-wasm-encoder  = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0" }
-wasm-smith    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0" }
-wasm-mutate   = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0" }
-wit-parser    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0" }
-wit-component = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0" }
+wasmparser    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0+rev2" }
+wat           = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0+rev2" }
+wast          = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0+rev2" }
+wasmprinter   = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0+rev2" }
+wasm-encoder  = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0+rev2" }
+wasm-smith    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0+rev2" }
+wasm-mutate   = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0+rev2" }
+wit-parser    = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0+rev2" }
+wit-component = { git = "https://github.com/wasmfx/wasmfx-tools", tag = "v1.206.0+rev2" }
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------


### PR DESCRIPTION
One of the previous merges inadvertently dropped support for certain
operations on continuation tables. This patch is a quick fix to
restore the functionality by interpreting continuation tables as func
tables.

Also, this PR imports the wasmfx-tools patch for subtyping check on `cont.new`.