### PR TITLE
Add wasmtime_linker_allow_unknown_exports to C API

### DIFF
--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -66,6 +66,15 @@ WASM_API_EXTERN void wasmtime_linker_allow_shadowing(wasmtime_linker_t *linker,
                                                      bool allow_shadowing);
 
 /**
+ * \brief Configures whether the given Linker will allow unknown exports from
+ * command modules.
+ *
+ * By default this setting is `false`.
+ */
+WASM_API_EXTERN void wasmtime_linker_allow_unknown_exports(wasmtime_linker_t *linker,
+                                                     bool allow_unknown_exports);
+
+/**
  * \brief Defines a new item in this linker.
  *
  * \param linker the linker the name is being defined in.

--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -71,8 +71,9 @@ WASM_API_EXTERN void wasmtime_linker_allow_shadowing(wasmtime_linker_t *linker,
  *
  * By default this setting is `false`.
  */
-WASM_API_EXTERN void wasmtime_linker_allow_unknown_exports(wasmtime_linker_t *linker,
-                                                     bool allow_unknown_exports);
+WASM_API_EXTERN void
+wasmtime_linker_allow_unknown_exports(wasmtime_linker_t *linker,
+                                      bool allow_unknown_exports);
 
 /**
  * \brief Defines a new item in this linker.

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -37,6 +37,14 @@ pub extern "C" fn wasmtime_linker_allow_shadowing(
     linker.linker.allow_shadowing(allow_shadowing);
 }
 
+#[no_mangle]
+pub extern "C" fn wasmtime_linker_allow_unknown_exports(
+    linker: &mut wasmtime_linker_t,
+    allow_unknown_exports: bool,
+) {
+    linker.linker.allow_unknown_exports(allow_unknown_exports);
+}
+
 macro_rules! to_str {
     ($ptr:expr, $len:expr) => {
         match str::from_utf8(crate::slice_from_raw_parts($ptr, $len)) {


### PR DESCRIPTION
The C API for using the wasmtime linker currently only gives access to the `allow_shadowing` setting of the linker, but not to the `allow_unknown_exports` setting. However, the latter setting needs to be enabled in order to allow exporting the global `__stack_pointer`. This is what's causing the issue described in wasmfx/waeio#2.

(Alternatively, we may add `__stack_pointer` to the list of blessed globals in the `command` function in crates/wasmtime/src/runtime/linker.rs, but the comments there suggest that new items shouldn't be added to that list. Therefore, just making this setting accessible in the C API seems less controversial.)