### PR TITLE
Bespoke continuation table type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -657,6 +657,12 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+    # Crude check for whether
+    # `unsafe_disable_continuation_linearity_check` makes the test
+    # `cont_twice` fail.
+    - run: |
+        cargo test --features=unsafe_disable_continuation_linearity_check --test wast -- --exact Cranelift/tests/misc_testsuite/typed-continuations/cont_twice.wast; test $? -eq 101
+
     # NB: the test job here is explicitly lacking in cancellation of this run if
     # something goes wrong. These take the longest anyway and otherwise if
     # Windows fails GitHub Actions will confusingly mark the failed Windows job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -661,7 +661,7 @@ jobs:
     # `unsafe_disable_continuation_linearity_check` makes the test
     # `cont_twice` fail.
     - run: |
-        cargo test --features=unsafe_disable_continuation_linearity_check --test wast -- --exact Cranelift/tests/misc_testsuite/typed-continuations/cont_twice.wast; test $? -eq 101
+        (cargo test --features=unsafe_disable_continuation_linearity_check --test wast -- --exact Cranelift/tests/misc_testsuite/typed-continuations/cont_twice.wast && test $? -eq 101) || test $? -eq 101
 
     # NB: the test job here is explicitly lacking in cancellation of this run if
     # something goes wrong. These take the longest anyway and otherwise if

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -56,7 +56,7 @@ pub mod types {
 /// line.
 ///
 /// Part of wasmtime::config::Config type (which is not in scope in this crate).
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct WasmFXConfig {
     pub stack_size: usize,
 
@@ -95,6 +95,7 @@ unsafe impl Send for StackLimits {}
 unsafe impl Sync for StackLimits {}
 
 #[repr(C)]
+#[derive(Debug, Clone)]
 pub struct Payloads {
     /// Number of currently occupied slots.
     pub length: types::payloads::Length,
@@ -134,7 +135,7 @@ pub const STACK_CHAIN_MAIN_STACK_DISCRIMINANT: usize = 1;
 pub const STACK_CHAIN_CONTINUATION_DISCRIMINANT: usize = 2;
 
 /// Encodes the life cycle of a `VMContRef`.
-#[derive(PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(i32)]
 pub enum State {
     /// The `VMContRef` has been created, but `resume` has never been
@@ -169,6 +170,7 @@ pub type TagId = u32;
 
 /// See SwitchDirection below for overall use of this type.
 #[repr(u32)]
+#[derive(Debug, Clone)]
 pub enum SwitchDirectionEnum {
     // Used to indicate that the contination has returned normally.
     Return = 0,
@@ -215,6 +217,7 @@ impl SwitchDirectionEnum {
 /// In that representation, bits 0 to 31 (where 0 is the LSB) contain the
 /// discriminant (as u32), while bits 32 to 63 contain the `data`.
 #[repr(C)]
+#[derive(Debug, Clone)]
 pub struct SwitchDirection {
     pub discriminant: SwitchDirectionEnum,
 

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -161,6 +161,9 @@ macro_rules! foreach_builtin_function {
             tc_print_int(vmctx: vmctx, arg : i64);
             // TODO
             tc_print_pointer(vmctx: vmctx, arg : pointer);
+
+            // Returns an index for Wasm's `table.grow` instruction for `contobj`s.
+            table_grow_cont_obj(vmctx: vmctx, table: i32, delta: i32, init: pointer) -> i32;
         }
     };
 }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -189,6 +189,8 @@ impl Table {
                         ty => unreachable!("not a top type: {ty:?}"),
                     }
                 }
+
+                runtime::TableElement::ContRef(_c) => todo!(), // TODO(dhil): Required for the embedder API.
             }
         }
     }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -220,6 +220,10 @@ unsafe fn table_grow(
             .unwrap()
             .map(|r| (*instance.store()).gc_store().clone_gc_ref(&r))
             .into(),
+        TableElementType::Cont => {
+            use crate::vm::continuation::VMContObj;
+            VMContObj::from_u64(u64::try_from(init_value as usize).unwrap()).into()
+        }
     };
 
     Ok(match instance.table_grow(table_index, delta, element)? {
@@ -229,6 +233,7 @@ unsafe fn table_grow(
 }
 
 use table_grow as table_grow_func_ref;
+use table_grow as table_grow_cont_obj;
 
 #[cfg(feature = "gc")]
 use table_grow as table_grow_gc_ref;
@@ -256,6 +261,12 @@ unsafe fn table_fill(
             let gc_ref = VMGcRef::from_r64(u64::try_from(val as usize).unwrap()).unwrap();
             let gc_ref = gc_ref.map(|r| gc_store.clone_gc_ref(&r));
             table.fill(gc_store, dst, gc_ref.into(), len)
+        }
+
+        TableElementType::Cont => {
+            use crate::vm::continuation::VMContObj;
+            let contobj = VMContObj::from_u64(u64::try_from(val as usize).unwrap()).unwrap();
+            table.fill((*instance.store()).gc_store(), dst, contobj.into(), len)
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(feature = "gc", allow(irrefutable_let_patterns))]
 
 use crate::prelude::*;
+use crate::runtime::vm::continuation::VMContObj;
 use crate::runtime::vm::vmcontext::{VMFuncRef, VMTableDefinition};
 use crate::runtime::vm::{GcStore, SendSyncPtr, Store, VMGcRef};
 use anyhow::{bail, ensure, format_err, Error, Result};
@@ -33,12 +34,16 @@ pub enum TableElement {
     /// (which has access to the info needed for lazy initialization)
     /// will replace it when fetched.
     UninitFunc,
+
+    /// A `contref`
+    ContRef(Option<VMContObj>),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum TableElementType {
     Func,
     GcRef,
+    Cont,
 }
 
 impl TableElementType {
@@ -46,6 +51,7 @@ impl TableElementType {
         match (val, self) {
             (TableElement::FuncRef(_), TableElementType::Func) => true,
             (TableElement::GcRef(_), TableElementType::GcRef) => true,
+            (TableElement::ContRef(_), TableElementType::Cont) => true,
             _ => false,
         }
     }
@@ -73,6 +79,7 @@ impl TableElement {
             Self::FuncRef(e) => e,
             Self::UninitFunc => panic!("Uninitialized table element value outside of table slot"),
             Self::GcRef(_) => panic!("GC reference is not a function reference"),
+            Self::ContRef(_) => panic!("Continuation reference is not a function reference"),
         }
     }
 
@@ -101,6 +108,18 @@ impl From<Option<VMGcRef>> for TableElement {
 impl From<VMGcRef> for TableElement {
     fn from(x: VMGcRef) -> TableElement {
         TableElement::GcRef(Some(x))
+    }
+}
+
+impl From<Option<VMContObj>> for TableElement {
+    fn from(c: Option<VMContObj>) -> TableElement {
+        TableElement::ContRef(c)
+    }
+}
+
+impl From<VMContObj> for TableElement {
+    fn from(c: VMContObj) -> TableElement {
+        TableElement::ContRef(Some(c))
     }
 }
 
@@ -138,10 +157,12 @@ impl TaggedFuncRef {
 }
 
 pub type FuncTableElem = Option<SendSyncPtr<VMFuncRef>>;
+pub type ContTableElem = Option<SendSyncPtr<VMContObj>>;
 
 pub enum StaticTable {
     Func(StaticFuncTable),
     GcRef(StaticGcRefTable),
+    Cont(StaticContTable),
 }
 
 impl From<StaticFuncTable> for StaticTable {
@@ -153,6 +174,12 @@ impl From<StaticFuncTable> for StaticTable {
 impl From<StaticGcRefTable> for StaticTable {
     fn from(value: StaticGcRefTable) -> Self {
         Self::GcRef(value)
+    }
+}
+
+impl From<StaticContTable> for StaticTable {
+    fn from(value: StaticContTable) -> Self {
+        Self::Cont(value)
     }
 }
 
@@ -174,9 +201,18 @@ pub struct StaticGcRefTable {
     size: u32,
 }
 
+pub struct StaticContTable {
+    /// Where data for this table is stored. The length of this list is the
+    /// maximum size of the table.
+    data: SendSyncPtr<[ContTableElem]>,
+    /// The current size of the table.
+    size: u32,
+}
+
 pub enum DynamicTable {
     Func(DynamicFuncTable),
     GcRef(DynamicGcRefTable),
+    Cont(DynamicContTable),
 }
 
 impl From<DynamicFuncTable> for DynamicTable {
@@ -188,6 +224,12 @@ impl From<DynamicFuncTable> for DynamicTable {
 impl From<DynamicGcRefTable> for DynamicTable {
     fn from(value: DynamicGcRefTable) -> Self {
         Self::GcRef(value)
+    }
+}
+
+impl From<DynamicContTable> for DynamicTable {
+    fn from(value: DynamicContTable) -> Self {
+        Self::Cont(value)
     }
 }
 
@@ -205,6 +247,14 @@ pub struct DynamicGcRefTable {
     /// Dynamically managed storage space for this table. The length of this
     /// vector is the current size of the table.
     elements: Vec<Option<VMGcRef>>,
+    /// Maximum size that `elements` can grow to.
+    maximum: Option<u32>,
+}
+
+pub struct DynamicContTable {
+    /// Dynamically managed storage space for this table. The length of this
+    /// vector is the current size of the table.
+    elements: Vec<ContTableElem>,
     /// Maximum size that `elements` can grow to.
     maximum: Option<u32>,
 }
@@ -239,6 +289,13 @@ impl From<StaticGcRefTable> for Table {
     }
 }
 
+impl From<StaticContTable> for Table {
+    fn from(value: StaticContTable) -> Self {
+        let t: StaticTable = value.into();
+        t.into()
+    }
+}
+
 impl From<DynamicTable> for Table {
     fn from(value: DynamicTable) -> Self {
         Self::Dynamic(value)
@@ -259,11 +316,18 @@ impl From<DynamicGcRefTable> for Table {
     }
 }
 
+impl From<DynamicContTable> for Table {
+    fn from(value: DynamicContTable) -> Self {
+        let t: DynamicTable = value.into();
+        t.into()
+    }
+}
+
 fn wasm_to_table_type(ty: WasmRefType) -> TableElementType {
     match ty.heap_type.top() {
         WasmHeapTopType::Func => TableElementType::Func,
         WasmHeapTopType::Any | WasmHeapTopType::Extern => TableElementType::GcRef,
-        WasmHeapTopType::Cont => TableElementType::Func, // TODO(dhil): Temporary hack until we have a bespoke cont element type.
+        WasmHeapTopType::Cont => TableElementType::Cont,
     }
 }
 
@@ -282,6 +346,10 @@ impl Table {
                 elements: (0..usize::try_from(plan.table.minimum).unwrap())
                     .map(|_| None)
                     .collect(),
+                maximum: plan.table.maximum,
+            })),
+            TableElementType::Cont => Ok(Self::from(DynamicContTable {
+                elements: vec![None; usize::try_from(plan.table.minimum).unwrap()],
                 maximum: plan.table.maximum,
             })),
         }
@@ -347,6 +415,27 @@ impl Table {
                 ));
                 Ok(Self::from(StaticGcRefTable { data, size }))
             }
+            TableElementType::Cont => {
+                let len = {
+                    let data = data.as_non_null().as_ref();
+                    let (before, data, after) = data.align_to::<ContTableElem>();
+                    assert!(before.is_empty());
+                    assert!(after.is_empty());
+                    data.len()
+                };
+                ensure!(
+                    usize::try_from(plan.table.minimum).unwrap() <= len,
+                    "initial table size of {} exceeds the pooling allocator's \
+                     configured maximum table size of {len} elements",
+                    plan.table.minimum,
+                );
+                let data = SendSyncPtr::new(NonNull::slice_from_raw_parts(
+                    data.as_non_null().cast::<ContTableElem>(),
+                    cmp::min(len, max),
+                ));
+                let TableStyle::CallerChecksSignature { lazy_init: _ } = plan.style;
+                Ok(Self::from(StaticContTable { data, size }))
+            }
         }
     }
 
@@ -369,6 +458,9 @@ impl Table {
             Table::Static(StaticTable::GcRef(_)) | Table::Dynamic(DynamicTable::GcRef(_)) => {
                 TableElementType::GcRef
             }
+            Table::Static(StaticTable::Cont(_)) | Table::Dynamic(DynamicTable::Cont(_)) => {
+                TableElementType::Cont
+            }
         }
     }
 
@@ -383,10 +475,14 @@ impl Table {
         match self {
             Table::Static(StaticTable::Func(StaticFuncTable { size, .. })) => *size,
             Table::Static(StaticTable::GcRef(StaticGcRefTable { size, .. })) => *size,
+            Table::Static(StaticTable::Cont(StaticContTable { size, .. })) => *size,
             Table::Dynamic(DynamicTable::Func(DynamicFuncTable { elements, .. })) => {
                 elements.len().try_into().unwrap()
             }
             Table::Dynamic(DynamicTable::GcRef(DynamicGcRefTable { elements, .. })) => {
+                elements.len().try_into().unwrap()
+            }
+            Table::Dynamic(DynamicTable::Cont(DynamicContTable { elements, .. })) => {
                 elements.len().try_into().unwrap()
             }
         }
@@ -406,8 +502,12 @@ impl Table {
             Table::Static(StaticTable::GcRef(StaticGcRefTable { data, .. })) => {
                 Some(u32::try_from(data.len()).unwrap())
             }
+            Table::Static(StaticTable::Cont(StaticContTable { data, .. })) => {
+                Some(u32::try_from(data.len()).unwrap())
+            }
             Table::Dynamic(DynamicTable::Func(DynamicFuncTable { maximum, .. })) => *maximum,
             Table::Dynamic(DynamicTable::GcRef(DynamicGcRefTable { maximum, .. })) => *maximum,
+            Table::Dynamic(DynamicTable::Cont(DynamicContTable { maximum, .. })) => *maximum,
         }
     }
 
@@ -501,6 +601,10 @@ impl Table {
                 let (funcrefs, _lazy_init) = self.funcrefs_mut();
                 funcrefs[start..end].fill(TaggedFuncRef::UNINIT);
             }
+            TableElement::ContRef(c) => {
+                let contrefs = self.contrefs_mut();
+                contrefs[start..end].fill(c);
+            }
         }
 
         Ok(())
@@ -582,6 +686,14 @@ impl Table {
                 }
                 *size = new_size;
             }
+            Table::Static(StaticTable::Cont(StaticContTable { data, size })) => {
+                unsafe {
+                    debug_assert!(data.as_ref()[*size as usize..new_size as usize]
+                        .iter()
+                        .all(|x| x.is_none()));
+                }
+                *size = new_size;
+            }
 
             // These calls to `resize` could move the base address of
             // `elements`. If this table's limits declare it to be fixed-size,
@@ -595,6 +707,9 @@ impl Table {
             }
             Table::Dynamic(DynamicTable::GcRef(DynamicGcRefTable { elements, .. })) => {
                 elements.resize_with(usize::try_from(new_size).unwrap(), || None);
+            }
+            Table::Dynamic(DynamicTable::Cont(DynamicContTable { elements, .. })) => {
+                elements.resize(usize::try_from(new_size).unwrap(), None);
             }
         }
 
@@ -621,6 +736,11 @@ impl Table {
                 let r = r.as_ref().map(|r| gc_store.clone_gc_ref(r));
                 TableElement::GcRef(r)
             }),
+            TableElementType::Cont => self
+                .contrefs()
+                .get(index)
+                .copied()
+                .map(|e| TableElement::ContRef(e)),
         }
     }
 
@@ -647,6 +767,9 @@ impl Table {
             }
             TableElement::GcRef(e) => {
                 *self.gc_refs_mut().get_mut(index).ok_or(())? = e;
+            }
+            TableElement::ContRef(c) => {
+                *self.contrefs_mut().get_mut(index).ok_or(())? = c;
             }
         }
         Ok(())
@@ -711,6 +834,10 @@ impl Table {
                     current_elements: *size,
                 }
             }
+            Table::Static(StaticTable::Cont(StaticContTable { data, size })) => VMTableDefinition {
+                base: data.as_ptr().cast(),
+                current_elements: *size,
+            },
             Table::Dynamic(DynamicTable::Func(DynamicFuncTable { elements, .. })) => {
                 VMTableDefinition {
                     base: elements.as_mut_ptr().cast(),
@@ -718,6 +845,12 @@ impl Table {
                 }
             }
             Table::Dynamic(DynamicTable::GcRef(DynamicGcRefTable { elements, .. })) => {
+                VMTableDefinition {
+                    base: elements.as_mut_ptr().cast(),
+                    current_elements: elements.len().try_into().unwrap(),
+                }
+            }
+            Table::Dynamic(DynamicTable::Cont(DynamicContTable { elements, .. })) => {
                 VMTableDefinition {
                     base: elements.as_mut_ptr().cast(),
                     current_elements: elements.len().try_into().unwrap(),
@@ -791,6 +924,32 @@ impl Table {
         }
     }
 
+    fn contrefs(&self) -> &[Option<VMContObj>] {
+        assert_eq!(self.element_type(), TableElementType::Cont);
+        match self {
+            Self::Dynamic(DynamicTable::Cont(DynamicContTable { elements, .. })) => unsafe {
+                slice::from_raw_parts(elements.as_ptr().cast(), elements.len())
+            },
+            Self::Static(StaticTable::Cont(StaticContTable { data, size })) => unsafe {
+                slice::from_raw_parts(data.as_ptr().cast(), usize::try_from(*size).unwrap())
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn contrefs_mut(&mut self) -> &mut [Option<VMContObj>] {
+        assert_eq!(self.element_type(), TableElementType::Cont);
+        match self {
+            Self::Dynamic(DynamicTable::Cont(DynamicContTable { elements, .. })) => unsafe {
+                slice::from_raw_parts_mut(elements.as_mut_ptr().cast(), elements.len())
+            },
+            Self::Static(StaticTable::Cont(StaticContTable { data, size })) => unsafe {
+                slice::from_raw_parts_mut(data.as_ptr().cast(), usize::try_from(*size).unwrap())
+            },
+            _ => unreachable!(),
+        }
+    }
+
     /// Get this table's GC references as a slice.
     ///
     /// Panics if this is not a table of GC references.
@@ -838,6 +997,11 @@ impl Table {
                     );
                 }
             }
+            TableElementType::Cont => {
+                // `contref` are `Copy`, so just do a mempcy
+                dst_table.contrefs_mut()[dst_range]
+                    .copy_from_slice(&src_table.contrefs()[src_range]);
+            }
         }
     }
 
@@ -883,6 +1047,10 @@ impl Table {
                         gc_store.write_gc_ref(dst, src);
                     }
                 }
+            }
+            TableElementType::Cont => {
+                // `contref` are `Copy`, so just do a memmove
+                self.contrefs_mut().copy_within(src_range, dst_range.start);
             }
         }
     }


### PR DESCRIPTION
This patch removes the "interpret continuation tables as function references tables" hack in favour of a dedicated handling of continuation tables. 

Note this patch does not implement the embedder-side of things.

Resolves #133.
