### PR TITLE
Continuation objects as fat pointers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -657,6 +657,12 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+    # Crude check for whether
+    # `unsafe_disable_continuation_linearity_check` makes the test
+    # `cont_twice` fail.
+    - run: |
+        cargo test --features=unsafe_disable_continuation_linearity_check --test wast -- --exact Cranelift/tests/misc_testsuite/typed-continuations/cont_twice.wast; test $? -eq 101
+
     # NB: the test job here is explicitly lacking in cancellation of this run if
     # something goes wrong. These take the longest anyway and otherwise if
     # Windows fails GitHub Actions will confusingly mark the failed Windows job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -661,7 +661,7 @@ jobs:
     # `unsafe_disable_continuation_linearity_check` makes the test
     # `cont_twice` fail.
     - run: |
-        cargo test --features=unsafe_disable_continuation_linearity_check --test wast -- --exact Cranelift/tests/misc_testsuite/typed-continuations/cont_twice.wast; test $? -eq 101
+        (cargo test --features=unsafe_disable_continuation_linearity_check --test wast -- --exact Cranelift/tests/misc_testsuite/typed-continuations/cont_twice.wast && test $? -eq 101) || test $? -eq 101
 
     # NB: the test job here is explicitly lacking in cancellation of this run if
     # something goes wrong. These take the longest anyway and otherwise if

--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -339,9 +339,8 @@ impl MemFlags {
             0b1010 => Some(TrapCode::Interrupt),
             0b1011 => Some(TrapCode::NullReference),
             0b1100 => Some(TrapCode::NullI31Ref),
-            0b1101 => Some(TrapCode::UnhandledTag),
-            // 0b1101 => {} not allocated
-            // 0b1110 => {} not allocated
+            0b1110 => Some(TrapCode::UnhandledTag),
+            0b1101 => Some(TrapCode::ContinuationAlreadyConsumed),
             0b1111 => None,
             _ => unreachable!(),
         }

--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -369,7 +369,8 @@ impl MemFlags {
             Some(TrapCode::Interrupt) => 0b1010,
             Some(TrapCode::NullReference) => 0b1011,
             Some(TrapCode::NullI31Ref) => 0b1100,
-            Some(TrapCode::UnhandledTag) => 0b1101,
+            Some(TrapCode::UnhandledTag) => 0b1110,
+            Some(TrapCode::ContinuationAlreadyConsumed) => 0b1101,
             None => 0b1111,
 
             Some(TrapCode::User(_)) => panic!("cannot set user trap code in mem flags"),

--- a/cranelift/codegen/src/ir/trapcode.rs
+++ b/cranelift/codegen/src/ir/trapcode.rs
@@ -58,6 +58,10 @@ pub enum TrapCode {
     /// We are suspending to a tag for which there is no active handler.
     UnhandledTag,
 
+    /// Attempt to resume a continuation object whose revision is out
+    /// of sync with the underlying continuation reference.
+    ContinuationAlreadyConsumed,
+
     /// A null `i31ref` was encountered which was required to be non-null.
     NullI31Ref,
 }
@@ -79,6 +83,7 @@ impl TrapCode {
             TrapCode::Interrupt,
             TrapCode::NullReference,
             TrapCode::UnhandledTag,
+            TrapCode::ContinuationAlreadyConsumed,
         ]
     }
 }
@@ -102,6 +107,7 @@ impl Display for TrapCode {
             NullReference => "null_reference",
             UnhandledTag => "unhandled_tag",
             NullI31Ref => "null_i31ref",
+            ContinuationAlreadyConsumed => "continuation_already_consumed",
         };
         f.write_str(identifier)
     }
@@ -127,6 +133,7 @@ impl FromStr for TrapCode {
             "null_reference" => Ok(NullReference),
             "unhandled_tag" => Ok(UnhandledTag),
             "null_i31ref" => Ok(NullI31Ref),
+            "continuation_already_consumed" => Ok(ContinuationAlreadyConsumed),
             _ if s.starts_with("user") => s[4..].parse().map(User).map_err(|_| ()),
             _ => Err(()),
         }

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -56,7 +56,7 @@ pub mod types {
 /// line.
 ///
 /// Part of wasmtime::config::Config type (which is not in scope in this crate).
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct WasmFXConfig {
     pub stack_size: usize,
 
@@ -95,6 +95,7 @@ unsafe impl Send for StackLimits {}
 unsafe impl Sync for StackLimits {}
 
 #[repr(C)]
+#[derive(Debug, Clone)]
 pub struct Payloads {
     /// Number of currently occupied slots.
     pub length: types::payloads::Length,
@@ -134,7 +135,7 @@ pub const STACK_CHAIN_MAIN_STACK_DISCRIMINANT: usize = 1;
 pub const STACK_CHAIN_CONTINUATION_DISCRIMINANT: usize = 2;
 
 /// Encodes the life cycle of a `VMContRef`.
-#[derive(PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[repr(i32)]
 pub enum State {
     /// The `VMContRef` has been created, but `resume` has never been
@@ -169,6 +170,7 @@ pub type TagId = u32;
 
 /// See SwitchDirection below for overall use of this type.
 #[repr(u32)]
+#[derive(Debug, Clone)]
 pub enum SwitchDirectionEnum {
     // Used to indicate that the contination has returned normally.
     Return = 0,
@@ -215,6 +217,7 @@ impl SwitchDirectionEnum {
 /// In that representation, bits 0 to 31 (where 0 is the LSB) contain the
 /// discriminant (as u32), while bits 32 to 63 contain the `data`.
 #[repr(C)]
+#[derive(Debug, Clone)]
 pub struct SwitchDirection {
     pub discriminant: SwitchDirectionEnum,
 

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -305,6 +305,8 @@ pub mod offsets {
         pub const TAG_RETURN_VALUES: usize = ARGS + core::mem::size_of::<Payloads>();
         /// Offset of `state` field
         pub const STATE: usize = TAG_RETURN_VALUES + core::mem::size_of::<Payloads>();
+        /// Offset of `revision` field
+        pub const REVISION: usize = STATE + core::mem::size_of::<usize>();
     }
 
     pub mod stack_limits {

--- a/crates/cranelift-shared/src/lib.rs
+++ b/crates/cranelift-shared/src/lib.rs
@@ -87,6 +87,8 @@ pub fn mach_trap_to_trap(trap: &MachTrap) -> Option<TrapInformation> {
             ir::TrapCode::User(CANNOT_ENTER_CODE) => Trap::CannotEnterComponent,
             ir::TrapCode::NullReference => Trap::NullReference,
             ir::TrapCode::NullI31Ref => Trap::NullI31Ref,
+            ir::TrapCode::UnhandledTag => Trap::UnhandledTag,
+            ir::TrapCode::ContinuationAlreadyConsumed => Trap::ContinuationAlreadyConsumed,
 
             // These do not get converted to wasmtime traps, since they
             // shouldn't ever be hit in theory. Instead of catching and handling

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -306,6 +306,7 @@ pub fn mach_trap_to_trap(trap: &MachTrap) -> Option<TrapInformation> {
             ir::TrapCode::NullReference => Trap::NullReference,
             ir::TrapCode::UnhandledTag => Trap::UnhandledTag,
             ir::TrapCode::NullI31Ref => Trap::NullI31Ref,
+            ir::TrapCode::ContinuationAlreadyConsumed => Trap::ContinuationAlreadyConsumed,
 
             // These do not get converted to wasmtime traps, since they
             // shouldn't ever be hit in theory. Instead of catching and handling

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -8,8 +8,6 @@ use cranelift_codegen::ir::InstBuilder;
 use cranelift_frontend::{FunctionBuilder, Switch};
 use cranelift_wasm::FuncEnvironment;
 use cranelift_wasm::{FuncTranslationState, WasmResult, WasmValType};
-use shared::typed_continuations_cont_obj_get_cont_ref;
-use shared::typed_continuations_new_cont_obj;
 use wasmtime_environ::PtrSize;
 
 #[macro_use]
@@ -76,7 +74,7 @@ pub(crate) mod typed_continuation_helpers {
                          val: ir::Value| {
             let ty = builder.func.dfg.value_type(val);
             let val = match ty {
-                I32 => builder.ins().uextend(I64, val),
+                I8 | I32 => builder.ins().uextend(I64, val),
                 I64 => val,
                 _ => panic!("Cannot print type {}", ty),
             };
@@ -418,6 +416,47 @@ pub(crate) mod typed_continuation_helpers {
         ) {
             let offset = wasmtime_continuations::offsets::vm_cont_ref::PARENT_CHAIN as i32;
             new_stack_chain.store(env, builder, self.address, offset)
+        }
+
+        /// Gets the revision counter on the continuation references.
+        pub fn get_revision<'a>(
+            &mut self,
+            _env: &mut crate::func_environ::FuncEnvironment<'a>,
+            builder: &mut FunctionBuilder,
+        ) -> ir::Value {
+            if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
+                builder.ins().iconst(I64, 0)
+            } else {
+                let mem_flags = ir::MemFlags::trusted();
+                let offset = wasmtime_continuations::offsets::vm_cont_ref::REVISION as i32;
+                let revision = builder.ins().load(I64, mem_flags, self.address, offset);
+                revision
+            }
+        }
+
+        /// Increments the revision counter on the continuation references.
+        pub fn incr_revision<'a>(
+            &mut self,
+            _env: &mut crate::func_environ::FuncEnvironment<'a>,
+            builder: &mut FunctionBuilder,
+            revision: ir::Value,
+        ) -> ir::Value {
+            if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
+                builder.ins().iconst(I64, 0)
+            } else {
+                let mem_flags = ir::MemFlags::trusted();
+                let offset = wasmtime_continuations::offsets::vm_cont_ref::REVISION as i32;
+                let revision_plus1 = builder.ins().iadd_imm(revision, 1);
+                builder
+                    .ins()
+                    .store(mem_flags, revision_plus1, self.address, offset);
+                let overflow =
+                    builder
+                        .ins()
+                        .icmp_imm(IntCC::UnsignedLessThan, revision_plus1, 1 << 16);
+                builder.ins().trapz(overflow, ir::TrapCode::IntegerOverflow); // TODO(dhil): Consider introducing a designated trap code.
+                revision_plus1
+            }
         }
     }
 
@@ -1268,11 +1307,38 @@ pub(crate) fn translate_cont_bind<'a>(
     args: &[ir::Value],
     remaining_arg_count: usize,
 ) -> ir::Value {
-    let contref = typed_continuations_cont_obj_get_cont_ref(env, builder, contobj);
+    //let contref = typed_continuations_cont_obj_get_cont_ref(env, builder, contobj);
+    let (witness, contref) = shared::disassemble_contobj(env, builder, contobj);
+    let mut vmcontref = tc::VMContRef::new(contref, env.pointer_type());
+    let revision = vmcontref.get_revision(env, builder);
+    let evidence = builder.ins().icmp(IntCC::Equal, witness, revision);
+    if wasmtime_continuations::ENABLE_DEBUG_PRINTING {
+        emit_debug_println!(
+            env,
+            builder,
+            "[cont_bind] witness = {}, revision = {}, evidence = {}",
+            witness,
+            revision,
+            evidence
+        );
+    }
+    builder
+        .ins()
+        .trapz(evidence, ir::TrapCode::ContinuationAlreadyConsumed);
+
     let remaining_arg_count = builder.ins().iconst(I32, remaining_arg_count as i64);
     typed_continuations_store_resume_args(env, builder, args, remaining_arg_count, contref);
 
-    typed_continuations_new_cont_obj(env, builder, contref)
+    let revision = vmcontref.incr_revision(env, builder, revision);
+    if wasmtime_continuations::ENABLE_DEBUG_PRINTING {
+        emit_debug_println!(env, builder, "new revision = {}", revision);
+    }
+    //typed_continuations_new_cont_obj(env, builder, contref)
+    let contobj = shared::assemble_contobj(env, builder, revision, contref);
+    if wasmtime_continuations::ENABLE_DEBUG_PRINTING {
+        emit_debug_println!(env, builder, "[cont_bind] contobj = {:p}", contobj);
+    }
+    contobj
 }
 
 pub(crate) fn translate_cont_new<'a>(
@@ -1286,7 +1352,11 @@ pub(crate) fn translate_cont_new<'a>(
     let nargs = builder.ins().iconst(I32, arg_types.len() as i64);
     let nreturns = builder.ins().iconst(I32, return_types.len() as i64);
     call_builtin!(builder, env, let contref = tc_cont_new(func, nargs, nreturns));
-    let contobj = typed_continuations_new_cont_obj(env, builder, contref);
+    let tag = tc::VMContRef::new(contref, env.pointer_type()).get_revision(env, builder);
+    let contobj = shared::assemble_contobj(env, builder, tag, contref); // typed_continuations_new_cont_obj(env, builder, contref);
+    if wasmtime_continuations::ENABLE_DEBUG_PRINTING {
+        emit_debug_println!(env, builder, "[cont_new] contobj = {:p}", contobj);
+    }
     Ok(contobj)
 }
 
@@ -1308,9 +1378,24 @@ pub(crate) fn translate_resume<'a>(
 
     // Preamble: Part of previously active block
 
-    let (resume_contref, parent_stack_chain) = {
-        let resume_contref =
-            shared::typed_continuations_cont_obj_get_cont_ref(env, builder, contobj);
+    let (next_revision, resume_contref, parent_stack_chain) = {
+        let (witness, resume_contref) = shared::disassemble_contobj(env, builder, contobj);
+        //shared::typed_continuations_cont_obj_get_cont_ref(env, builder, contobj);
+
+        let mut vmcontref = tc::VMContRef::new(resume_contref, env.pointer_type());
+
+        let revision = vmcontref.get_revision(env, builder);
+        let evidence = builder.ins().icmp(IntCC::Equal, revision, witness);
+        if wasmtime_continuations::ENABLE_DEBUG_PRINTING {
+            emit_debug_println!(env, builder, "[resume] contobj = {:p}, resume_contref = {:p} witness = {}, revision = {}, evidence = {}", contobj, resume_contref, witness, revision, evidence);
+        }
+        builder
+            .ins()
+            .trapz(evidence, ir::TrapCode::ContinuationAlreadyConsumed);
+        let next_revision = vmcontref.incr_revision(env, builder, revision);
+        if wasmtime_continuations::ENABLE_DEBUG_PRINTING {
+            emit_debug_println!(env, builder, "[resume] new revision = {}", next_revision);
+        }
 
         if resume_args.len() > 0 {
             // We store the arguments in the `VMContRef` to be resumed.
@@ -1322,14 +1407,10 @@ pub(crate) fn translate_resume<'a>(
         let original_stack_chain =
             tc::VMContext::new(vmctx, env.pointer_type()).load_stack_chain(env, builder);
         original_stack_chain.assert_not_absent(env, builder);
-        tc::VMContRef::new(resume_contref, env.pointer_type()).set_parent_stack_chain(
-            env,
-            builder,
-            &original_stack_chain,
-        );
+        vmcontref.set_parent_stack_chain(env, builder, &original_stack_chain);
 
         builder.ins().jump(resume_block, &[]);
-        (resume_contref, original_stack_chain)
+        (next_revision, resume_contref, original_stack_chain)
     };
 
     // Resume block: actually resume the fiber corresponding to the
@@ -1499,12 +1580,23 @@ pub(crate) fn translate_resume<'a>(
         // link to `StackChain::Absent`.
         let pointer_type = env.pointer_type();
         let chain = tc::StackChain::absent(builder, pointer_type);
-        tc::VMContRef::new(resume_contref, pointer_type)
-            .set_parent_stack_chain(env, builder, &chain);
+        let mut vmcontref = tc::VMContRef::new(resume_contref, pointer_type);
+        vmcontref.set_parent_stack_chain(env, builder, &chain);
 
         // Create and push the continuation object. We only create
         // them here because we don't need them when forwarding.
-        let contobj = typed_continuations_new_cont_obj(env, builder, resume_contref);
+        // let revision = vmcontref.get_revision(env, builder);
+        let contobj = shared::assemble_contobj(env, builder, next_revision, resume_contref);
+        if wasmtime_continuations::ENABLE_DEBUG_PRINTING {
+            emit_debug_println!(
+                env,
+                builder,
+                "[resume] revision = {}, contobj = {:p}",
+                next_revision,
+                contobj
+            );
+        }
+        //let contobj = typed_continuations_new_cont_obj(env, builder, resume_contref);
 
         args.push(contobj);
 

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -105,13 +105,6 @@ macro_rules! foreach_builtin_function {
             tc_resume(vmctx: vmctx, contref: pointer, parent_stack_limits: pointer) -> i64;
             // Suspends a continuation.
             tc_suspend(vmctx: vmctx, tag: i32);
-            // Returns the continuation reference corresponding to the given continuation object.
-            tc_cont_obj_get_cont_ref(vmctx: vmctx, contobj: pointer) -> pointer;
-            // Drops the given continuation reference. Currently unused.
-            //cont_ref_drop(vmctx: vmctx, contref: pointer);
-            // Creates a new continuation object.
-            tc_new_cont_obj(vmctx: vmctx, contref: pointer) -> pointer;
-
 
             // Sets the tag return values of `child_contref` to those of `parent_contref`.
             // This is implemented by exchanging the pointers to the underlying buffers.

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -168,6 +168,9 @@ macro_rules! foreach_builtin_function {
             tc_print_int(vmctx: vmctx, arg : i64);
             // TODO
             tc_print_pointer(vmctx: vmctx, arg : pointer);
+
+            // Returns an index for Wasm's `table.grow` instruction for `contobj`s.
+            table_grow_cont_obj(vmctx: vmctx, table: i32, delta: i32, init: pointer) -> i32;
         }
     };
 }

--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -85,6 +85,9 @@ pub enum Trap {
 
     /// We are suspending to a tag for which there is no active handler.
     UnhandledTag,
+
+    /// Attempt to resume a continuation twice.
+    ContinuationAlreadyConsumed,
     // if adding a variant here be sure to update the `check!` macro below
 }
 
@@ -120,6 +123,7 @@ impl Trap {
             NullI31Ref
             CannotEnterComponent
             UnhandledTag
+            ContinuationAlreadyConsumed
         }
 
         None
@@ -149,6 +153,7 @@ impl fmt::Display for Trap {
             NullI31Ref => "null i31 reference",
             CannotEnterComponent => "cannot enter component instance",
             UnhandledTag => "unhandled tag",
+            ContinuationAlreadyConsumed => "continuation already consumed",
         };
         write!(f, "wasm trap: {desc}")
     }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -189,6 +189,8 @@ impl Table {
                         ty => unreachable!("not a top type: {ty:?}"),
                     }
                 }
+
+                runtime::TableElement::ContRef(_c) => todo!(), // TODO(dhil): Required for the embedder API.
             }
         }
     }

--- a/crates/wasmtime/src/runtime/vm/continuation.rs
+++ b/crates/wasmtime/src/runtime/vm/continuation.rs
@@ -16,7 +16,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "unsafe_disable_continuation_linearity_check")] {
         /// NOTE(dhil): This representation is never used, but added
         /// here to illustrate the semantics of the generated code.
-        #[repr(C)]
+        #[repr(transparent)]
         pub struct VMContObj(pub *mut imp::VMContRef);
 
         impl VMContObj {
@@ -25,7 +25,7 @@ cfg_if::cfg_if! {
             }
 
             pub fn take_contref(&mut self) -> Result<*mut imp::VMContRef> {
-                Ok(self.cast::<VMContRef>())
+                Ok(self.0.cast::<imp::VMContRef>())
             }
         }
     } else {

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -874,40 +874,6 @@ fn tc_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason>
     crate::vm::continuation::optimized::suspend(instance, tag_index)
 }
 
-fn tc_new_cont_obj(_instance: &mut Instance, contref: *mut u8) -> *mut u8 {
-    // If this is enabled, we should never call this function.
-    assert!(!cfg!(
-        feature = "unsafe_disable_continuation_linearity_check"
-    ));
-    crate::vm::continuation::VMContObj::new(
-        contref.cast::<crate::vm::continuation::imp::VMContRef>(),
-    )
-    .cast::<u8>()
-}
-
-fn tc_cont_obj_get_cont_ref(
-    _instance: &mut Instance,
-    contobj: *mut u8,
-) -> Result<*mut u8, TrapReason> {
-    // If this is enabled, we should never call this function.
-    assert!(!cfg!(
-        feature = "unsafe_disable_continuation_linearity_check"
-    ));
-
-    let contobj = contobj.cast::<crate::vm::continuation::VMContObj>();
-    let contobj = unsafe {
-        contobj.as_mut().ok_or_else(|| {
-            TrapReason::user_without_backtrace(anyhow::anyhow!(
-                "Attempt to dereference null VMContObj!"
-            ))
-        })?
-    };
-    let contref = contobj
-        .take_contref()
-        .map_err(|error| TrapReason::user_without_backtrace(error))?;
-    Ok(contref.cast::<u8>())
-}
-
 fn tc_cont_ref_forward_tag_return_values_buffer(
     _instance: &mut Instance,
     parent_contref: *mut u8,


### PR DESCRIPTION
This patch makes continuation objects allocation free by representing a continuation object as an immediate, whose 16 high bits are to be implemented as a witness of the continuation reference revision counter, and the 48 low bits are the actual continuation reference address. This gives us a cheap way of implementing the linearity check for continuations. Using 16 bits for the witness, means that we are currently restricted to 2^16 uses, which suffices for our examples and benchmarks, but isn't sufficient in general. However, we can readily generalise this implementation in a subsequent patch.

The compile time option `unsafe_disable_continuation_linearity_check` preserves its behaviour.

Resolves #178.