### PR TITLE
Enable typed-continuations feature by default

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -306,6 +306,19 @@ impl Config {
         // but it's not implemented in Wasmtime yet so disable it.
         ret.features.set(WasmFeatures::TAIL_CALL, false);
 
+        // WasmFX (aka typed-continuations) and its dependencies are enabled by
+        // default in our fork. This is just to make it easier to use.
+        // While the WasmFX proposal does not require garbage collection, it
+        // depends on the function references feature, whose implementation
+        // requires the Cargo feature "gc" to be present.
+        // We thus only enable WasmFX by default if the "gc" Cargo feature is
+        // enabled.
+        if cfg!(feature = "gc") {
+            ret.features.set(WasmFeatures::TYPED_CONTINUATIONS, true);
+            ret.features.set(WasmFeatures::EXCEPTIONS, true);
+            ret.features.set(WasmFeatures::FUNCTION_REFERENCES, true);
+        }
+
         ret
     }
 

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -1044,6 +1044,7 @@ fn pass_cross_store_arg(config: &mut Config) -> anyhow::Result<()> {
 fn externref_signature_no_reference_types() -> anyhow::Result<()> {
     let mut config = Config::new();
     config.wasm_reference_types(false);
+    config.wasm_function_references(false);
     let mut store = Store::new(&Engine::new(&config)?, ());
     Func::wrap(&mut store, |_: Option<Func>| {});
     let func_ty = FuncType::new(

--- a/tests/rlimited-memory.rs
+++ b/tests/rlimited-memory.rs
@@ -47,6 +47,7 @@ fn custom_limiter_detect_os_oom_failure() -> Result<()> {
     // memory grow will hit Linux for a larger mmap.
     let mut config = Config::new();
     config.wasm_reference_types(false);
+    config.wasm_function_references(false);
     let engine = Engine::new(&config)?;
     let linker = Linker::new(&engine);
     let module = Module::new(&engine, r#"(module (memory (export "m") 0))"#).unwrap();


### PR DESCRIPTION
This PR enables the `typed-continuations` Wasm feature by default, as well as its dependencies, as long as `gc` is enabled in Cargo.

This requires adapting two test cases that disable reference types. Otherwise, we would try to disable `reference-types` while keeping `function-references` enabled, even though it depends on the former.


