### PR TITLE
WasmFX-specific documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-This repository contains an up-to-date fork of [Wasmtime](https://docs.wasmtime.dev/), a standalone WebAssembly engine. This fork adds support for the [WasmFX](https://wasmfx.dev/) proposal for stack switching. 
+This repository contains an up-to-date fork of
+[Wasmtime](https://docs.wasmtime.dev/), a standalone WebAssembly engine. This
+fork adds support for the [WasmFX](https://wasmfx.dev/) proposal for stack
+switching. 
 
 The [stack switching repository](https://github.com/WebAssembly/stack-switching) contains a 
 [high-level summary of the proposal](https://github.com/WebAssembly/stack-switching/blob/main/proposals/continuations/Explainer.md),
@@ -7,11 +10,15 @@ and [examples](https://github.com/WebAssembly/stack-switching/tree/main/proposal
 
 ## Building 
 
-The build steps are equivalent to the [standard steps for building Wasmtime from source](https://docs.wasmtime.dev/contributing-building.html), but using this repository instead. There is no need to build or install the original version of Wasmtime to use this fork.
+The build steps are equivalent to the [standard steps for building Wasmtime from
+source](https://docs.wasmtime.dev/contributing-building.html), but using this
+repository instead. There is no need to build or install the original version of
+Wasmtime to use this fork.
 
 Concretely, the steps are as follows:
 
-1. Make sure that you have a Rust toolchain installed, for example using [rustup](https://www.rust-lang.org/tools/install).
+1. Make sure that you have a Rust toolchain installed, for example using
+   [rustup](https://www.rust-lang.org/tools/install).
 2. Check out this repository:
 ``` sh
 git clone https://github.com/wasmfx/wasmfxtime.git
@@ -23,14 +30,19 @@ git submodule update --init
 cargo build
 ```
 
-As a result, a debug build of the `wasmtime` executable will be created at `target/debug/wasmtime`.
+As a result, a debug build of the `wasmtime` executable will be created at
+`target/debug/wasmtime`.
 
-To create a release build instead, run `cargo build --release`, which will create `target/release/wasmtime`.
+To create a release build instead, run `cargo build --release`, which will
+create `target/release/wasmtime`.
 
 
 ## Running programs
 
-A WebAssembly module `my_module.wat` (or `my_module.wasm`)  is executed using the `wasmtime` executable [in the usual way](https://docs.wasmtime.dev/cli.html). To run programs containing WasmFX instructions, enable the necessary features as follows:
+A WebAssembly module `my_module.wat` (or `my_module.wasm`) is executed using the
+`wasmtime` executable [in the usual way](https://docs.wasmtime.dev/cli.html). To
+run programs containing WasmFX instructions, enable the necessary features as
+follows:
 
 ``` sh
 wasmtime -W=exceptions,function-references,typed-continuations my_module.wat
@@ -102,7 +114,9 @@ The following module implements a generator and consumer using stack switching.
 )
 ```
 
-See [examples/generator.wat](https://github.com/frank-emrich/wasmtime/blob/main/examples/generator.wat) for the full version of the file, including the definition of `$println_u32`.
+See
+[examples/generator.wat](https://github.com/frank-emrich/wasmtime/blob/main/examples/generator.wat)
+for the full version of the file, including the definition of `$println_u32`.
 
 Running the full version with 
 ```
@@ -115,7 +129,9 @@ then prints the numbers 100 down to 1 in the terminal.
 
 The implementation of the WasmFX proposal is currently limited in a few ways:
 - The only supported platform is x64 Linux. 
-- Only a single module can be executed. In particular, providing additional modules using the `--preload` option of `wasmtime` can lead to unexpected behavior.
+- Only a single module can be executed. In particular, providing additional
+  modules using the `--preload` option of `wasmtime` can lead to unexpected
+  behavior.
 
 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ git clone https://github.com/wasmfx/wasmfxtime.git
 cd wasmfxtime
 git submodule update --init
 ```
-3. Build:
+3. Build in debug mode:
 ``` sh
 cargo build
 ```
@@ -33,22 +33,20 @@ cargo build
 As a result, a debug build of the `wasmtime` executable will be created at
 `target/debug/wasmtime`.
 
-To create a release build instead, run `cargo build --release`, which will
-create `target/release/wasmtime`.
+Analogously, to build in release mode run `cargo build --release`, which places the `wasmtime` artifact in `target/release/`.
 
 
 ## Running programs
 
-A WebAssembly module `my_module.wat` (or `my_module.wasm`) is executed using the
-`wasmtime` executable [in the usual way](https://docs.wasmtime.dev/cli.html). To
-run programs containing WasmFX instructions, enable the necessary features as
-follows:
+The `wasmtime` executable can compile and run WebAssembly modules [in the usual way](https://docs.wasmtime.dev/cli.html). However, if a module contains WasmFX instructions, then it is necessary to enable additional features, e.g.
 
 ``` sh
 wasmtime -W=exceptions,function-references,typed-continuations my_module.wat
 ```
 
-To run an arbitrary function exported as `foo` by the module run 
+The first two features are prerequisite features, i.e. the `exceptions` feature is required to support WebAssembly tags and the `function-references` feature is required to support typed references. The `typed-continuations` feature enables support for the WasmFX instruction set.
+
+To run an arbitrary function exported as `foo` by the module type 
 
 ``` sh
 wasmtime -W=exceptions,function-references,typed-continuations --invoke=foo my_module.wat

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Concretely, the steps are as follows:
 1. Make sure that you have a Rust toolchain installed, for example using
    [rustup](https://www.rust-lang.org/tools/install).
 2. Check out this repository:
-``` sh
+```sh
 git clone https://github.com/wasmfx/wasmfxtime.git
 cd wasmfxtime
 git submodule update --init
 ```
 3. Build in debug mode:
-``` sh
+```sh
 cargo build
 ```
 
@@ -40,7 +40,7 @@ Analogously, to build in release mode run `cargo build --release`, which places 
 
 The `wasmtime` executable can compile and run WebAssembly modules [in the usual way](https://docs.wasmtime.dev/cli.html). However, if a module contains WasmFX instructions, then it is necessary to enable additional features, e.g.
 
-``` sh
+```sh
 wasmtime -W=exceptions,function-references,typed-continuations my_module.wat
 ```
 
@@ -48,7 +48,7 @@ The first two features are prerequisite features, i.e. the `exceptions` feature 
 
 To run an arbitrary function exported as `foo` by the module type 
 
-``` sh
+```sh
 wasmtime -W=exceptions,function-references,typed-continuations --invoke=foo my_module.wat
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ This repository contains an up-to-date fork of
 fork adds support for the [WasmFX](https://wasmfx.dev/) proposal for stack
 switching. 
 
+Additional key resources are
+* An [explainer document](https://github.com/WebAssembly/stack-switching/blob/main/proposals/continuations/Explainer.md) with an informal introduction to the instruction set extension along with [example programs](https://github.com/WebAssembly/stack-switching/tree/main/proposals/continuations/examples).
+* A [formal description](https://github.com/WebAssembly/stack-switching/blob/main/proposals/continuations/Overview.md) of the extension.
+* A collection of [benchmark programs](https://github.com/wasmfx/benchfx) and a prototype library for [asynchronous I/O programming](https://github.com/wasmfx/waeio) leveraging the instruction extension.
+
 The [stack switching repository](https://github.com/WebAssembly/stack-switching) contains a 
 [high-level summary of the proposal](https://github.com/WebAssembly/stack-switching/blob/main/proposals/continuations/Explainer.md),
 [a more formal description](https://github.com/WebAssembly/stack-switching/blob/main/proposals/continuations/Overview.md),

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-This repository contains an up-to-date fork of
-[Wasmtime](https://docs.wasmtime.dev/), a standalone WebAssembly engine. This
-fork adds support for the [WasmFX](https://wasmfx.dev/) proposal for stack
-switching. 
+This repository is a fork of [Wasmtime](https://docs.wasmtime.dev/) extended
+with support for the [WasmFX](https://wasmfx.dev/) instruction set. WasmFX adds
+stack switching capabilities to core Wasm, thereby enabling interleaving of
+computation. The design of the instruction set extension is based on [effect
+handlers](https://effect-handlers.org), which provide a structured facility for
+handling non-local control flow. 
 
 Additional key resources are
 * An [explainer document](https://github.com/WebAssembly/stack-switching/blob/main/proposals/continuations/Explainer.md) with an informal introduction to the instruction set extension along with [example programs](https://github.com/WebAssembly/stack-switching/tree/main/proposals/continuations/examples).

--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ Additional key resources are
 * A [formal description](https://github.com/WebAssembly/stack-switching/blob/main/proposals/continuations/Overview.md) of the extension.
 * A collection of [benchmark programs](https://github.com/wasmfx/benchfx) and a prototype library for [asynchronous I/O programming](https://github.com/wasmfx/waeio) leveraging the instruction extension.
 
-The [stack switching repository](https://github.com/WebAssembly/stack-switching) contains a 
-[high-level summary of the proposal](https://github.com/WebAssembly/stack-switching/blob/main/proposals/continuations/Explainer.md),
-[a more formal description](https://github.com/WebAssembly/stack-switching/blob/main/proposals/continuations/Overview.md),
-and [examples](https://github.com/WebAssembly/stack-switching/tree/main/proposals/continuations/examples).
-
 ## Building 
 
 The build steps are equivalent to the [standard steps for building Wasmtime from

--- a/examples/generator.wat
+++ b/examples/generator.wat
@@ -1,0 +1,124 @@
+(module
+  (type $ft (func))
+  (type $ct (cont $ft))
+
+  ;; Tag used by generator, the i32 payload corresponds to the generated values
+  (tag $yield (param i32))
+
+
+  ;; Import only required for printing
+  (import "wasi_snapshot_preview1" "fd_write"
+     (func $wasmi_fd_write (param $fd i32)
+                  (param $iovec i32)
+                  (param $len i32)
+                  (param $written i32) (result i32)))
+
+  ;; Memory only required for printing
+  (memory 24)
+  (export "memory" (memory 0))
+
+
+  ;; Printing function for unsigned integers.
+  ;; This function is unrelated to stack switching.
+  (func $println_u32 (param $value i32)
+
+    ;; We use the linear memory as follows:
+    ;;
+    ;; Offset | Size | Content
+    ;; ---------------------------------------------------------------------------
+    ;;      0 |    4 | Constant i32 value:
+    ;;      4 |    4 | Size of string: 2 + number of digits
+    ;;      8 |   10 | Digits of $num, ASCII-encoded, with last digit at offset 17
+    ;;     18 |    1 | Constant i32 value: 10 (newline)
+    ;;     19 |    1 | Constant i32 value: 0 (\0)
+    ;;     20 |    4 | Result area for $wasi_fd_write to put written length
+
+    ;; index into memory where we write the next digit of $value
+    (local $digit_address i32)
+
+    (local.set $digit_address (i32.const 17))
+
+    (loop $l
+      ;; address where to write next digit
+      (local.get $digit_address)
+      ;; calculate next digit to print
+      (i32.rem_u (local.get $value) (i32.const 10))
+      ;; convert number to ASCII
+      (i32.add (i32.const 48))
+
+      (i32.store8)
+
+      ;; decrement address
+      (i32.sub (local.get $digit_address) (i32.const 1))
+      (local.set $digit_address)
+
+      ;; right-shift $value in base 10
+      (i32.div_u (local.get $value) (i32.const 10))
+      (local.tee $value)
+
+      (br_if $l)
+    )
+
+    ;; Write \n and \0
+    (i32.store8 (i32.const 18) (i32.const 10))
+    (i32.store8 (i32.const 19) (i32.const 0))
+
+    ;; Write iovec part1: start of string
+    (i32.const 0) ;; offset
+    ;; start of the string:
+    (i32.add (local.get $digit_address) (i32.const 1))
+    (i32.store)
+
+    (i32.const 4)                ;; offset
+    ;; value, the length of the string:
+    ;; NB: 19 is address of last byte of the string
+    (i32.sub (i32.const 19) (local.get $digit_address))
+    (i32.store offset=0 align=2)
+    (i32.const 1)   ;; 1 for stdout
+    (i32.const 0)   ;; 0 as we stored the beginning of __wasi_ciovec_t
+    (i32.const 1)   ;;
+    (i32.const 24)  ;; nwritten
+    (call $wasmi_fd_write)
+    (drop)
+  )
+
+
+  ;; Simple generator yielding values from 100 down to 1
+  (func $generator
+    (local $i i32)
+    (local.set $i (i32.const 100))
+    (loop $l
+      ;; Suspend generator, yield current value of $i to consumer
+      (suspend $yield (local.get $i))
+      ;; Decrement $i and exit loop once $i reaches 0
+      (local.tee $i (i32.sub (local.get $i) (i32.const 1)))
+      (br_if $l)
+    )
+  )
+  (elem declare func $generator)
+
+  (func $consumer
+    (local $c (ref $ct))
+    ;; Create continuation executing function $generator
+    (local.set $c (cont.new $ct (ref.func $generator)))
+
+    (loop $loop
+      (block $on_yield (result i32 (ref $ct))
+        ;; Resume continuation $c
+        (resume $ct (tag $yield $on_yield) (local.get $c))
+        ;; Generator returned: no more data
+        (return)
+      )
+      ;; Generator suspend, stack contains [i32 (ref $ct)]
+      (local.set $c)
+      ;; Stack now contains the i32 value yielded by generator
+      (call $println_u32)
+
+      (br $loop)
+    )
+  )
+
+  (func $start (export "_start")
+    (call $consumer)
+  )
+)


### PR DESCRIPTION
This PR adds some documentation at the beginning of README.md, with the original Wasmtime documentation left below.

The README contains a minimal generator example to facilitate just copy-pasting it elsewhere and playing with it. The full version of the example, where printing is actually implemented, is put in `examples/generator.wat`.
