### PR TITLE
Linking tags

### DIFF
--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2579,9 +2579,8 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let params = state.peekn(param_types.len());
             let param_count = params.len();
 
-            let tag_index_val = builder.ins().iconst(I32, *tag_index as i64);
             let return_values =
-                environ.translate_suspend(builder, tag_index_val, params, &return_types);
+                environ.translate_suspend(builder, *tag_index, params, &return_types);
 
             state.popn(param_count);
             state.pushn(&return_values);

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -647,7 +647,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn translate_suspend(
         &mut self,
         builder: &mut FunctionBuilder,
-        tag_index: ir::Value,
+        tag_index: u32,
         suspend_args: &[ir::Value],
         tag_return_types: &[wasmtime_types::WasmValType],
     ) -> Vec<ir::Value>;

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -27,9 +27,7 @@ use wasmtime_types::ConstExpr;
 
 fn tag(e: TagType) -> Tag {
     match e.kind {
-        wasmparser::TagKind::Exception => Tag {
-            ty: TypeIndex::from_u32(e.func_type_idx),
-        },
+        wasmparser::TagKind::Exception => Tag::partial(e.func_type_idx),
     }
 }
 

--- a/crates/c-api/src/extern.rs
+++ b/crates/c-api/src/extern.rs
@@ -21,6 +21,7 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
         Extern::Table(_) => crate::WASM_EXTERN_TABLE,
         Extern::Memory(_) => crate::WASM_EXTERN_MEMORY,
         Extern::SharedMemory(_) => todo!(),
+        Extern::Tag(_) => todo!(),
     }
 }
 
@@ -141,6 +142,7 @@ impl From<Extern> for wasmtime_extern_t {
                     sharedmemory: ManuallyDrop::new(Box::new(sharedmemory)),
                 },
             },
+            Extern::Tag(_) => todo!(),
         }
     }
 }

--- a/crates/c-api/src/types/extern.rs
+++ b/crates/c-api/src/types/extern.rs
@@ -25,6 +25,7 @@ impl CExternType {
             ExternType::Global(f) => CExternType::Global(CGlobalType::new(f)),
             ExternType::Memory(f) => CExternType::Memory(CMemoryType::new(f)),
             ExternType::Table(f) => CExternType::Table(CTableType::new(f)),
+            ExternType::Tag(_) => todo!(),
         }
     }
 }

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -259,15 +259,15 @@ pub struct ControlEffect(TaggedPointer);
 impl ControlEffect {
     pub fn suspend(ptr: *const u8) -> Self {
         let tptr = TaggedPointer::untagged(ptr as usize);
-        Self(TaggedPointer::low_tag(tptr, 0b01))
+        Self(TaggedPointer::low_tag(tptr, 0b01_usize))
     }
 
     pub fn return_() -> Self {
-        Self((0b00 as usize).into())
+        Self((0b00_usize).into())
     }
 
     pub fn resume() -> Self {
-        Self((0b11 as usize).into())
+        Self((0b11_usize).into())
     }
 
     fn new(raw: usize) -> Self {

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -216,7 +216,8 @@ pub mod offsets {
 pub struct TaggedPointer(usize);
 
 impl TaggedPointer {
-    const LOW_TAG_MASK: usize = 0b11;
+    const LOW_TAG_BITS: usize = 2;
+    const LOW_TAG_MASK: usize = (1 << Self::LOW_TAG_BITS) - 1;
 
     pub fn untagged(val: usize) -> Self {
         Self(val)

--- a/crates/cranelift/src/wasmfx/baseline.rs
+++ b/crates/cranelift/src/wasmfx/baseline.rs
@@ -443,12 +443,13 @@ pub(crate) fn translate_cont_new<'a>(
 pub(crate) fn translate_suspend<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    tag_index: ir::Value,
+    tag_index: u32,
     suspend_args: &[ir::Value],
     tag_return_types: &[WasmValType],
 ) -> Vec<ir::Value> {
+    let tag_index_val = builder.ins().iconst(I32, tag_index as i64);
     typed_continuations_store_payloads(env, builder, suspend_args);
-    call_builtin!(builder, env, tc_baseline_suspend(tag_index));
+    call_builtin!(builder, env, tc_baseline_suspend(tag_index_val));
     let contref = typed_continuations_load_continuation_reference(env, builder);
 
     let return_values =

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -1712,6 +1712,7 @@ pub(crate) fn translate_suspend<'a>(
     typed_continuations_store_payloads(env, builder, suspend_args);
 
     let tag_addr = shared::tag_address(env, builder, tag_index);
+    emit_debug_println!(env, builder, "[suspend] suspending with tag {:p}", tag_addr);
     call_builtin!(builder, env, tc_suspend(tag_addr));
 
     let contref = typed_continuations_load_continuation_reference(env, builder);

--- a/crates/cranelift/src/wasmfx/optimized.rs
+++ b/crates/cranelift/src/wasmfx/optimized.rs
@@ -5,13 +5,13 @@ use cranelift_codegen::ir;
 use cranelift_codegen::ir::condcodes::*;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::InstBuilder;
-use cranelift_frontend::{FunctionBuilder, Switch};
+use cranelift_frontend::FunctionBuilder;
 use cranelift_wasm::FuncEnvironment;
 use cranelift_wasm::{FuncTranslationState, WasmResult, WasmValType};
 use wasmtime_environ::PtrSize;
 
 #[cfg_attr(feature = "wasmfx_baseline", allow(unused_imports))]
-pub(crate) use shared::{assemble_contobj, disassemble_contobj, vm_contobj_type};
+pub(crate) use shared::{assemble_contobj, disassemble_contobj, vm_contobj_type, ControlEffect};
 
 #[macro_use]
 pub(crate) mod typed_continuation_helpers {
@@ -1369,16 +1369,63 @@ pub(crate) fn translate_resume<'a>(
     resume_args: &[ir::Value],
     resumetable: &[(u32, ir::Block)],
 ) -> Vec<ir::Value> {
+    // The resume instruction is the most involved instruction to
+    // compile as it is responsible for both continuation application
+    // and control tag dispatch.
+    //
+    // We store the continuation arguments, continuation return
+    // values, and suspension payloads on the vm context.
+    //
+    // Here we translate a resume instruction into several basic
+    // blocks as follows:
+    //
+    //        prelude_block
+    //              |
+    //              |
+    //        resume_block <-----------\
+    //              |                  |
+    //              |                  |
+    //         control_block           |
+    //        /             \          |
+    //        |             |          |
+    //  return_block  dispatch_block   |
+    //                      |          |
+    //                      |          |
+    //                 forward_block --/
+    //
+    // * prelude_block pushes the continuation arguments onto the
+    //   buffer in the libcall context.
+    // * resume_block continues a given `contref`. It jumps to
+    //   the `control_block`.
+    // * control_block handles the control effect of resume, i.e. on
+    //   ordinary return from resume, it jumps to the `return_block`,
+    //   whereas on suspension it jumps to the `dispatch_block`.
+    // * return_block reads the return values from the libcall
+    //   context.
+    // * dispatch_block(NOTE1) dispatches on a tag provided by the
+    //   control_block to an associated user-defined block. If
+    //   there is no suitable user-defined block, then it jumps to
+    //   the forward_block.
+    // * forward_block dispatches the handling of a given tag to
+    //   the ambient context. Once control returns it jumps to the
+    //   resume_block to continue continuation at the suspension
+    //   site.
+    //
+    // NOTE1: The dispatch block is the head of a collection of blocks
+    // which encodes a right-leaning (almost binary) decision tree,
+    // that is a series of nested if-then-else. The `then` branch
+    // contains a "leaf" node which setups the jump to a user-defined
+    // handler block, whilst the `else` branch contains another
+    // decision tree or the forward_block.
     let resume_block = builder.create_block();
     let return_block = builder.create_block();
-    let suspend_block = builder.create_block();
-    let switch_block = builder.create_block();
+    let control_block = builder.create_block();
+    let dispatch_block = builder.create_block();
     let forwarding_block = builder.create_block();
 
     let vmctx = env.vmctx_val(&mut builder.cursor());
 
-    // Preamble: Part of previously active block
-
+    // Preamble: Part of previously active block.
     let (next_revision, resume_contref, parent_stack_chain) = {
         let (witness, resume_contref) = shared::disassemble_contobj(env, builder, contobj);
 
@@ -1468,47 +1515,35 @@ pub(crate) fn translate_resume<'a>(
 
         // Now the parent contref (or main stack) is active again
         vmctx.store_stack_chain(env, builder, &parent_stack_chain);
-
-        // The `result` is a value of type wasmtime_continuations::SwitchDirection,
-        // using the encoding described at its definition.
-        // Thus, the first 32 bit encode the discriminant, and the
-        // subsequent 32 bit encode the tag if suspending, or 0 otherwise.
-        // Thus, when returning, the overall u64 should be zero.
-        let return_discriminant =
-            wasmtime_continuations::SwitchDirectionEnum::Return.discriminant_val();
-        debug_assert_eq!(return_discriminant, 0);
-
-        // If these two assumptions don't hold anymore, the code here becomes invalid.
-        debug_assert_eq!(
-            std::mem::size_of::<wasmtime_continuations::types::switch_reason::Discriminant>(),
-            4
-        );
-        debug_assert_eq!(
-            std::mem::size_of::<wasmtime_continuations::types::switch_reason::Data>(),
-            4
-        );
-
-        if cfg!(debug_assertions) {
-            let discriminant = builder.ins().ireduce(I32, result);
-            emit_debug_println!(env, builder, "[resume] discriminant is {}", discriminant);
-        }
-
         let vm_runtime_limits_ptr = vmctx.load_vm_runtime_limits_ptr(env, builder);
 
-        // Jump to the return block if the result is 0, otherwise jump to
+        // Extract the result and signal bit.
+        let result = ControlEffect::new(result);
+        let signal = ControlEffect::signal(result, env, builder);
+
+        emit_debug_println!(
+            env,
+            builder,
+            "[resume] in resume block, signal is {}",
+            signal
+        );
+
+        // Jump to the return block if the result signal is 0, otherwise jump to
         // the suspend block.
         builder
             .ins()
-            .brif(result, suspend_block, &[], return_block, &[]);
+            .brif(signal, control_block, &[], return_block, &[]);
 
         // We do not seal this block, yet, because the effect forwarding block has a back edge to it
         (result, vm_runtime_limits_ptr)
     };
 
-    // Suspend block.
-    let tag = {
-        builder.switch_to_block(suspend_block);
-        builder.seal_block(suspend_block);
+    // The control block; here we extract the tag of the suspension
+    // (regardless of whether an actual suspension occurred... the
+    // return_block never reads `tag`).
+    let suspend_tag_addr = {
+        builder.switch_to_block(control_block);
+        builder.seal_block(control_block);
 
         // We store parts of the VMRuntimeLimits into the continuation that just suspended.
         let suspended_chain =
@@ -1519,71 +1554,96 @@ pub(crate) fn translate_resume<'a>(
         // parent of the suspended continuation (which is now active).
         parent_stack_chain.write_limits_to_vmcontext(env, builder, vm_runtime_limits_ptr);
 
-        let discriminant = builder.ins().ireduce(I32, resume_result);
-        let discriminant_size_bytes =
-            std::mem::size_of::<wasmtime_continuations::types::switch_reason::Discriminant>();
-
-        if cfg!(debug_assertions) {
-            let suspend_discriminant =
-                wasmtime_continuations::SwitchDirectionEnum::Suspend.discriminant_val();
-            let suspend_discriminant = builder.ins().iconst(I32, suspend_discriminant as i64);
-            emit_debug_assert_eq!(env, builder, discriminant, suspend_discriminant);
-        }
-
-        let tag = builder
-            .ins()
-            .ushr_imm(resume_result, discriminant_size_bytes as i64 * 8);
-        let tag = builder.ins().ireduce(I32, tag);
-
-        emit_debug_println!(env, builder, "[resume] in suspend block, tag is {}", tag);
+        // Extract the tag
+        let tag = ControlEffect::value(resume_result, env, builder);
+        emit_debug_println!(env, builder, "[resume] in suspend block, tag is {:p}", tag);
 
         // We need to terminate this block before being allowed to switch to another one
-        builder.ins().jump(switch_block, &[]);
+        builder.ins().jump(dispatch_block, &[]);
+        builder.seal_block(dispatch_block);
 
         tag
     };
 
-    // Now, construct blocks for the three continuations:
-    // 1) `resume` returned normally.
-    // 2) `resume` returned via a suspend.
-    // 3) `resume` is forwarding
+    // Forwarding block: The last block in the if-then-else dispatch
+    // chain. Control flows to this block when the table on (resume
+    // ...) does not have a matching mapping (on ...).
+    {
+        builder.switch_to_block(forwarding_block);
 
-    // Strategy:
-    //
-    // Translate each each `(tag, label)` pair in the resume table
-    // to a switch-case of the form "case tag: br label". NOTE:
-    // `tag` may appear multiple times in resume table, only the
-    // first appearance should be processed as it shadows the
-    // subsequent entries.  The switching logic then ensures that
-    // we jump to the block handling the corresponding tag.
-    //
-    // The fallback/default case performs effect forwarding (TODO).
-    //
-    // First, initialise the switch structure.
-    let mut switch = Switch::new();
-    // Second, we consume the resume table entry-wise.
-    let mut case_blocks = vec![];
+        let parent_contref = parent_stack_chain.unwrap_continuation_or_trap(
+            env,
+            builder,
+            ir::TrapCode::UnhandledTag,
+        );
+
+        // We suspend, thus deferring handling to the parent.  We do
+        // nothing about tag *parameters*, these remain unchanged
+        // within the payload buffer associated with the whole
+        // VMContext.
+        call_builtin!(builder, env, tc_suspend(suspend_tag_addr));
+
+        // "Tag return values" (i.e., values provided by cont.bind or
+        // resume to the continuation) are actually stored in
+        // `VMContRef`s, and we need to move them down the chain back
+        // to the `VMContRef` where we originally suspended.
+        typed_continuations_forward_tag_return_values(env, builder, parent_contref, resume_contref);
+
+        // We create a back edge to the resume block.  Note that both
+        // `resume_contobj` and `parent_stack_chain` remain unchanged:
+        // In the current design, where forwarding is implemented by
+        // suspending up the chain of parent continuations and
+        // subsequently resume-ing back down the chain, both the
+        // continuation being resumed and its parent stay the same.
+        builder.ins().jump(resume_block, &[]);
+        builder.seal_block(resume_block);
+    }
+
+    // Dispatch block. Now we create the nested if-then-else chain,
+    // which attempts to find a suitable handler for
+    // `suspend_tag_addr`.
     let mut tag_seen = std::collections::HashSet::new(); // Used to keep track of tags
-    for &(tag, target_block) in resumetable {
-        // Skip if this `tag` has been seen previously.
-        if !tag_seen.insert(tag) {
+    let mut tail_block = dispatch_block;
+    for &(handle_tag, target_block) in resumetable {
+        // Skip if this tag has been seen previously.
+        if !tag_seen.insert(handle_tag) {
             continue;
         }
-        let case = builder.create_block();
-        switch.set_entry(tag as u128, case);
-        builder.switch_to_block(case);
+        // Switch to the current tail of the dispatch chain.
+        builder.switch_to_block(tail_block);
+        // Generate the test for whether `handle_tag` matches the suspension tag.
+        let tag_addr = shared::tag_address(env, builder, handle_tag);
+        emit_debug_println!(
+            env,
+            builder,
+            "[resume] comparing handle_tag_addr = {:p} and suspend_tag_addr = {:p}",
+            tag_addr,
+            suspend_tag_addr
+        );
+        let cond = builder.ins().icmp(IntCC::Equal, suspend_tag_addr, tag_addr);
+        // Create landing sites:
+        // 1. If the tags match, then jump to the preamble block to load data
+        // 2. Otherwise jump to the next tail block
+        let target_preamble_block = builder.create_block();
+        tail_block = builder.create_block();
+        builder
+            .ins()
+            .brif(cond, target_preamble_block, &[], tail_block, &[]);
+        builder.seal_block(tail_block);
+        builder.seal_block(target_preamble_block);
 
+        // Fill the preamble block.
+        builder.switch_to_block(target_preamble_block);
         // Load and push arguments.
-        let param_types = env.tag_params(tag);
+        let param_types = env.tag_params(handle_tag); // TODO(dhil): Check whether this function behaves correctly for imported tags.
         let param_types: Vec<ir::Type> = param_types
             .iter()
             .map(|wty| crate::value_type(env.isa, *wty))
             .collect();
         let mut args = typed_continuations_load_payloads(env, builder, &param_types);
 
-        // We have an actual handling block for this tag, rather than just
-        // forwarding. Detatch the `VMContRef` by setting its parent
-        // link to `StackChain::Absent`.
+        // Detatch the `VMContRef` by setting its parent link to
+        // `StackChain::Absent`.
         let pointer_type = env.pointer_type();
         let chain = tc::StackChain::absent(builder, pointer_type);
         let mut vmcontref = tc::VMContRef::new(resume_contref, pointer_type);
@@ -1599,75 +1659,26 @@ pub(crate) fn translate_resume<'a>(
             next_revision,
             resume_contref
         );
-
         args.push(contobj);
 
-        // Now jump to the actual user-defined block handling
-        // this tag, as given by the resumetable.
+        // Now jump to the actual user-defined block handling this
+        // tag, as given by the resume table.
         builder.ins().jump(target_block, &args);
-        case_blocks.push(case);
     }
+    // The last tail_block unconditionally jumps to the forwarding
+    // block.
+    builder.switch_to_block(tail_block);
+    builder.ins().jump(forwarding_block, &[]);
+    builder.seal_block(forwarding_block);
 
-    // Note that at this point we haven't actually emitted any
-    // code for the switching logic itself, but only filled
-    // the Switch structure and created the blocks it jumps
-    // to.
-
-    // Forwarding block: Default case for the switching logic on the
-    // tag. Used when the (resume ...) clause we currently translate
-    // does not have a matching (tag ...) entry.
-    {
-        builder.switch_to_block(forwarding_block);
-
-        let parent_contref = parent_stack_chain.unwrap_continuation_or_trap(
-            env,
-            builder,
-            ir::TrapCode::UnhandledTag,
-        );
-
-        // We suspend, thus deferring handling to the parent.
-        // We do nothing about tag *parameters*, these remain unchanged within the
-        // payload buffer associated with the whole VMContext.
-        call_builtin!(builder, env, tc_suspend(tag));
-
-        // "Tag return values" (i.e., values provided by cont.bind or
-        // resume to the continuation) are actually stored in
-        // `VMContRef`s, and we need to move them down the chain
-        // back to the `VMContRef` where we originally
-        // suspended.
-        typed_continuations_forward_tag_return_values(env, builder, parent_contref, resume_contref);
-
-        // We create a back edge to the resume block.
-        // Note that both `resume_cotobj` and `parent_stack_chain` remain unchanged:
-        // In the current design, where forwarding is implemented by suspending
-        // up the chain of parent continuations and subsequently resume-ing back
-        // down the chain, both the continuation being resumed and its parent
-        // stay the same.
-        builder.ins().jump(resume_block, &[]);
-        builder.seal_block(resume_block);
-    }
-
-    // Switch block: actual switching logic is emitted here.
-    {
-        builder.switch_to_block(switch_block);
-        switch.emit(builder, tag, forwarding_block);
-        builder.seal_block(switch_block);
-        builder.seal_block(forwarding_block);
-
-        // We can only seal the blocks we generated for each
-        // tag now, after switch.emit ran.
-        for case_block in case_blocks {
-            builder.seal_block(case_block);
-        }
-    }
-
-    // Return block: Jumped to by resume block if continuation returned normally.
+    // Return block: Jumped to by resume block if continuation
+    // returned normally.
     {
         builder.switch_to_block(return_block);
         builder.seal_block(return_block);
 
-        // Restore parts of the VMRuntimeLimits from the
-        // parent of the returned continuation (which is now active).
+        // Restore parts of the VMRuntimeLimits from the parent of the
+        // returned continuation (which is now active).
         parent_stack_chain.write_limits_to_vmcontext(env, builder, vm_runtime_limits_ptr);
 
         let co = tc::VMContRef::new(resume_contref, env.pointer_type());
@@ -1677,8 +1688,8 @@ pub(crate) fn translate_resume<'a>(
         let returns = env.continuation_returns(type_index).to_vec();
         let values = typed_continuations_load_return_values(env, builder, &returns, resume_contref);
 
-        // The continuation has returned and all `VMContObjs`
-        // to it should have been be invalidated. We may safely deallocate
+        // The continuation has returned and all `VMContObjs` to it
+        // should have been be invalidated. We may safely deallocate
         // it.
         shared::typed_continuations_drop_cont_ref(env, builder, resume_contref);
 
@@ -1689,13 +1700,14 @@ pub(crate) fn translate_resume<'a>(
 pub(crate) fn translate_suspend<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
-    tag_index: ir::Value,
+    tag_index: u32,
     suspend_args: &[ir::Value],
     tag_return_types: &[WasmValType],
 ) -> Vec<ir::Value> {
     typed_continuations_store_payloads(env, builder, suspend_args);
 
-    call_builtin!(builder, env, tc_suspend(tag_index));
+    let tag_addr = shared::tag_address(env, builder, tag_index);
+    call_builtin!(builder, env, tc_suspend(tag_addr));
 
     let contref = typed_continuations_load_continuation_reference(env, builder);
 

--- a/crates/cranelift/src/wasmfx/shared.rs
+++ b/crates/cranelift/src/wasmfx/shared.rs
@@ -146,8 +146,9 @@ pub(crate) fn typed_continuations_drop_cont_ref<'a>(
 pub struct TaggedPointer(pub ir::Value);
 
 impl TaggedPointer {
-    const LOW_TAG_MASK: i64 = 0b11;
-    const LOW_TAG_INVERSE_MASK: i64 = !0b11;
+    const LOW_TAG_BITS: i64 = 2;
+    const LOW_TAG_MASK: i64 = (1 << Self::LOW_TAG_BITS) - 1;
+    const LOW_TAG_INVERSE_MASK: i64 = !Self::LOW_TAG_MASK;
 
     pub fn new(val: ir::Value) -> Self {
         Self(val)

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -102,9 +102,9 @@ macro_rules! foreach_builtin_function {
             tc_cont_new(vmctx: vmctx, r: pointer, param_count: i32, result_count: i32) -> pointer;
             // Resumes a continuation. The result value is of type
             // wasmtime_continuations::SwitchDirection.
-            tc_resume(vmctx: vmctx, contref: pointer, parent_stack_limits: pointer) -> i64;
+            tc_resume(vmctx: vmctx, contref: pointer, parent_stack_limits: pointer) -> pointer;
             // Suspends a continuation.
-            tc_suspend(vmctx: vmctx, tag: i32);
+            tc_suspend(vmctx: vmctx, tag: pointer);
 
             // Sets the tag return values of `child_contref` to those of `parent_contref`.
             // This is implemented by exchanging the pointers to the underlying buffers.

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -943,6 +943,7 @@ impl<'a> Inliner<'a> {
                 EntityIndex::Table(i) => frame.tables[i].clone().into(),
                 EntityIndex::Global(i) => frame.globals[i].clone().into(),
                 EntityIndex::Memory(i) => frame.memories[i].clone().into(),
+                EntityIndex::Tag(_) => todo!(), // TODO(dhil): Revisit later
             },
         }
     }

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -161,7 +161,7 @@ pub trait PtrSize {
     /// Return the size of `VMTagDefinition`.
     #[inline]
     fn size_of_vmtag_definition(&self) -> u8 {
-        8
+        16
     }
 
     /// This is the size of the largest value type (i.e. a V128).

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -161,7 +161,7 @@ pub trait PtrSize {
     /// Return the size of `VMTagDefinition`.
     #[inline]
     fn size_of_vmtag_definition(&self) -> u8 {
-        16
+        4
     }
 
     /// This is the size of the largest value type (i.e. a V128).
@@ -550,6 +550,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
                 = cmul(ret.num_defined_globals, ret.ptr.size_of_vmglobal_definition()),
             size(defined_tags)
                 = cmul(ret.num_defined_tags, ret.ptr.size_of_vmtag_definition()),
+            align(16),
             size(defined_func_refs) = cmul(
                 ret.num_escaped_funcs,
                 ret.ptr.size_of_vm_func_ref(),

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -23,6 +23,7 @@ pub fn dummy_extern<T>(store: &mut Store<T>, ty: ExternType) -> Result<Extern> {
         ExternType::Global(global_ty) => Extern::Global(dummy_global(store, global_ty)?),
         ExternType::Table(table_ty) => Extern::Table(dummy_table(store, table_ty)?),
         ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(store, mem_ty)?),
+        ExternType::Tag(_) => todo!(),
     })
 }
 

--- a/crates/wasmtime/src/runtime/externals.rs
+++ b/crates/wasmtime/src/runtime/externals.rs
@@ -3,9 +3,11 @@ use crate::{AsContext, Engine, ExternType, Func, Memory, SharedMemory};
 
 mod global;
 mod table;
+mod tag;
 
 pub use global::Global;
 pub use table::Table;
+pub use tag::Tag;
 
 // Externals
 
@@ -30,6 +32,8 @@ pub enum Extern {
     /// A WebAssembly shared memory; these are handled separately from
     /// [`Memory`].
     SharedMemory(SharedMemory),
+    /// A WebAssembly `tag`.
+    Tag(Tag),
 }
 
 impl Extern {
@@ -100,6 +104,7 @@ impl Extern {
             Extern::SharedMemory(ft) => ExternType::Memory(ft.ty()),
             Extern::Table(tt) => ExternType::Table(tt.ty(store)),
             Extern::Global(gt) => ExternType::Global(gt.ty(store)),
+            Extern::Tag(tt) => ExternType::Tag(tt.ty(store)),
         }
     }
 
@@ -124,6 +129,7 @@ impl Extern {
             crate::runtime::vm::Export::Table(t) => {
                 Extern::Table(Table::from_wasmtime_table(t, store))
             }
+            crate::runtime::vm::Export::Tag(t) => Extern::Tag(Tag::from_wasmtime_tag(t, store)),
         }
     }
 
@@ -134,6 +140,7 @@ impl Extern {
             Extern::Memory(m) => m.comes_from_same_store(store),
             Extern::SharedMemory(m) => Engine::same(m.engine(), store.engine()),
             Extern::Table(t) => store.store_data().contains(t.0),
+            Extern::Tag(t) => store.store_data().contains(t.0),
         }
     }
 }
@@ -165,6 +172,12 @@ impl From<SharedMemory> for Extern {
 impl From<Table> for Extern {
     fn from(r: Table) -> Self {
         Extern::Table(r)
+    }
+}
+
+impl From<Tag> for Extern {
+    fn from(r: Tag) -> Self {
+        Extern::Tag(r)
     }
 }
 

--- a/crates/wasmtime/src/runtime/externals/tag.rs
+++ b/crates/wasmtime/src/runtime/externals/tag.rs
@@ -1,0 +1,44 @@
+use crate::runtime::types::TagType;
+use crate::{
+    store::{StoreData, StoreOpaque, Stored},
+    AsContext,
+};
+
+/// A WebAssembly `tag`.
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)] // here for the C API
+pub struct Tag(pub(super) Stored<crate::runtime::vm::ExportTag>);
+
+impl Tag {
+    pub(crate) unsafe fn from_wasmtime_tag(
+        mut wasmtime_export: crate::runtime::vm::ExportTag,
+        store: &mut StoreOpaque,
+    ) -> Self {
+        use wasmtime_environ::TypeTrace;
+        wasmtime_export
+            .tag
+            .canonicalize_for_runtime_usage(&mut |module_index| {
+                crate::runtime::vm::Instance::from_vmctx(wasmtime_export.vmctx, |instance| {
+                    instance.engine_type_index(module_index)
+                })
+            });
+
+        Tag(store.store_data_mut().insert(wasmtime_export))
+    }
+
+    pub(crate) fn ty(&self, _store: impl AsContext) -> TagType {
+        todo!()
+    }
+
+    pub(crate) fn wasmtime_ty<'a>(&self, data: &'a StoreData) -> &'a wasmtime_environ::Tag {
+        &data[self.0].tag
+    }
+
+    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTagImport {
+        let export = &store[self.0];
+        crate::runtime::vm::VMTagImport {
+            from: export.definition,
+            vmctx: export.vmctx,
+        }
+    }
+}

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -2,7 +2,7 @@ use crate::linker::{Definition, DefinitionType};
 use crate::prelude::*;
 use crate::runtime::vm::{
     Imports, InstanceAllocationRequest, ModuleRuntimeInfo, StorePtr, VMFuncRef, VMFunctionImport,
-    VMGlobalImport, VMMemoryImport, VMOpaqueContext, VMTableImport,
+    VMGlobalImport, VMMemoryImport, VMOpaqueContext, VMTableImport, VMTagImport,
 };
 use crate::store::{InstanceId, StoreOpaque, Stored};
 use crate::types::matching;
@@ -14,7 +14,8 @@ use alloc::sync::Arc;
 use core::ptr::NonNull;
 use wasmparser::WasmFeatures;
 use wasmtime_environ::{
-    EntityIndex, EntityType, FuncIndex, GlobalIndex, MemoryIndex, PrimaryMap, TableIndex, TypeTrace,
+    EntityIndex, EntityType, FuncIndex, GlobalIndex, MemoryIndex, PrimaryMap, TableIndex, TagIndex,
+    TypeTrace,
 };
 
 /// An instantiated WebAssembly module.
@@ -651,6 +652,7 @@ pub(crate) struct OwnedImports {
     tables: PrimaryMap<TableIndex, VMTableImport>,
     memories: PrimaryMap<MemoryIndex, VMMemoryImport>,
     globals: PrimaryMap<GlobalIndex, VMGlobalImport>,
+    tags: PrimaryMap<TagIndex, VMTagImport>,
 }
 
 impl OwnedImports {
@@ -666,6 +668,7 @@ impl OwnedImports {
             tables: PrimaryMap::new(),
             memories: PrimaryMap::new(),
             globals: PrimaryMap::new(),
+            tags: PrimaryMap::new(),
         }
     }
 
@@ -675,6 +678,7 @@ impl OwnedImports {
         self.tables.reserve(raw.num_imported_tables);
         self.memories.reserve(raw.num_imported_memories);
         self.globals.reserve(raw.num_imported_globals);
+        self.tags.reserve(raw.num_imported_tags);
     }
 
     #[cfg(feature = "component-model")]
@@ -683,6 +687,7 @@ impl OwnedImports {
         self.tables.clear();
         self.memories.clear();
         self.globals.clear();
+        self.tags.clear();
     }
 
     fn push(&mut self, item: &Extern, store: &mut StoreOpaque, module: &Module) {
@@ -701,6 +706,9 @@ impl OwnedImports {
             }
             Extern::SharedMemory(i) => {
                 self.memories.push(i.vmimport(store));
+            }
+            Extern::Tag(i) => {
+                self.tags.push(i.vmimport(store));
             }
         }
     }
@@ -734,6 +742,12 @@ impl OwnedImports {
                     index: m.index,
                 });
             }
+            crate::runtime::vm::Export::Tag(t) => {
+                self.tags.push(VMTagImport {
+                    from: t.definition,
+                    vmctx: t.vmctx,
+                });
+            }
         }
     }
 
@@ -743,6 +757,7 @@ impl OwnedImports {
             globals: self.globals.values().as_slice(),
             memories: self.memories.values().as_slice(),
             functions: self.functions.values().as_slice(),
+            tags: self.tags.values().as_slice(),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -131,6 +131,7 @@ pub(crate) enum DefinitionType {
     // no longer be the current size of the table/memory.
     Table(wasmtime_environ::Table, u32),
     Memory(wasmtime_environ::Memory, u64),
+    Tag(wasmtime_environ::Tag),
 }
 
 impl<T> Linker<T> {
@@ -1391,6 +1392,7 @@ impl DefinitionType {
                 DefinitionType::Memory(*t.wasmtime_ty(data), t.internal_size(store))
             }
             Extern::SharedMemory(t) => DefinitionType::Memory(*t.ty().wasmtime_memory(), t.size()),
+            Extern::Tag(t) => DefinitionType::Tag(*t.wasmtime_ty(data)),
         }
     }
 
@@ -1400,6 +1402,7 @@ impl DefinitionType {
             DefinitionType::Table(..) => "table",
             DefinitionType::Memory(..) => "memory",
             DefinitionType::Global(_) => "global",
+            DefinitionType::Tag(_) => "tag",
         }
     }
 }

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -27,6 +27,7 @@ pub struct StoreData {
     globals: Vec<crate::runtime::vm::ExportGlobal>,
     instances: Vec<crate::instance::InstanceData>,
     memories: Vec<crate::runtime::vm::ExportMemory>,
+    tags: Vec<crate::runtime::vm::ExportTag>,
     #[cfg(feature = "component-model")]
     pub(crate) components: crate::component::ComponentStoreData,
 }
@@ -53,6 +54,7 @@ impl_store_data! {
     globals => crate::runtime::vm::ExportGlobal,
     instances => crate::instance::InstanceData,
     memories => crate::runtime::vm::ExportMemory,
+    tags => crate::runtime::vm::ExportTag,
 }
 
 impl StoreData {
@@ -64,6 +66,7 @@ impl StoreData {
             globals: Vec::new(),
             instances: Vec::new(),
             memories: Vec::new(),
+            tags: Vec::new(),
             #[cfg(feature = "component-model")]
             components: Default::default(),
         }

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1306,6 +1306,8 @@ pub enum ExternType {
     Table(TableType),
     /// This external type is the type of a WebAssembly memory.
     Memory(MemoryType),
+    /// This external type is the type of a WebAssembly tag.
+    Tag(TagType),
 }
 
 macro_rules! extern_type_accessors {
@@ -1338,6 +1340,7 @@ impl ExternType {
         (Global(GlobalType) global unwrap_global)
         (Table(TableType) table unwrap_table)
         (Memory(MemoryType) memory unwrap_memory)
+        (Tag(TagType) tag unwrap_tag)
     }
 
     pub(crate) fn from_wasmtime(
@@ -1365,7 +1368,26 @@ impl ExternType {
             EntityType::Global(ty) => GlobalType::from_wasmtime_global(engine, ty).into(),
             EntityType::Memory(ty) => MemoryType::from_wasmtime_memory(ty).into(),
             EntityType::Table(ty) => TableType::from_wasmtime_table(engine, ty).into(),
-            EntityType::Tag(_) => unimplemented!("wasm tag support"),
+            EntityType::Tag(_idx) => {
+                todo!()
+                // let ty = match idx {
+                //     EngineOrModuleTypeIndex::Engine(e) => {
+                //         FuncType::from_shared_type_index(engine, *e).into()
+                //     }
+                //     EngineOrModuleTypeIndex::Module(m) => {
+                //         let subty = &types[*m];
+                //         FuncType::from_wasm_func_type(
+                //             engine,
+                //             subty.is_final,
+                //             subty.supertype,
+                //             subty.unwrap_func().clone(),
+                //         )
+                //             .into()
+                //     }
+                //     EngineOrModuleTypeIndex::RecGroup(_) => unreachable!(),
+                // };
+                // TagType::from_wasmtime_tag(engine, ty).into()
+            }
         }
     }
 }
@@ -1391,6 +1413,12 @@ impl From<MemoryType> for ExternType {
 impl From<TableType> for ExternType {
     fn from(ty: TableType) -> ExternType {
         ExternType::Table(ty)
+    }
+}
+
+impl From<TagType> for ExternType {
+    fn from(ty: TagType) -> ExternType {
+        ExternType::Tag(ty)
     }
 }
 
@@ -2980,6 +3008,13 @@ impl MemoryType {
     pub(crate) fn wasmtime_memory(&self) -> &Memory {
         &self.ty
     }
+}
+
+// Tag types
+/// A descriptor for a tag in a WebAssembly module.
+#[derive(Debug, Clone, Hash)]
+pub struct TagType {
+    ty: WasmFuncType,
 }
 
 // Import Types

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -79,7 +79,13 @@ impl MatchCx<'_> {
                 }
                 _ => bail!("expected func, but found {}", actual.desc()),
             },
-            EntityType::Tag(_) => unimplemented!(),
+            EntityType::Tag(expected) => match actual {
+                DefinitionType::Tag(actual) => self.type_reference(
+                    expected.signature.unwrap_engine_type_index(),
+                    actual.signature.unwrap_engine_type_index(),
+                ),
+                _ => bail!("expected tag, but found {}", actual.desc()),
+            },
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -74,7 +74,7 @@ pub use crate::runtime::vm::traphandlers::*;
 pub use crate::runtime::vm::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
     VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport,
-    VMOpaqueContext, VMRuntimeLimits, VMTableImport, VMWasmCallFunction, ValRaw,
+    VMOpaqueContext, VMRuntimeLimits, VMTableImport, VMTagImport, VMWasmCallFunction, ValRaw,
 };
 
 pub use send_sync_ptr::SendSyncPtr;

--- a/crates/wasmtime/src/runtime/vm/continuation.rs
+++ b/crates/wasmtime/src/runtime/vm/continuation.rs
@@ -826,7 +826,7 @@ pub mod stack_chain {
 #[cfg(feature = "wasmfx_baseline")]
 pub mod optimized {
     use crate::runtime::vm::{Instance, TrapReason};
-    pub use wasmtime_continuations::{StackLimits, SwitchDirection};
+    pub use wasmtime_continuations::{ControlEffect, StackLimits};
 
     pub type VMContRef = super::baseline::VMContRef;
 
@@ -857,12 +857,12 @@ pub mod optimized {
         _instance: &mut Instance,
         _contref: *mut VMContRef,
         _parent_stack_limits: *mut StackLimits,
-    ) -> Result<SwitchDirection, TrapReason> {
+    ) -> Result<ControlEffect, TrapReason> {
         panic!("attempt to execute continuation::optimized::resume with `typed_continuation_baseline_implementation` toggled!")
     }
 
     #[inline(always)]
-    pub fn suspend(_instance: &mut Instance, _tag_index: u32) -> Result<(), TrapReason> {
+    pub fn suspend(_instance: &mut Instance, _tag_addr: *mut u8) -> Result<(), TrapReason> {
         panic!("attempt to execute continuation::optimized::suspend with `typed_continuation_baseline_implementation` toggled!")
     }
 }

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -1,8 +1,9 @@
 use crate::runtime::vm::vmcontext::{
     VMContext, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
+    VMTagDefinition,
 };
 use core::ptr::NonNull;
-use wasmtime_environ::{DefinedMemoryIndex, Global, MemoryPlan, TablePlan};
+use wasmtime_environ::{DefinedMemoryIndex, Global, MemoryPlan, TablePlan, Tag};
 
 /// The value of an export passed from one instance to another.
 pub enum Export {
@@ -17,6 +18,9 @@ pub enum Export {
 
     /// A global export value.
     Global(ExportGlobal),
+
+    /// A tag export value.
+    Tag(ExportTag),
 }
 
 /// A function export value.
@@ -104,5 +108,26 @@ unsafe impl Sync for ExportGlobal {}
 impl From<ExportGlobal> for Export {
     fn from(func: ExportGlobal) -> Export {
         Export::Global(func)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportTag {
+    /// The address of the tag.
+    pub definition: *mut VMTagDefinition,
+    /// Pointer to the containing `VMContext`. May be null for
+    /// host-created tags.
+    pub vmctx: *mut VMContext,
+    /// The tag declaration, used for compatibility checking.
+    pub tag: Tag,
+}
+
+// See docs on send/sync for `ExportFunction` above.
+unsafe impl Send for ExportTag {}
+unsafe impl Sync for ExportTag {}
+
+impl From<ExportTag> for Export {
+    fn from(e: ExportTag) -> Export {
+        Export::Tag(e)
     }
 }

--- a/crates/wasmtime/src/runtime/vm/fibre/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/mod.rs
@@ -9,7 +9,7 @@ cfg_if::cfg_if! {
         use std::cell::Cell;
         use std::io;
         use std::ops::Range;
-        use wasmtime_continuations::{SwitchDirection, SwitchDirectionEnum};
+        use wasmtime_continuations::ControlEffect;
 
         use crate::runtime::vm::{VMContext, VMFuncRef, ValRaw};
 
@@ -111,16 +111,12 @@ cfg_if::cfg_if! {
             ///
             /// Note that if the fiber itself panics during execution then the panic
             /// will be propagated to this caller.
-            pub fn resume(&self) -> SwitchDirection {
+            pub fn resume(&self) -> ControlEffect {
                 assert!(!self.done.replace(true), "cannot resume a finished fiber");
                 let reason = self.inner.resume(&self.stack.0);
-                if let SwitchDirection {
-                    discriminant: SwitchDirectionEnum::Suspend,
-                    data: _,
-                } = reason
-                {
+                if ControlEffect::is_suspend(reason) {
                     self.done.set(false)
-                };
+                }
                 reason
             }
 

--- a/crates/wasmtime/src/runtime/vm/fibre/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/unix.rs
@@ -104,7 +104,7 @@ use std::alloc::{alloc, dealloc, Layout};
 use std::io;
 use std::ops::Range;
 use std::ptr;
-use wasmtime_continuations::SwitchDirection;
+use wasmtime_continuations::ControlEffect;
 
 use crate::runtime::vm::{VMContext, VMFuncRef, VMOpaqueContext, ValRaw};
 
@@ -263,7 +263,7 @@ extern "C" fn fiber_start(
 
         // Switch back to parent, indicating that the continuation returned.
         let inner = Suspend(top_of_stack);
-        let reason = SwitchDirection::return_();
+        let reason = ControlEffect::return_();
         inner.switch(reason);
     }
 }
@@ -290,16 +290,16 @@ impl Fiber {
         Ok(Self)
     }
 
-    pub(crate) fn resume(&self, stack: &FiberStack) -> SwitchDirection {
+    pub(crate) fn resume(&self, stack: &FiberStack) -> ControlEffect {
         unsafe {
-            let reason = SwitchDirection::resume().into();
-            SwitchDirection::from(wasmtime_fibre_switch(stack.top, reason))
+            let reason = ControlEffect::resume().into();
+            ControlEffect::from(wasmtime_fibre_switch(stack.top, reason))
         }
     }
 }
 
 impl Suspend {
-    pub fn switch(&self, payload: SwitchDirection) {
+    pub fn switch(&self, payload: ControlEffect) {
         unsafe {
             let arg = payload.into();
             wasmtime_fibre_switch(self.0, arg);

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -1094,10 +1094,12 @@ mod tests {
             num_imported_tables: 0,
             num_imported_memories: 0,
             num_imported_globals: 0,
+            num_imported_tags: 0,
             num_defined_tables: 0,
             num_defined_memories: 0,
             num_owned_memories: 0,
             num_defined_globals: 0,
+            num_defined_tags: 0,
             num_escaped_funcs: 0,
         });
 
@@ -1122,10 +1124,12 @@ mod tests {
             num_imported_tables: 0,
             num_imported_memories: 0,
             num_imported_globals: 0,
+            num_imported_tags: 0,
             num_defined_tables: 0,
             num_defined_memories: 0,
             num_owned_memories: 0,
             num_defined_globals: 0,
+            num_defined_tags: 0,
             num_escaped_funcs: 0,
         });
         assert_eq!(
@@ -1149,10 +1153,12 @@ mod tests {
             num_imported_tables: 0,
             num_imported_memories: 0,
             num_imported_globals: 0,
+            num_imported_tags: 0,
             num_defined_tables: 0,
             num_defined_memories: 0,
             num_owned_memories: 0,
             num_defined_globals: 0,
+            num_defined_tags: 0,
             num_escaped_funcs: 0,
         });
         assert_eq!(

--- a/crates/wasmtime/src/runtime/vm/imports.rs
+++ b/crates/wasmtime/src/runtime/vm/imports.rs
@@ -1,5 +1,5 @@
 use crate::runtime::vm::vmcontext::{
-    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport,
+    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport, VMTagImport,
 };
 
 /// Resolved import pointers.
@@ -26,4 +26,7 @@ pub struct Imports<'a> {
 
     /// Resolved addresses for imported globals.
     pub globals: &'a [VMGlobalImport],
+
+    /// Resolved addresses for imported tags.
+    pub tags: &'a [VMTagImport],
 }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -935,7 +935,7 @@ fn tc_resume(
     instance: &mut Instance,
     contref: *mut u8,
     parent_stack_limits: *mut u8,
-) -> Result<u64, TrapReason> {
+) -> Result<*mut u8, TrapReason> {
     crate::vm::continuation::optimized::resume(
         instance,
         contref.cast::<crate::vm::continuation::optimized::VMContRef>(),
@@ -944,8 +944,8 @@ fn tc_resume(
     .map(|reason| reason.into())
 }
 
-fn tc_suspend(instance: &mut Instance, tag_index: u32) -> Result<(), TrapReason> {
-    crate::vm::continuation::optimized::suspend(instance, tag_index)
+fn tc_suspend(instance: &mut Instance, tag_addr: *mut u8) -> Result<(), TrapReason> {
+    crate::vm::continuation::optimized::suspend(instance, tag_addr)
 }
 
 fn tc_cont_ref_forward_tag_return_values_buffer(

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -258,7 +258,7 @@ mod test_vmglobal_import {
 pub struct VMTagImport {
     /// A pointer to the imported tag description.
     pub from: *mut VMTagDefinition,
-    /// A pointer to the `VMContext` that owns the tag description.
+    /// A pointer to the owning instance.
     pub vmctx: *mut VMContext,
 }
 
@@ -663,7 +663,7 @@ mod test_vmshared_type_index {
 /// A WebAssembly tag defined within the instance.
 ///
 #[derive(Debug)]
-#[repr(C, align(8))]
+#[repr(C, align(16))]
 pub struct VMTagDefinition {
     /// Function signature's type id.
     pub type_index: VMSharedTypeIndex,
@@ -689,6 +689,13 @@ mod test_vmtag_definition {
             size_of::<VMTagDefinition>(),
             usize::from(offsets.ptr.size_of_vmtag_definition())
         );
+    }
+
+    #[test]
+    fn check_vmtag_begins_aligned() {
+        let module = Module::new();
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        assert_eq!(offsets.vmctx_tags_begin() % 16, 0);
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -270,8 +270,7 @@ unsafe impl Sync for VMTagImport {}
 #[cfg(test)]
 mod test_vmtag_import {
     use super::VMTagImport;
-    use memoffset::offset_of;
-    use std::mem::size_of;
+    use core::mem::{offset_of, size_of};
     use wasmtime_environ::{Module, VMOffsets};
 
     #[test]

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -257,7 +257,7 @@ mod test_vmglobal_import {
 #[repr(C)]
 pub struct VMTagImport {
     /// A pointer to the imported tag description.
-    pub from: *mut VMTagDefinition, // TODO(dhil): May not be heap aligned!
+    pub from: *mut VMTagDefinition,
     /// A pointer to the owning instance.
     pub vmctx: *mut VMContext,
 }

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -251,6 +251,44 @@ mod test_vmglobal_import {
     }
 }
 
+/// The fields compiled code needs to access to utilize a WebAssembly
+/// tag imported from another instance.
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct VMTagImport {
+    /// A pointer to the imported tag description.
+    pub from: *mut VMTagDefinition,
+    /// A pointer to the `VMContext` that owns the tag description.
+    pub vmctx: *mut VMContext,
+}
+
+// Declare that this type is send/sync, it's the responsibility of users of
+// `VMGlobalImport` to uphold this guarantee.
+unsafe impl Send for VMTagImport {}
+unsafe impl Sync for VMTagImport {}
+
+#[cfg(test)]
+mod test_vmtag_import {
+    use super::VMTagImport;
+    use memoffset::offset_of;
+    use std::mem::size_of;
+    use wasmtime_environ::{Module, VMOffsets};
+
+    #[test]
+    fn check_vmtag_import_offsets() {
+        let module = Module::new();
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        assert_eq!(
+            size_of::<VMTagImport>(),
+            usize::from(offsets.size_of_vmtag_import())
+        );
+        assert_eq!(
+            offset_of!(VMTagImport, from),
+            usize::from(offsets.vmtag_import_from())
+        );
+    }
+}
+
 /// The fields compiled code needs to access to utilize a WebAssembly linear
 /// memory defined within the instance, namely the start address and the
 /// size in bytes.
@@ -619,6 +657,38 @@ mod test_vmshared_type_index {
         assert_eq!(
             size_of::<VMSharedTypeIndex>(),
             usize::from(offsets.size_of_vmshared_type_index())
+        );
+    }
+}
+
+/// A WebAssembly tag defined within the instance.
+///
+#[derive(Debug)]
+#[repr(C, align(8))]
+pub struct VMTagDefinition {
+    /// Function signature's type id.
+    pub type_index: VMSharedTypeIndex,
+}
+
+impl VMTagDefinition {
+    pub fn new(type_index: VMSharedTypeIndex) -> Self {
+        Self { type_index }
+    }
+}
+
+#[cfg(test)]
+mod test_vmtag_definition {
+    use super::VMTagDefinition;
+    use std::mem::size_of;
+    use wasmtime_environ::{Module, PtrSize, VMOffsets};
+
+    #[test]
+    fn check_vmtag_definition_offsets() {
+        let module = Module::new();
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        assert_eq!(
+            size_of::<VMTagDefinition>(),
+            usize::from(offsets.ptr.size_of_vmtag_definition())
         );
     }
 }

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -257,7 +257,7 @@ mod test_vmglobal_import {
 #[repr(C)]
 pub struct VMTagImport {
     /// A pointer to the imported tag description.
-    pub from: *mut VMTagDefinition,
+    pub from: *mut VMTagDefinition, // TODO(dhil): May not be heap aligned!
     /// A pointer to the owning instance.
     pub vmctx: *mut VMContext,
 }
@@ -663,7 +663,7 @@ mod test_vmshared_type_index {
 /// A WebAssembly tag defined within the instance.
 ///
 #[derive(Debug)]
-#[repr(C, align(16))]
+#[repr(C)]
 pub struct VMTagDefinition {
     /// Function signature's type id.
     pub type_index: VMSharedTypeIndex,

--- a/tests/misc_testsuite/typed-continuations/linking_tags.wast
+++ b/tests/misc_testsuite/typed-continuations/linking_tags.wast
@@ -1,23 +1,169 @@
-(module $foo
-  (tag $foo (export "foo"))
+(module $alien
+  (tag $alien_tag (export "alien_tag"))
 )
-(register "foo")
+(register "alien")
 
-(module $bar
+(module $mine
   (type $ft (func))
   (type $ct (cont $ft))
-  (tag $foo (import "foo" "foo"))
-  (tag $bar)
-  (func $do_foo
-    (suspend $foo))
+  (tag $alien_tag (import "alien" "alien_tag"))
+  (tag $my_tag)
+  (func $do_alien_tag
+    (suspend $alien_tag))
 
-  (func $main (export "main")
-    (block $on_bar (result (ref $ct))
-      (resume $ct (tag $bar $on_bar) (cont.new $ct (ref.func $do_foo)))
+  ;; Don't handle the imported alien.
+  (func (export "main-1")
+    (block $on_my_tag (result (ref $ct))
+      (resume $ct (on $my_tag $on_my_tag) (cont.new $ct (ref.func $do_alien_tag)))
       (unreachable)
     )
     (unreachable))
+
+  ;; Handle the imported alien.
+  (func (export "main-2")
+    (block $on_alien_tag (result (ref $ct))
+      (resume $ct (on $alien_tag $on_alien_tag) (cont.new $ct (ref.func $do_alien_tag)))
+      (unreachable)
+    )
+    (drop))
+
+  (elem declare func $do_alien_tag)
+)
+(register "mine")
+(assert_suspension (invoke "main-1") "unhandled")
+(assert_return (invoke "main-2"))
+
+(module $foo
+  (type $ft (func (result i32)))
+  (type $ct (cont $ft))
+  (type $ft-2 (func (param i32) (result i32)))
+  (type $ct-2 (cont $ft-2))
+
+  (tag $foo (export "foo") (result i32)) ;; occupies defined tag entry 0
+
+  (func $do_foo (export "do_foo") (result i32)
+     (suspend $foo))
+  (func $handle_foo (export "handle_foo") (param $f (ref $ft)) (result i32)
+    (block $on_foo (result (ref $ct-2))
+      (resume $ct (on $foo $on_foo) (cont.new $ct (local.get $f)))
+      (return)
+    ) ;; on_foo
+    (drop)
+    (return (i32.const 1))
+  )
+  (func (export "test_foo") (result i32)
+    (call $handle_foo (ref.func $do_foo)))
+  (elem declare func $do_foo)
+)
+(register "foo")
+(assert_return (invoke "test_foo") (i32.const 1))
+
+(module $bar
+  (type $ft (func (result i32)))
+  (type $ct (cont $ft))
+
+  (type $ft-2 (func (param i32) (result i32)))
+  (type $ct-2 (cont $ft-2))
+
+  (tag $foo (import "foo" "foo") (result i32))
+  (tag $bar (result i32))
+  (func $do_foo (result i32)
+    (suspend $foo))
+
+  ;; Don't handle the imported foo.
+  (func (export "skip-imported-foo") (result i32)
+    (block $on_bar (result (ref $ct-2))
+      (resume $ct (on $bar $on_bar) (cont.new $ct (ref.func $do_foo)))
+      (unreachable)
+    )
+    (unreachable))
+
+  ;; Handle the imported foo.
+  (func (export "handle-imported-foo") (result i32)
+    (block $on_foo (result (ref $ct-2))
+      (resume $ct (on $foo $on_foo) (cont.new $ct (ref.func $do_foo)))
+      (unreachable)
+    )
+    (drop)
+    (return (i32.const 2))
+  )
+
   (elem declare func $do_foo)
 )
 (register "bar")
-(assert_suspension (invoke "main") "unhandled")
+(assert_suspension (invoke "skip-imported-foo") "unhandled")
+(assert_return (invoke "handle-imported-foo") (i32.const 2))
+
+
+(module $baz
+  (type $ft (func (result i32)))
+  (type $ct (cont $ft))
+
+  (type $ft-2 (func (param i32) (result i32)))
+  (type $ct-2 (cont $ft-2))
+
+  (func $handle_foo (import "foo" "handle_foo") (param (ref $ft)) (result i32))
+  (func $do_foo (import "foo" "do_foo") (result i32))
+
+  (tag $baz (result i32)) ;; unused, but occupies defined tag entry 0
+
+  (func $handle_baz (param $f (ref $ft)) (result i32)
+    (block $on_baz (result (ref $ct-2))
+      (resume $ct (on $baz $on_baz) (cont.new $ct (local.get $f)))
+      (return)
+    ) ;; on_baz
+    (drop)
+    (return (i32.const 3))
+  )
+
+  (func $inner-baz (result i32)
+    (call $handle_baz (ref.func $do_foo)))
+  (func (export "compose-handle-foo-baz") (result i32)
+    (call $handle_foo (ref.func $inner-baz)))
+
+  (func $inner-foo (result i32)
+    (call $handle_foo (ref.func $do_foo)))
+  (func (export "compose-handle-baz-foo") (result i32)
+    (call $handle_baz (ref.func $inner-foo)))
+  (elem declare func $do_foo $inner-baz $inner-foo)
+)
+(register "baz")
+(assert_return (invoke "compose-handle-baz-foo") (i32.const 1))
+(assert_return (invoke "compose-handle-foo-baz") (i32.const 1))
+
+(module $quux
+  (type $ft (func (result i32)))
+  (type $ct (cont $ft))
+
+  (type $ft-2 (func (param i32) (result i32)))
+  (type $ct-2 (cont $ft-2))
+
+  (func $handle_foo (import "foo" "handle_foo") (param (ref $ft)) (result i32))
+  (tag $foo (import "foo" "foo") (result i32))
+
+  (func $do_foo (result i32)
+    (suspend $foo))
+
+  (func $my_handle_foo (param $f (ref $ft)) (result i32)
+    (block $on_foo (result (ref $ct-2))
+      (resume $ct (on $foo $on_foo) (cont.new $ct (local.get $f)))
+      (return)
+    ) ;; on_foo
+    (drop)
+    (return (i32.const 4))
+  )
+
+  (func $inner-my-foo (result i32)
+    (call $my_handle_foo (ref.func $do_foo)))
+  (func (export "compose-handle-foo-my-foo") (result i32)
+    (call $handle_foo (ref.func $inner-my-foo)))
+
+  (func $inner-foo (result i32)
+    (call $handle_foo (ref.func $do_foo)))
+  (func (export "compose-handle-my-foo-foo") (result i32)
+    (call $my_handle_foo (ref.func $inner-foo)))
+  (elem declare func $do_foo $inner-my-foo $inner-foo)
+)
+(register "quux")
+(assert_return (invoke "compose-handle-foo-my-foo") (i32.const 4))
+(assert_return (invoke "compose-handle-my-foo-foo") (i32.const 1))

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -193,20 +193,12 @@ fn ignore(test: &Path, strategy: Strategy) -> bool {
             .iter()
             .any(|i| test.ends_with(i));
         }
-
-        if part == "typed-continuations" {
-            // TODO(dhil): Tag linking is currently broken
-            if test.ends_with("linking_tags.wast") {
-                return true;
-            }
-
-            // This test specifically checks that we catch a continuation being
-            // resumed twice, which we cannot detect in this mode.
-            if cfg!(feature = "unsafe_disable_continuation_linearity_check")
-                && test.ends_with("cont_twice.wast")
-            {
-                return true;
-            }
+        // This test specifically checks that we catch a continuation being
+        // resumed twice, which we cannot detect in this mode.
+        if cfg!(feature = "unsafe_disable_continuation_linearity_check")
+            && test.ends_with("cont_twice.wast")
+        {
+            return true;
         }
     }
 


### PR DESCRIPTION
This patch implements support for importing and exporting tags in the virtual machine. As a consequence tags are now unique to their origin instance, meaning that two different instantiations of the same module yields distinct tags.

The runtime representation of a tag has changed from an `u32` to a `usize` (or native pointer). The identity of a tag is given by its address in the vmcontext.

Resolves https://github.com/wasmfx/wasmfxtime/issues/25.