### PR TITLE
VMContRef pooling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -710,17 +710,15 @@ jobs:
     # `VMContRef` should still be allocated, meaning that we can reliably detect
     # that the test is resuming an already returned fiber.
     # We expect the test case to trigger an internal assertion failure (rather
-    # than a proper Wasm trap), which turns into a SIGILL (4).
-    # However, we are happy as long as the test fails in some way, meaning that
-    # it did not produce the correct Wasm trap (which it should only do if
-    # unsafe_disable_continuation_linearity_check is disabled)
+    # than a proper Wasm trap), which turns into a SIGILL (signal 4, exit code
+    # 132).
     - run: |
         # By default, Github actions run commands with pipefail enabled. We don't want that, as the command below is supposed to fail:
         set +e
         # Let's keep the build step separate from the run step below, because the former should not fail:
         cargo build --features=unsafe_disable_continuation_linearity_check,wasmfx_pooling_allocator
         # We want this to fail and are happy with any non-zero exit code:
-        cargo run --features=unsafe_disable_continuation_linearity_check,wasmfx_pooling_allocator -- wast -W=exceptions,function-references,typed-continuations tests/misc_testsuite/typed-continuations/cont_twice.wast ; test $? -ne 0
+        cargo run --features=unsafe_disable_continuation_linearity_check,wasmfx_pooling_allocator -- wast -W=exceptions,function-references,typed-continuations tests/misc_testsuite/typed-continuations/cont_twice.wast ; test $? -eq 132
 
     # NB: the test job here is explicitly lacking in cancellation of this run if
     # something goes wrong. These take the longest anyway and otherwise if

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -706,6 +706,9 @@ jobs:
     # Crude check for whether
     # `unsafe_disable_continuation_linearity_check` makes the test
     # `cont_twice` fail.
+    # We run it with continuation pooling enabled, so that the involved
+    # `VMContRef` should still be allocated, meaning that we can reliably detect
+    # that the test is resuming an already returned fiber.
     # We expect the test case to trigger an internal assertion failure (rather
     # than a proper Wasm trap), which turns into a SIGILL (4).
     # However, we are happy as long as the test fails in some way, meaning that
@@ -715,9 +718,9 @@ jobs:
         # By default, Github actions run commands with pipefail enabled. We don't want that, as the command below is supposed to fail:
         set +e
         # Let's keep the build step separate from the run step below, because the former should not fail:
-        cargo build --features=unsafe_disable_continuation_linearity_check
+        cargo build --features=unsafe_disable_continuation_linearity_check,wasmfx_pooling_allocator
         # We want this to fail and are happy with any non-zero exit code:
-        cargo run --features=unsafe_disable_continuation_linearity_check -- wast -W=exceptions,function-references,typed-continuations tests/misc_testsuite/typed-continuations/cont_twice.wast ; test $? -ne 0
+        cargo run --features=unsafe_disable_continuation_linearity_check,wasmfx_pooling_allocator -- wast -W=exceptions,function-references,typed-continuations tests/misc_testsuite/typed-continuations/cont_twice.wast ; test $? -ne 0
 
     # NB: the test job here is explicitly lacking in cancellation of this run if
     # something goes wrong. These take the longest anyway and otherwise if

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -146,6 +146,10 @@ impl Payloads {
             self.length = 0;
         }
     }
+
+    pub fn clear(&mut self) {
+        self.length = 0;
+    }
 }
 
 /// Discriminant of variant `Absent` in

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -104,6 +104,7 @@ pub struct Payloads {
 }
 
 impl Payloads {
+    #[inline]
     pub fn new(capacity: u32) -> Self {
         let data = if capacity == 0 {
             ptr::null_mut()
@@ -122,6 +123,7 @@ impl Payloads {
 
     /// Ensures that we can hold at least the required number of elements.
     /// Does not preserve existing elements and can therefore only be called on empty `Payloads`.
+    #[inline]
     pub fn ensure_capacity(&mut self, required_capacity: u32) {
         assert_eq!(self.length, 0);
         if self.capacity < required_capacity {
@@ -130,7 +132,7 @@ impl Payloads {
             *self = Self::new(required_capacity)
         }
     }
-
+    #[inline]
     pub fn deallocate(&mut self) {
         if self.data.is_null() {
             debug_assert_eq!(self.length, 0);
@@ -147,6 +149,7 @@ impl Payloads {
         }
     }
 
+    #[inline]
     pub fn clear(&mut self) {
         self.length = 0;
     }

--- a/crates/wasmtime/src/runtime/vm/continuation.rs
+++ b/crates/wasmtime/src/runtime/vm/continuation.rs
@@ -81,7 +81,6 @@ pub mod optimized {
     use core::mem;
     use wasmtime_continuations::{debug_println, ControlEffect, ENABLE_DEBUG_PRINTING};
     pub use wasmtime_continuations::{Payloads, StackLimits, State};
-    use wasmtime_environ::prelude::*;
 
     /// Fibers used for continuations
     pub type FiberStack = crate::runtime::vm::fibre::FiberStack;
@@ -151,7 +150,6 @@ pub mod optimized {
         fn drop(&mut self) {
             // Note that continuation references do not own their parents, and we
             // don't drop them here.
-
 
             // `Payloads` must be deallocated explicitly, they are considered non-owning.
             self.args.deallocate();

--- a/crates/wasmtime/src/runtime/vm/continuation.rs
+++ b/crates/wasmtime/src/runtime/vm/continuation.rs
@@ -125,7 +125,9 @@ pub mod optimized {
             core::mem::replace(&mut self.stack, FiberStack::unallocated())
         }
 
-        pub fn dummy() -> Self {
+        /// This is effectively a `Default` implementation, without calling it
+        /// so. Used to create `VMContRef`s when initializing pooling allocator.
+        pub fn empty() -> Self {
             let limits = StackLimits::with_stack_limit(Default::default());
             let parent_chain = StackChain::Absent;
             let stack = FiberStack::unallocated();
@@ -448,7 +450,9 @@ pub mod baseline {
                 .into_stack()
         }
 
-        pub fn dummy() -> Self {
+        /// This is effectively a `Default` implementation, without calling it
+        /// so. Used to create `VMContRef`s when initializing pooling allocator.
+        pub fn empty() -> Self {
             let limits = StackLimits::with_stack_limit(Default::default());
             let parent_chain = StackChain::Absent;
             let parent = core::ptr::null_mut();

--- a/crates/wasmtime/src/runtime/vm/continuation.rs
+++ b/crates/wasmtime/src/runtime/vm/continuation.rs
@@ -160,7 +160,7 @@ pub mod optimized {
             // We would like to enforce the invariant that any continuation that
             // was created for a cont.new (rather than, say, just living in a
             // pool and never being touched), either ran to completion or was
-            // cancelled. But failint to doso should yield a custom error,
+            // cancelled. But failing to do so should yield a custom error,
             // instead of panicking here.
         }
     }
@@ -223,7 +223,7 @@ pub mod optimized {
             contref.tag_return_values.deallocate();
         }
 
-        // The WasmFX allocator decides if "droppin" a continuation means
+        // The WasmFX allocator decides if "deallocating" a continuation means
         // putting it back into the pool or actually deallocating it.
         instance.wasmfx_deallocate_continuation(contref);
     }

--- a/crates/wasmtime/src/runtime/vm/continuation.rs
+++ b/crates/wasmtime/src/runtime/vm/continuation.rs
@@ -474,6 +474,11 @@ pub mod baseline {
         }
     }
 
+    // These are required so the WasmFX pooling allocator can store a Vec of
+    // `VMContRef`s.
+    unsafe impl Send for VMContRef {}
+    unsafe impl Sync for VMContRef {}
+
     // We use thread local state to simulate the VMContext. The use of
     // thread local state is necessary to reliably pass the testsuite,
     // as the test driver is multi-threaded.

--- a/crates/wasmtime/src/runtime/vm/fibre/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/mod.rs
@@ -63,6 +63,12 @@ cfg_if::cfg_if! {
                 Ok(Self(imp::FiberStack::from_raw_parts(bottom, len)?))
             }
 
+            /// Is this a manually-managed stack created from raw parts? If so, it is up
+            /// to whoever created it to manage the stack's memory allocation.
+            pub fn is_from_raw_parts(&self) -> bool {
+                self.0.is_from_raw_parts()
+            }
+
             /// Gets the top of the stack.
             ///
             /// Returns `None` if the platform does not support getting the top of the

--- a/crates/wasmtime/src/runtime/vm/fibre/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/mod.rs
@@ -32,6 +32,16 @@ cfg_if::cfg_if! {
                 Ok(Self(imp::FiberStack::new(size)?))
             }
 
+            /// Returns a stack of size 0.
+            pub fn unallocated() -> Self {
+                Self(imp::FiberStack::unallocated())
+            }
+
+            /// Is this stack unallocated/of size 0?
+            pub fn is_unallocated(&self) -> bool {
+                imp::FiberStack::is_unallocated(&self.0)
+            }
+
             /// Creates a new fiber stack of the given size (using malloc).
             pub fn malloc(size: usize) -> io::Result<Self> {
                 Ok(Self(imp::FiberStack::malloc(size)?))

--- a/crates/wasmtime/src/runtime/vm/fibre/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/unix.rs
@@ -174,6 +174,19 @@ impl FiberStack {
         }
     }
 
+    pub fn unallocated() -> Self {
+        Self {
+            top: std::ptr::null_mut(),
+            len: 0,
+            allocator: Allocator::Custom,
+        }
+    }
+
+    pub fn is_unallocated(&self) -> bool {
+        debug_assert_eq!(self.len == 0, self.top == std::ptr::null_mut());
+        self.len == 0
+    }
+
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn from_raw_parts(base: *mut u8, len: usize) -> io::Result<Self> {
         Ok(Self {

--- a/crates/wasmtime/src/runtime/vm/fibre/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/unix.rs
@@ -108,7 +108,7 @@ use wasmtime_continuations::ControlEffect;
 
 use crate::runtime::vm::{VMContext, VMFuncRef, VMOpaqueContext, ValRaw};
 
-#[derive(Debug)]
+#[derive(Debug,PartialEq, Eq)]
 pub enum Allocator {
     Malloc,
     Mmap,
@@ -194,6 +194,11 @@ impl FiberStack {
             len,
             allocator: Allocator::Custom,
         })
+    }
+
+
+    pub fn is_from_raw_parts(&self) -> bool {
+        self.allocator == Allocator::Custom
     }
 
     pub fn top(&self) -> Option<*mut u8> {

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1385,7 +1385,15 @@ impl Instance {
     }
 
     // TODO
-    pub(crate) fn wasmfx_allocate_stack(&mut self) -> Result<wasmfx_allocator::FiberStack, Error> {
+    pub(crate) fn wasmfx_allocate_continuation(
+        &mut self,
+    ) -> Result<
+        (
+            *mut wasmfx_allocator::VMContRef,
+            wasmfx_allocator::FiberStack,
+        ),
+        Error,
+    > {
         match &self.wasmfx_allocator {
             Some(allocator) => allocator.allocate(),
             None => {
@@ -1396,8 +1404,11 @@ impl Instance {
         }
     }
 
-    pub(crate) fn wasmfx_deallocate_stack(&mut self, stack: &wasmfx_allocator::FiberStack) {
-        self.wasmfx_allocator.as_ref().unwrap().deallocate(stack)
+    pub(crate) fn wasmfx_deallocate_continuation(
+        &mut self,
+        contref: *mut wasmfx_allocator::VMContRef,
+    ) {
+        self.wasmfx_allocator.as_ref().unwrap().deallocate(contref)
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1394,12 +1394,12 @@ impl Instance {
         ),
         Error,
     > {
-        match &self.wasmfx_allocator {
+        match &mut self.wasmfx_allocator {
             Some(allocator) => allocator.allocate(),
             None => {
                 let wasmfx_config = unsafe { &*(*self.store()).wasmfx_config() };
                 self.wasmfx_allocator = Some(Box::new(WasmFXAllocator::new(wasmfx_config)?));
-                self.wasmfx_allocator.as_ref().unwrap().allocate()
+                self.wasmfx_allocator.as_mut().unwrap().allocate()
             }
         }
     }
@@ -1408,7 +1408,7 @@ impl Instance {
         &mut self,
         contref: *mut wasmfx_allocator::VMContRef,
     ) {
-        self.wasmfx_allocator.as_ref().unwrap().deallocate(contref)
+        self.wasmfx_allocator.as_mut().unwrap().deallocate(contref)
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
@@ -38,7 +38,7 @@ pub mod wasmfx_on_demand {
                 }
             };
             let stack = stack.map_err(|_| anyhow::anyhow!("Fiber stack allocation failed"));
-            let contref = Box::into_raw(Box::new(VMContRef::dummy()));
+            let contref = Box::into_raw(Box::new(VMContRef::empty()));
             Ok((contref, stack?))
         }
 
@@ -122,7 +122,7 @@ pub mod wasmfx_pooling {
             }
 
             let mut continuations = Vec::with_capacity(total_stacks as usize);
-            continuations.resize_with(total_stacks as usize, VMContRef::dummy);
+            continuations.resize_with(total_stacks as usize, VMContRef::empty);
 
             Ok(Self {
                 continuations,

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
@@ -51,6 +51,11 @@ pub mod wasmfx_on_demand {
 
 // This module is dead code if the on-demand allocator is toggled.
 #[allow(dead_code)]
+// We want to compile this module unconditionally, even if the
+// `wasmfx_pooling_allocator` feature is disabled. However, its implementation
+// depends on code only available if Wasmtime's own `pooling-allocator` feature
+// is enabled.
+#[cfg(feature = "pooling-allocator")]
 pub mod wasmfx_pooling {
     use super::*;
 

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
@@ -63,8 +63,7 @@ pub mod wasmfx_on_demand {
 }
 
 // This module is dead code if the on-demand allocator is toggled.
-// #[allow(dead_code)]
-// #[cfg(feature = "wasmfx_pooling_allocator")]
+#[allow(dead_code)]
 pub mod wasmfx_pooling {
     use super::*;
 

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
@@ -43,8 +43,8 @@ pub mod wasmfx_on_demand {
         }
 
         pub fn deallocate(&mut self, contref: *mut VMContRef) {
-            // In on-demand mode, we actually deallocate the continuation by dropping it.
-            let _ = unsafe { Box::from_raw(contref) };
+            // In on-demand mode, we actually deallocate the continuation.
+            unsafe { core::mem::drop(Box::from_raw(contref)) };
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/wasmfx_allocator.rs
@@ -208,6 +208,14 @@ pub mod wasmfx_pooling {
             let index = (start_of_stack - base) / self.stack_size;
             assert!(index < self.max_stacks);
 
+            // If the `FiberStack` has the given `index` in the pool, then the
+            // `VMContRef` must also be at that index in the `continuations`
+            // vector.
+            assert_eq!(
+                continuation as *mut VMContRef,
+                &mut self.continuations[index] as *mut VMContRef
+            );
+
             self.index_allocator.free(SlotId(index as u32));
         }
     }


### PR DESCRIPTION
This PR extends the existing `WasmFXAllocator` to also allocate `VMContRefs` in addition to `FiberStacks`. In particular, this means the *pooling* implementation of the allocator now pools these `VMContRef` objects, too.

The overall goal is that eventually, when the pooling allocator is enabled, executing `cont.new` instructions can usually be done without needing to use the system allocator.

To this end, our pooling allocator is equipped with a `Vec<VMContRef>`. The underlying mechanism for maintaining which indices into the pool are free vs used (provided by `SimpleIndexAllocator`) remains unchanged: The idea is that index `i` in the pool refers to the i-th VMContRef (in the `Vec`) and the i-th region of stack memory (from the overall `mmap`-ped stack memory allocation).

One notable aspect is the following: The `allocate` API does not simply return a `VMContRef` (with a stack attached to it). This is due to how the setup for `Fiber`'s works in the baseline implementation: `wasmtime-fiber` dictates that a `Fiber` is obtained by properly initializing a `FiberStack`, for example by providing the closure to run inside the `Fiber`. Thus, the creation of the `Fiber` must happen outside of the pool itself, and remains in the implementation of `cont_new`.
Instead, the `allocate` function of the `WasmFXAllocator` now returns two things:
1. A pointer to the `VMContRef`, which currently has no stack attached to it.
2. A `FiberStack`.

Users of the API can then perform the necessary initializiaton work. For the baseline implementation, this means creating a `Fiber` from the `FiberStack` and setting the `fiber` field of the `VMContRef` to it. In the optimized implementation, it sufficies to call the `initialize` method of the `FiberStack` and then set the `stack` field of the `VMContRef`.

A few more implementation details:
- In order to represent a `VMContRef` with no stack attached to it, its `fiber` field is now `Option`-al in the baseline implementation. In the optimized implementation, there is now a notion of an unallocated `FiberStack`, which is used for this purpose.
- In order to initialize the pool's `Vec<VMContRef>`s, we need to be able to create dummy values of this type. To this end, I've added a `empty()` function to both `VMContRef` types, which creates an "empty" (for lack of a better word) `VMContRef`. It's basically a default value, but it felt weird to actually implement `Default` for `VMContRef`.
- In the optimized implementation when using the pooling allocator, we leave the `Payloads` objects allocated when putting the `VMContRef` owning them back into the pool. This means that when we get a `VMContRef` from the pool, we only need to (re)-allocate `Payloads` objects if the existing one is too small.
