### PR TITLE
set up Cranelift to allow using stack_switch instruction

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2134,6 +2134,24 @@ impl Config {
             bail!("cannot disable the simd proposal but enable the relaxed simd proposal");
         }
 
+        if features.contains(WasmFeatures::TYPED_CONTINUATIONS) {
+            let model = match target.operating_system {
+                target_lexicon::OperatingSystem::Windows => "update_windows_tib",
+                target_lexicon::OperatingSystem::Linux => "basic",
+                _ => bail!("typed-continuations feature not supported on this platform "),
+            };
+
+            if !self
+                .compiler_config
+                .ensure_setting_unset_or_given("stack_switch_model".into(), model.into())
+            {
+                bail!(
+                    "compiler option 'stack_switch_model' must be set to '{}' on this platform",
+                    model
+                );
+            }
+        }
+
         // Apply compiler settings and flags
         for (k, v) in self.compiler_config.settings.iter() {
             compiler.set(k, v)?;

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -337,6 +337,21 @@ impl Engine {
                 }
             }
 
+            // stack switch model must match the current OS
+            "stack_switch_model" => {
+                if self.features().contains(WasmFeatures::TYPED_CONTINUATIONS) {
+                    let expected =
+                    match target.operating_system  {
+                        target_lexicon::OperatingSystem::Windows => "update_windows_tib",
+                        target_lexicon::OperatingSystem::Linux => "basic",
+                        _ => {return Err(String::from("typed-continuations feature not supported on this platform"));}
+                    };
+                    *value == FlagValue::Enum(expected)
+                } else {
+                    return Ok(())
+                }
+            }
+
             // These settings don't affect the interface or functionality of
             // the module itself, so their configuration values shouldn't
             // matter.
@@ -353,7 +368,6 @@ impl Engine {
             | "bb_padding_log2_minus_one"
             | "machine_code_cfg_info"
             | "tls_model" // wasmtime doesn't use tls right now
-            | "stack_switch_model" // wasmtime doesn't use stack switching right now
             | "opt_level" // opt level doesn't change semantics
             | "enable_alias_analysis" // alias analysis-based opts don't change semantics
             | "probestack_size_log2" // probestack above asserted disabled


### PR DESCRIPTION
This PR is part of a series that implements native stack switching.

This particular PR sets up the Cranelift configuration used by Wasmtime so that we may use the `stack_switch` CLIF instruction.

Note that this configuration is operating system specific:
- On Linux, everything is great.
- On Windows, we need to use a different setting, informing Cranelift that stack switching works slightly different. That *setting* already exists, even though actually using it would cause a failure within Cranelift later on. I'm nevertheless performing the proper setup in this PR because our fork does not compile on Windows to begin with, unless `wasmfx_baseline` is enabled, in which case none of this matters.
- On macOS, we will currently fail during Engine setup if `typed-continuations` is enabled. That's because I haven't fully looked into whether it's safe to just do the same was we are doing on Linux. In that case, we could actually perform native stack switching on x64 macOS using the same codegen as for Linux (not that anyone would care).
