### PR TITLE
Native stack switching

### DIFF
--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -100,11 +100,6 @@ macro_rules! foreach_builtin_function {
 
             // Creates a new continuation from a funcref.
             tc_cont_new(vmctx: vmctx, r: pointer, param_count: i32, result_count: i32) -> pointer;
-            // Resumes a continuation. The result value is of type
-            // wasmtime_continuations::SwitchDirection.
-            tc_resume(vmctx: vmctx, contref: pointer) -> pointer;
-            // Suspends a continuation.
-            tc_suspend(vmctx: vmctx, tag: pointer);
 
             // Sets the tag return values of `child_contref` to those of `parent_contref`.
             // This is implemented by exchanging the pointers to the underlying buffers.

--- a/crates/wasmtime/src/runtime/vm/continuation.rs
+++ b/crates/wasmtime/src/runtime/vm/continuation.rs
@@ -79,7 +79,7 @@ pub mod optimized {
     };
     use core::cmp;
     use core::mem;
-    use wasmtime_continuations::{debug_println, ControlEffect, ENABLE_DEBUG_PRINTING};
+    use wasmtime_continuations::{debug_println, ENABLE_DEBUG_PRINTING};
     pub use wasmtime_continuations::{Payloads, StackLimits, State};
 
     /// Fibers used for continuations
@@ -291,84 +291,6 @@ pub mod optimized {
         // continuation reference objects.
         debug_println!("Created contref @ {:p}", contref);
         Ok(contref)
-    }
-
-    /// TODO
-    #[inline(always)]
-    pub fn resume(
-        instance: &mut Instance,
-        contref: *mut VMContRef,
-    ) -> Result<ControlEffect, TrapReason> {
-        let cont = unsafe {
-            contref.as_ref().ok_or_else(|| {
-                TrapReason::user_without_backtrace(anyhow::anyhow!(
-                    "Attempt to dereference null VMContRef!"
-                ))
-            })?
-        };
-        assert!(cont.state == State::Allocated || cont.state == State::Invoked);
-
-        if ENABLE_DEBUG_PRINTING {
-            let chain = instance.typed_continuations_stack_chain();
-            // SAFETY: We maintain as an invariant that the stack chain field in the
-            // VMContext is non-null and contains a chain of zero or more
-            // StackChain::Continuation values followed by StackChain::Main.
-            match unsafe { (**chain).0.get_mut() } {
-                StackChain::Continuation(running_contref) => {
-                    debug_assert_eq!(contref, *running_contref);
-                    debug_println!(
-                        "Resuming contref @ {:p}, previously running contref is {:p}",
-                        contref,
-                        running_contref
-                    )
-                }
-                _ => {
-                    // Before calling this function as a libcall, we must have set
-                    // the parent of the to-be-resumed continuation to the
-                    // previously running one. Hence, we must see a
-                    // `StackChain::Continuation` variant.
-                    return Err(TrapReason::user_without_backtrace(anyhow::anyhow!(
-                        "Invalid StackChain value in VMContext"
-                    )));
-                }
-            }
-        }
-
-        Ok(cont.stack.resume())
-    }
-
-    /// TODO
-    #[inline(always)]
-    pub fn suspend(instance: &mut Instance, tag_addr: *mut u8) -> Result<(), TrapReason> {
-        let chain_ptr = instance.typed_continuations_stack_chain();
-
-        // TODO(dhil): This should be handled in generated code.
-        // SAFETY: We maintain as an invariant that the stack chain field in the
-        // VMContext is non-null and contains a chain of zero or more
-        // StackChain::Continuation values followed by StackChain::Main.
-        let chain = unsafe { (**chain_ptr).0.get_mut() };
-        let running = match chain {
-            StackChain::Absent => Err(TrapReason::user_without_backtrace(anyhow::anyhow!(
-                "Internal error: StackChain not initialised"
-            ))),
-            StackChain::MainStack { .. } => Err(TrapReason::user_without_backtrace(
-                anyhow::anyhow!("Calling suspend outside of a continuation"),
-            )),
-            StackChain::Continuation(running) => {
-                // SAFETY: See above.
-                Ok(unsafe { &**running })
-            }
-        }?;
-
-        let stack = &running.stack;
-        debug_println!(
-            "Suspending while running {:p}, parent is {:?}",
-            running,
-            running.parent_chain
-        );
-
-        let payload = ControlEffect::suspend(tag_addr as *const u8);
-        Ok(stack.suspend(payload))
     }
 
     // Tests
@@ -941,19 +863,6 @@ pub mod optimized {
         _result_count: u32,
     ) -> Result<*mut VMContRef, TrapReason> {
         panic!("attempt to execute continuation::optimized::cont_new with `typed_continuation_baseline_implementation` toggled!")
-    }
-
-    #[inline(always)]
-    pub fn resume(
-        _instance: &mut Instance,
-        _contref: *mut VMContRef,
-    ) -> Result<ControlEffect, TrapReason> {
-        panic!("attempt to execute continuation::optimized::resume with `typed_continuation_baseline_implementation` toggled!")
-    }
-
-    #[inline(always)]
-    pub fn suspend(_instance: &mut Instance, _tag_addr: *mut u8) -> Result<(), TrapReason> {
-        panic!("attempt to execute continuation::optimized::suspend with `typed_continuation_baseline_implementation` toggled!")
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/fibre/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/mod.rs
@@ -8,7 +8,6 @@ cfg_if::cfg_if! {
 
         use std::io;
         use std::ops::Range;
-        use wasmtime_continuations::ControlEffect;
 
         use crate::runtime::vm::{VMContext, VMFuncRef, ValRaw};
 
@@ -81,15 +80,6 @@ cfg_if::cfg_if! {
             /// supports it.
             pub fn range(&self) -> Option<Range<usize>> {
                 self.0.range()
-            }
-
-            /// Resumes execution of this fiber.
-            pub fn resume(&self) -> ControlEffect {
-                self.0.resume()
-            }
-
-            pub fn suspend(&self, payload: ControlEffect) {
-                self.0.suspend(payload)
             }
 
             pub fn initialize(

--- a/crates/wasmtime/src/runtime/vm/fibre/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/unix.rs
@@ -3,10 +3,15 @@
 //!
 //! ```text
 //! 0xB000 +-----------------------+   <- top of stack (TOS)
-//!        | *const u8             |   <- "dummy return PC"
+//!        | saved RIP             |
 //! 0xAff8 +-----------------------+
-//!        | *const u8             |   <- "resume frame pointer"
-//! 0xAff0 +-----------------------+   <- 16-byte aligned
+//!        | saved RBP             |
+//! 0xAff0 +-----------------------+
+//!        | saved RSP             |
+//! 0xAfe8 +-----------------------+   <- beginning of "control context",
+//!        | 0                     |
+//! 0xAfe0 +-----------------------+   <- beginning of usable stack space
+//!        |                       |      (16-byte aligned)
 //!        |                       |
 //!        ~        ...            ~   <- actual native stack space to use
 //!        |                       |
@@ -15,87 +20,28 @@
 //! 0x0000 +-----------------------+
 //! ```
 //!
-//! The meaning of the first two values are as follows:
+//! The "control context" indicates how to resume a computation. The layout is
+//! determined by Cranelift's stack_switch instruction, which reads and writes
+//! these fields. The fields used as follows, where we distinguish two cases:
 //!
-//! 1. Resume frame pointer (at TOS - 0x10, 0xAff0 above):
-//!
-//! This value indicates how to resume computation.
-//! We  distinguish two cases
-//!
-//! 1.1
+//! 1
 //! If the continuation is currently active (i.e., running directly, or ancestor
-//! of the running continuation), it points into the stack of the parent of the
-//! continuation, which looks something like this: Here, we assume that some
-//! funtion $g resume-d the active continuation.
+//! of the running continuation), it stores the PC, RSP, and RBP of the *parent* of
+//! the running continuation.
 //!
-//! ```text
-//!
-//! 0xF000 +-----------------------+
-//!        |return PC ($g's caller)|   <- beginning of $g's frame
-//! 0xEFF8 | - - - - - - - - - - - |
-//!        |frame ptr ($g's caller)|
-//! 0xEFF0 | - - - - - - - - - - - |
-//!        ~         ...           ~
-//!        |   stack frame of wasm |
-//!  ...   |       function $g     |
-//!        |     calling resume    |
-//!        ~ - - - - - - - - - - - ~
-//!        |  caller-saved regs    |
-//!        |    stored here        |
-//! 0xD000 +-----------------------+   <- beginning of pseudo frame
-//!        |    return PC of $g    |      of wasmtime_fibre_switch
-//! 0xCFF8 | - - - - - - - - - - - |
-//!        |   saved RBP (of $g)   |   <- "pseudo frame pointer" of
-//! 0xCFF0 | - - - - - - - - - - - |      wasmtime_fibre_switch
-//!        |   saved RBX (of $g)   |
-//! 0xCFE8 | - - - - - - - - - - - |
-//!        |   saved R12 (of $g)   |
-//! 0xCFE0 | - - - - - - - - - - - |
-//!        |   saved R13 (of $g)   |
-//! 0xCFD8 | - - - - - - - - - - - |
-//!        |   saved R14 (of $g)   |
-//! 0xCFD0 | - - - - - - - - - - - |
-//!        |   saved R15 (of $g)   |
-//! 0xCFC8 +-----------------------+ <- stack pointer at time of
-//!                                         switching away
-//! ```
-//! Here, the pseudo-frame of the wasmtime_fibre_switch invocation that switched
-//! to the active continuation begins at 0xD000. It's only a pseudo-frame
-//! in the sense that we never go back to it by executing a ret instruction, but by
-//! switching back to it using another invocation of wasmtime_fibre_switch. The
-//! "resume frame pointer" stored in the active continuation (i.e., at 0xAff0 in
-//! the first picture) is then the "pseudo frame pointer" of wamtime_fibre_switch.
-//! In other words, we store 0xCFF0 at 0xAFF0.
-//!
-//! 1.2
-//! If the first picture shows a suspended computation, then we also store a
-//! "pseudo frame pointer" of wamtime_fibre_switch at TOS - 0x10, but this time
-//! the one that resulted from calling wasmtime_fibre_switch when suspending.
-//! (i.e., the stored pseudo frame pointer resides within the continuation's own
-//! stack).
-//!
-//!
-//! 2. Dummy return PC (at TOS - 0x10, 0xAff0 above):
-//! The goal of the layout described in the previous two pictures is to ensure
-//! the following: Whenever a continuation is active, the values at TOS - 0x08
-//! and TOS - 0x10 together look like the beginning of an ordinary stack frame:
-//! Address TOS - 0x10 (called 0xAff0 in first picutre) denotes its frame
-//! pointer, and in turn contains the frame pointer of its "caller". Here, the
-//! "caller" is supposed to be the parent continuation, or rather the call to
-//! `wasmtime_fibre_switch` from the parent. In order to make sure that things
-//! indeed look like a valid stack, we need to put a return PC above the frame
-//! pointer. Thus, at TOS - 0x08 (called 0xAff8 in first picture), we store a PC
-//! that's inside wasmtime_fibre_switch. Note that this PC is never used to
-//! execute an actual ret instruction, but it ensures that any external tool
-//! walking the frame pointer chain to construct a backtrace sees that the
-//! "calling" function is wasmtime_fibre_switch, and the latter's caller is the
-//! function that invoked `resume`.
+//! 2 If the picture shows a suspended computation, then store the PC,
+//! RSP, and RBP at the time of the suspension.
 //!
 //! Note that this design ensures that external tools can construct backtraces
-//! in the presence of stack switching by using frame pointers only. Wasmtime's
-//! own mechanism for constructing back traces also relies on frame pointer
-//! chains. However, it understands continuations and does not rely on the
-//! trickery outlined here to go from the frames in one continuation to the
+//! in the presence of stack switching by using frame pointers only:
+//! The wasmtime_fibre_start trampoline uses the address of the RBP field in the
+//! control context (0xAff0) as its frame pointer. This means that when passing
+//! the wasmtime_fibre_start frame while doing frame pointer walking, the parent
+//! of that frame is the last frame in the parent of this continuation.
+//!
+//! Wasmtime's own mechanism for constructing backtraces also relies on frame
+//! pointer chains. However, it understands continuations and does not rely on
+//! the trickery outlined here to go from the frames in one continuation to the
 //! parent.
 
 #![allow(unused_macros)]
@@ -104,7 +50,6 @@ use std::alloc::{alloc, dealloc, Layout};
 use std::io;
 use std::ops::Range;
 use std::ptr;
-use wasmtime_continuations::ControlEffect;
 
 use crate::runtime::vm::{VMContext, VMFuncRef, VMOpaqueContext, ValRaw};
 
@@ -210,6 +155,30 @@ impl FiberStack {
         Some(base..base + self.len)
     }
 
+    /// This function installs the launchpad for the computation to run on the
+    /// fiber, such that executing a `stack_switch` instruction on the stack
+    /// actually runs the desired computation.
+    ///
+    /// Concretely, switching to the stack prepared by this function
+    /// causes that we enter `wasmtime_fibre_start`, which then in turn
+    /// calls `fiber_start` with  the following arguments:
+    /// TOS, func_ref, caller_vmctx, args_ptr, args_capacity
+    ///
+    /// The layout of the FiberStack near the top of stack (TOS) *after* running
+    /// this function is as follows:
+    ///
+    ///  Offset from    |
+    ///       TOS       | Contents
+    ///  ---------------|-------------------------------------------------------
+    ///          -0x08   address of wasmtime_fibre_start function (future PC)
+    ///          -0x10   TOS - 0x10 (future RBP)
+    ///          -0x18   TOS - 0x40 (future RSP)
+    ///          -0x20   0 (alignment and wasmtime_fibre_start can't return)
+    ///          -0x28   func_ref
+    ///          -0x30   caller_vmctx
+    ///          -0x38   args_ptr
+    ///          -0x40   args_capacity
+    ///          -0x48   undefined
     pub fn initialize(
         &self,
         func_ref: *const VMFuncRef,
@@ -217,34 +186,39 @@ impl FiberStack {
         args_ptr: *mut ValRaw,
         args_capacity: usize,
     ) {
+        let tos = self.top;
+
         unsafe {
-            wasmtime_fibre_init(
-                self.top,
-                func_ref,
-                caller_vmctx,
-                args_ptr,
-                args_capacity,
-                wasmtime_fibre_switch as *const u8,
-            );
+            let store = |tos_neg_offset, value| {
+                let target = tos.sub(tos_neg_offset) as *mut usize;
+                target.write(value)
+            };
+
+            // Yes, these offsets are technically redundant, but they make
+            // things more readable.
+            let to_store = [
+                (0x08, wasmtime_fibre_start as usize),
+                (0x10, tos.sub(0x10) as usize),
+                (0x18, tos.sub(0x40) as usize),
+                (0x20, 0),
+                (0x28, func_ref as usize),
+                (0x30, caller_vmctx as usize),
+                (0x38, args_ptr as usize),
+                (0x40, args_capacity),
+            ];
+
+            for (offset, data) in to_store {
+                store(offset, data);
+            }
         }
+
     }
 
-    pub(crate) fn resume(&self) -> ControlEffect {
-        unsafe {
-            let reason = ControlEffect::resume().into();
-            ControlEffect::from(wasmtime_fibre_switch(self.top, reason))
-        }
-    }
-
-    pub fn suspend(&self, payload: ControlEffect) {
-        suspend_fiber(self.top, payload)
-    }
 }
 
-pub fn suspend_fiber(top_of_stack: *mut u8, payload: ControlEffect) {
+pub fn switch_to_parent(top_of_stack: *mut u8) {
     unsafe {
-        let arg = payload.into();
-        wasmtime_fibre_switch(top_of_stack, arg);
+        wasmtime_fibre_switch_to_parent(top_of_stack);
     }
 }
 
@@ -267,20 +241,7 @@ impl Drop for FiberStack {
 }
 
 extern "C" {
-    // We allow "improper ctypes" here (i.e., passing values as parameters in an
-    // extern C function that Rust deems non FFI-safe): The two problematic
-    // parameters, namely `func_ref` and `args_ptr`, are piped through into
-    // `fiber_start` (a Rust function), and not accessed in between.
-    #[allow(improper_ctypes)]
-    fn wasmtime_fibre_init(
-        top_of_stack: *mut u8,
-        func_ref: *const VMFuncRef,
-        caller_vmctx: *mut VMContext,
-        args_ptr: *mut ValRaw,
-        args_capacity: usize,
-        wasmtime_fibre_switch_pc: *const u8,
-    );
-    fn wasmtime_fibre_switch(top_of_stack: *mut u8, payload: u64) -> u64;
+    fn wasmtime_fibre_switch_to_parent(top_of_stack: *mut u8);
     #[allow(dead_code)] // only used in inline assembly for some platforms
     fn wasmtime_fibre_start();
 }
@@ -314,8 +275,7 @@ extern "C" fn fiber_start(
         array_call_trampoline(callee_vmxtx, caller_vmxtx, args_ptr, args_capacity);
 
         // Switch back to parent, indicating that the continuation returned.
-        let reason = ControlEffect::return_();
-        suspend_fiber(top_of_stack, reason)
+        switch_to_parent(top_of_stack);
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/fibre/unix/x86_64.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/unix/x86_64.rs
@@ -9,141 +9,31 @@ use wasmtime_asm_macros::asm_func;
 
 // fn(
 //    top_of_stack(rdi): *mut u8
-//    payload(rsi) : u64
 // )
 //
-// The payload (i.e., second argument) is return unchanged, allowing data to be
-// passed from the continuation that calls `wasmtime_fibre_switch` to the one
-// that subsequently runs.
+// Switches to the parent of the stack identified by `top_of_stack`. This
+// functions is only intended for the case where we have finished execution on
+// the current stack and are returning to the parent.
+// Thus, this function never returns.
 asm_func!(
-    "wasmtime_fibre_switch",
+    "wasmtime_fibre_switch_to_parent",
     "
-        // We're switching to arbitrary code somewhere else, so pessimistically
-        // assume that all callee-save register are clobbered. This means we need
-        // to save/restore all of them.
-        //
-        // Note that this order for saving is important since we use CFI directives
-        // below to point to where all the saved registers are.
-        //
-        // The frame pointer must come first, so that we have the return address
-        // and then the frame pointer on the stack (at addresses called 0xCFF8
-        // and 0xCFF0, respectively, in the second picture in unix.rs)
-        push rbp
-        mov rbp, rsp
-        push rbx // at -0x08[rbp]
-        push r12 // at -0x10[rbp]
-        push r13 // at -0x18[rbp]
-        push r14 // at -0x20[rbp]
-        push r15 // at -0x28[rbp]
+        // We need RDI later on, use RSI for top of stack instead.
+        mov rsi, rdi
 
-        // Load the resume frame pointer that we're going to resume at and
-        // store where we're going to get resumed from.
-        mov rax, -0x10[rdi]
-        mov -0x10[rdi], rbp
+        mov rbp, -0x10[rsi]
+        mov rsp, -0x18[rsi]
 
+        // The stack_switch instruction uses register RDI for the payload.
+        // Here, the payload indicates that we are returning (value 0).
+        // See the test case at the end of this file to keep this in sync with
+        // ControlEffect::return_()
+        mov rdi, 0
 
-        // Swap stacks: We loaded the resume frame pointer into RAX, meaning
-        // that it is near the beginning of the pseudo frame of the invocation of
-        // wasmtime_fibe_switch that we want to get back to.
-        // Thus, we need to turn this *frame* pointer back into the
-        // corresponding *stack* pointer. This is simple: The resume frame
-        // pointer is where wamtime_fibre_switch stored RBP, and we want to
-        // calculate the stack pointer after it pushed the next 5 registers, too.
-        //
-        // Using the values from the second picture in unix.rs: If we loaded
-        // 0xCFF0 into RAX, then we want to set RSP to 0xCFC8. Thus, to reflect
-        // that an additional 5 registers where pushed on the stack after RBP, we
-        // subtract 5 * 8 = 0x28 from RAX.
-        lea rsp, -0x28[rax]
-        // Restore callee-saved registers
-        pop r15
-        pop r14
-        pop r13
-        pop r12
-        pop rbx
-        pop rbp
-
-        // We return the payload (i.e., the second argument to this function)
-        mov rax, rsi
-
-        ret
+        jmp -0x08[rsi]
     ",
 );
 
-// fn(
-//    top_of_stack(rdi): *mut u8,
-//    func_ref(rsi): *const VMFuncRef,
-//    caller_vmctx(rdx): *mut VMContext
-//    args_ptr(rcx): *mut ValRaw
-//    args_capacity(r8) : u64
-//    wasmtime_fibre_switch_pc(r9): *mut u8,
-// )
-//
-// This function installs the launchpad for the computation to run on the fiber,
-// such that invoking wasmtime_fibre_switch on the stack actually runs the
-// desired computation.
-//
-// Concretely, switching to the stack prepare by the `wasmtime_fibre_init`
-// function evokes that we enter `wasmtime_fibre_start`, which then in turn
-// calls `fiber_start` with a subset of the arguments above (namely: func_ref,
-// caller_vmctx, args_ptr, args_capacity).
-//
-// The layout of the FiberStack near the top of stack (TOS) *after* running this
-// function is as follows:
-//
-//  Offset from    |
-//       TOS       | Contents
-//  ---------------|-----------------------------------------------------------
-//          -0x08   wasmtime_fibre_switch_pc
-//          -0x10   TOS - 0x20
-//          -0x18   (RIP-relative) address of wasmtime_fibre_start function
-//          -0x20   TOS - 0x10
-//          -0x28   func_ref
-//          -0x30   caller_vmctx
-//          -0x38   args_ptr
-//          -0x40   args_capacity
-//          -0x48   undefined
-#[rustfmt::skip]
-asm_func!(
-    "wasmtime_fibre_init",
-    "
-        // Here we're going to set up a stack frame as expected by
-        // `wasmtime_fibre_switch`. The values we store here will get restored into
-        // registers by that function and the `wasmtime_fibre_start` function will
-        // take over and understands which values are in which registers.
-        //
-        // Install wasmtime_fibre_switch_pc at TOS - 0x08:
-        mov -0x08[rdi], r9
-
-        // Store TOS - 0x20 at TOS - 0x10
-        // This is the resume frame pointer from which we calculate the new
-        // value of RSP when switching to this stack.
-        lea rax, -0x20[rdi]
-        mov -0x10[rdi], rax // loaded first into rax during switch
-
-        // Install wasmtime_fibre_start PC at TOS - 0x18
-        lea r9, {start}[rip]
-        mov -0x18[rdi], r9
-
-        // Store TOS - 0x10 at TOS - 0x20
-        // This is popped into RBP at the end of wasmtime_fibre_switch when
-        // switching to this stack. It thus becomes the value of RBP while
-        // executing wasmtime_fibre_start. Thus, wasmtime_fibre_start thinks
-        // 'my parent's frame pointer is stored at TOS - 0x10'.
-        // NB: RAX still contains TOS - 0x20 at this point.
-        add rax, 0x10
-        mov -0x20[rdi], rax
-
-        // Install remaining arguments
-        mov -0x28[rdi], rsi   // loaded into rbx during switch
-        mov -0x30[rdi], rdx   // loaded into r12 during switch
-        mov -0x38[rdi], rcx   // loaded into r13 during switch
-        mov -0x40[rdi], r8    // loaded into r14 during switch
-
-        ret
-    ",
-    start = sym super::wasmtime_fibre_start,
-);
 
 // This is a pretty special function that has no real signature. Its use is to
 // be the "base" function of all fibers. This entrypoint is used in
@@ -158,106 +48,23 @@ asm_func!(
 // If you're curious a decent introduction to CFI things and unwinding is at
 // https://www.imperialviolet.org/2017/01/18/cfi.html
 //
-// Note that this function is never called directly. It is only ever entered via
-// the return instruction in wasmtime_fibre_switch, with a stack that
-// was prepared by wasmtime_fibre_init before calling wasmtime_fibre_switch.
+// Note that this function is never called directly. It is only ever entered
+// when a `stack_switch` instruction loads its address when switching to a stack
+// prepared by `FiberStack::initialize`.
 //
-// This execution of wasmtime_fibre_switch on a stack as described in the
-// comment on wasmtime_fibre_init leads to the following values in various
-// registers at the right before the RET instruction of the former is executed:
+// Executing `stack_switch` on a stack prepared by `FiberStack::initialize` as
+// described in the comment on `FiberStack::initialize` leads to the following
+// values in various registers when execution of wasmtime_fibre_start begins:
 //
-// RSP: TOS - 0x18
-// RDI: TOS
-// RSI: irrelevant  (not read by wasmtime_fibre_start)
-// RAX: irrelevant  (not read by wasmtime_fibre_start)
+// RSP: TOS - 0x40
 // RBP: TOS - 0x10
-// RBX: func_ref       (= VMFuncRef to execute)
-// R12: caller_vmctx
-// R13: args_ptr       (used by array call trampoline)
-// R14: args_capacity  (used by array call trampoline)
-// R15: irrelevant  (not read by wasmtime_fibre_start)
-//
-// At this point in time, the stack layout is as follows:
-//
-//  Offset from   |
-//       TOS      | Contents
-//  --------------|---------------------------------
-//         -0x08   PC at beginning of wasmtime_fibre_switch
-//
-//         -0x10   frame pointer of wasmtime_fibre_switch that switched to us,
-//                 thus pointing right below stack frame of caller of
-//                 Fiber::resume, with pseudo frame of wasmtime_fibre_switch
-//                 below.
-//
-//         -0x18   (RIP-relative) address of wasmtime_fibre_start function
-//
-//
-// Note that after executing the RET instruction in wasmtime_fibre_switch,
-// we then start executing wasmtime_fibre_start with RSP = TOS - 0x10.
 asm_func!(
     "wasmtime_fibre_start",
     "
-        // Use the `simple` directive on the startproc here which indicates that
-        // some default settings for the platform are omitted, since this
-        // function is so nonstandard
-        .cfi_startproc simple
-        .cfi_def_cfa_offset 0
+        // TODO(frank-emrich): Restore DWARF information for this function. In
+        // the meantime, debugging is possible using frame pointer walking.
 
-        // This is where things get special, we're specifying a custom dwarf
-        // expression for how to calculate the CFA. The goal here is that we
-        // need to load the parent's stack pointer just before the call it made
-        // into `wasmtime_fibre_switch`. Note that the CFA value changes over
-        // time as well because a fiber may be resumed multiple times from
-        // different points on the original stack. This means that our custom
-        // CFA directive involves `DW_OP_deref`, which loads data from memory.
-        //
-        // The expression we're encoding here is that the CFA, the stack pointer
-        // of whatever called into `wasmtime_fibre_start`, is:
-        //
-        //        *$rsp + 0x10
-        //
-        // $rsp is the stack pointer of `wasmtime_fibre_start` at the time the
-        // next instruction after the `.cfi_escape` is executed. Our $rsp at the
-        // start of this function is 16 bytes below the top of the stack (0xAff0
-        // in the diagram in unix.rs). The $rbp of wasmtime_fibre_switch of our
-        // parent invocation is stored at that location, so we dereference the
-        // stack pointer to load it.
-        //
-        // After dereferencing, though, we have the $rbp value for
-        // `wasmtime_fibre_switch` itself. That's a weird function which sort of
-        // and sort of doesn't exist on the stack.  We want to point to the
-        // caller of `wasmtime_fibre_switch`, so to do that we need to skip the
-        // stack space reserved by `wasmtime_fibre_switch`, which is the saved
-        // rbp register plus the return address of the caller's `call` instruction.
-        // Hence we offset another 0x10 bytes.
-        .cfi_escape 0x0f, /* DW_CFA_def_cfa_expression */ \
-            4,            /* the byte length of this expression */ \
-            0x57,         /* DW_OP_reg7 (rsp) */ \
-            0x06,         /* DW_OP_deref */ \
-            0x23, 0x10    /* DW_OP_plus_uconst 0x10 */
 
-        // And now after we've indicated where our CFA is for our parent
-        // function, we can define that where all of the saved registers are
-        // located. This uses standard `.cfi` directives which indicate that
-        // these registers are all stored relative to the CFA. Note that this
-        // order is kept in sync with the above register spills in
-        // `wasmtime_fibre_switch`.
-        .cfi_rel_offset rip, -8
-        .cfi_rel_offset rbp, -16
-        .cfi_rel_offset rbx, -24
-        .cfi_rel_offset r12, -32
-        .cfi_rel_offset r13, -40
-        .cfi_rel_offset r14, -48
-        .cfi_rel_offset r15, -56
-
-        // The body of this function is pretty similar. All our parameters are
-        // already loaded into registers by the switch function. The
-        // `wasmtime_fibre_init` routine arranged the various values to be
-        // materialized into the registers used here. Our job is to then move
-        // the values into the ABI-defined registers and call the entry-point
-        // (i.e., the fiber_start function).
-        // Note that `call` is used here to leave this frame on the stack so we
-        // can use the dwarf info here for unwinding.
         //
         // Note that the next 5 instructions amount to calling fiber_start
         // with the following arguments:
@@ -267,19 +74,25 @@ asm_func!(
         // 4. args_ptr
         // 5. args_capacity
         //
-        // Note that fiber_start never returns: Instead, it // resume to the
-        // parent FiberStack via wasmtime_fibre_switch.
+        // Note that `fiber_start` never returns: Instead, it resume to the
+        // parent using `wasmtime_fibre_switch_to_parent`.
 
-        // TOS is already in RDI
-        mov rsi, rbx // func_ref
-        mov rdx, r12 // caller_vmctx
-        mov rcx, r13 // args_ptr
-        mov r8, r14  // args_capacity
+        pop r8  // args_capacity
+        pop rcx // args_ptr
+        pop rdx // caller_vmctx
+        pop rsi // func_ref
+        lea rdi, 0x20[rsp] // TOS
         call {fiber_start}
 
         // We should never get here and purposely emit an invalid instruction.
         ud2
-        .cfi_endproc
     ",
     fiber_start = sym super::fiber_start,
 );
+
+
+#[test]
+fn test_return_payload() {
+  // The following assumption is baked into `wasmtime_fibre_switch_to_parent`.
+  assert_eq!(u64::from(wasmtime_continuations::ControlEffect::return_()), 0);
+}

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1367,14 +1367,6 @@ impl Instance {
         fault
     }
 
-    // NOTE(dhil): This function is not called when `wasmfx_baseline` is toggled.
-    #[cfg(not(feature = "wasmfx_baseline"))]
-    pub(crate) fn typed_continuations_stack_chain(&mut self) -> *mut *mut StackChainCell {
-        unsafe {
-            self.vmctx_plus_offset_mut(self.offsets().vmctx_typed_continuations_stack_chain())
-        }
-    }
-
     #[allow(dead_code)]
     pub(crate) fn set_typed_continuations_stack_chain(&mut self, chain: *mut *mut StackChainCell) {
         unsafe {

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -931,18 +931,6 @@ fn tc_cont_new(
     Ok(ans.cast::<u8>())
 }
 
-fn tc_resume(instance: &mut Instance, contref: *mut u8) -> Result<*mut u8, TrapReason> {
-    crate::vm::continuation::optimized::resume(
-        instance,
-        contref.cast::<crate::vm::continuation::optimized::VMContRef>(),
-    )
-    .map(|reason| reason.into())
-}
-
-fn tc_suspend(instance: &mut Instance, tag_addr: *mut u8) -> Result<(), TrapReason> {
-    crate::vm::continuation::optimized::suspend(instance, tag_addr)
-}
-
 fn tc_cont_ref_forward_tag_return_values_buffer(
     _instance: &mut Instance,
     parent_contref: *mut u8,


### PR DESCRIPTION
This PR moves stack switching in the optimized implementation from libcalls to generated code using the CLIF `stack_switch` instruction.

Due to earlier preparation work, the changes are fairly localized:

- The layout of `FiberStacks` remains similar: Near the top of stack address, we store metadata about the stack's parent (if running) or itself (when suspended). This area has grown from 2 to 4 words, storing RSP, RIP and RBP now. Previously, we only stored RSP there, and RIP and RBP were stored on the actual stack itself. See `unix.rs` for a detailed description of the layout.
- Code emitted in `optimized.rs` hasn't changed much, it's mostly just replacing libcalls to `tc_resume` and `tc_suspend` with usages of `stack_switch`. The instruction is given a "context pointer" into the 4-word region near the top of stack mentioned above.
- Most changes happen in the `fibre` module:
  + `wasmtime_fibre_switch`, the function previously doing all switching under the hood, is gone now. There is however a new, related function `wasmtime_fibre_switch_to_parent` that is exclusively used to return back to the parent when a continuation finishes.
  + `wasmtime_fibre_init`, previously used to initialize `FiberStacks`, is gone too. Conceptually, we still need to do very similar initialization work as before, but I realized that there wasn't a need for this function to be implemented in assembly anymore. The initialization logic is therefore moved to Rust code in `FiberStack::initialize`.
  + `wasmtime_fibre_start`, the "launchpad" and bottom frame in every `FiberStack,` is conceptually still doing the same and has seen only minor changes, related to where certain data is obtained from now. I've temporarily removed all the .cfi_* directives from the function, meaning that its custom DWARF info is gone for now. That has no actual impact on our work: Unlike the original `wasmtime-fiber`, our stacks are designed so that external tools can obtain cross-continuation backtraces just by doing frame pointer walking. I'm nevertheless planning to re-add the DWARF info at a later point.
- The bodies of the libcalls `tc_resume` and `tc_suspend` are no longer needed and hence removed.