### PR TITLE
[CI] Disable benchmark job

### DIFF
--- a/.github/workflows/benchfx.yml
+++ b/.github/workflows/benchfx.yml
@@ -22,6 +22,9 @@ env:
 
 jobs:
   bench:
+    # TODO(dhil): Disable this workflow until we have brought our
+    # toolchains up-to-date with the new binary format.
+    if: false
     name: Setup and run benchmarks
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This patch disables the CI benchmark job. We should reactivate it after our toolchains have been brought up to date with the new binary format.