### PR TITLE
Rebranding

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -259,12 +259,12 @@ WASMTIME_CONFIG_PROP(void, wasm_exceptions, bool)
 WASMTIME_CONFIG_PROP(void, wasm_function_references, bool)
 
 /**
- * \brief Configures whether the WebAssembly typed continuations
+ * \brief Configures whether the WebAssembly stack switching
  * proposal is enabled.
  *
  * This setting is `false` by default.
  */
-WASMTIME_CONFIG_PROP(void, wasm_typed_continuations, bool)
+WASMTIME_CONFIG_PROP(void, wasm_stack_switching, bool)
 
 /**
  * \brief Configures how JIT code will be compiled.

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -214,10 +214,10 @@ macro_rules! foreach_builtin_function {
             // TODO
             tc_drop_cont_ref(vmctx: vmctx, contref: pointer);
 
-            // General-purpose allocation. Only used by typed-continuations
+            // General-purpose allocation. Only used by stack-switching
             // code at the moment.
             tc_allocate(vmctx: vmctx, size: i64, align: i64) -> pointer;
-            // General-purpose deallocation. Only used by typed-continuations
+            // General-purpose deallocation. Only used by stack-switching
             // code at the moment.
             tc_deallocate(vmctx: vmctx, ptr: pointer, size: i64, align: i64);
             // General-purpose reallocation without preserving existing data. Concretely, behaves like

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2186,7 +2186,7 @@ impl Config {
             let model = match target.operating_system {
                 target_lexicon::OperatingSystem::Windows => "update_windows_tib",
                 target_lexicon::OperatingSystem::Linux => "basic",
-                _ => bail!("typed-continuations feature not supported on this platform "),
+                _ => bail!("stack-switching feature not supported on this platform "),
             };
 
             if !self


### PR DESCRIPTION
This patch rebrands a few public APIs from typed-continuations to stack-switching.

Resolves #146.
