### PR TITLE
Split linking_tags.wast into two files

### DIFF
--- a/tests/misc_testsuite/stack-switching/linking_tags1.wast
+++ b/tests/misc_testsuite/stack-switching/linking_tags1.wast
@@ -1,0 +1,36 @@
+(module $alien
+  (tag $alien_tag (export "alien_tag"))
+)
+(register "alien")
+
+(module $mine
+  (type $ft (func))
+  (type $ct (cont $ft))
+  (tag $alien_tag (import "alien" "alien_tag"))
+  (tag $my_tag)
+  (func $do_alien_tag
+    (suspend $alien_tag))
+
+  ;; Don't handle the imported alien.
+  (func (export "main-1")
+    (block $on_my_tag (result (ref $ct))
+      (resume $ct (on $my_tag $on_my_tag) (cont.new $ct (ref.func $do_alien_tag)))
+      (unreachable)
+    )
+    (unreachable))
+
+  ;; Handle the imported alien.
+  (func (export "main-2")
+    (block $on_alien_tag (result (ref $ct))
+      (resume $ct (on $alien_tag $on_alien_tag) (cont.new $ct (ref.func $do_alien_tag)))
+      (unreachable)
+    )
+    (drop))
+
+  (elem declare func $do_alien_tag)
+)
+(register "mine")
+(assert_return (invoke "main-2"))
+;; Due to issue #253, we need to make sure that nothing happens afterwards in
+;; the test:
+(assert_suspension (invoke "main-1") "unhandled")


### PR DESCRIPTION
This PR splits `linking_tags.wast` into two files.

This is a preparation step needed to land fast effect forwarding due to the following:
`linking_tags.wast` currently has two `assert_suspension` directives. In the current implementation, we are always on the main stack when we detect that a tag is unhandled and trap from there. However, in the presence of fast effect forwarding, we detect the lack of an appropriate handler at the `suspend` site and trap there (i.e., possibly while still running on a continuation stack).

As a result, the `assert_suspension` directives in `linking_tags.wast` trigger the problem described in #253 as soon as fast fowarding lands. As a workaround, this PR splits the file into two, where the `assert_suspension` is the very last step in each test (i.e., we avoid further execution inside the `Store` where we trapped while inside a continuation). The combined contents of both files is identical to the original `linking_tags.wast`, but the module `bar` is moved to the end of the second file.

