### PR TITLE
Restore wast testsuite functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,12 +429,14 @@ disable-logging = ["log/max_level_off", "tracing/max_level_off"]
 wasmfx_baseline = [
   "wasmtime-cranelift/wasmfx_baseline",
   "wasmtime/wasmfx_baseline",
+  "wasmtime-wast-util/wasmfx_baseline",
 ]
 
 # Synthetic feature to enable CI testing of the optimised implementation
 wasmfx_no_baseline = [
   "wasmtime-cranelift/wasmfx_no_baseline",
   "wasmtime/wasmfx_no_baseline",
+  "wasmtime-wast-util/wasmfx_no_baseline",
 ]
 
 # Toggle the WasmFX pooling allocator

--- a/crates/wast-util/Cargo.toml
+++ b/crates/wast-util/Cargo.toml
@@ -17,3 +17,7 @@ toml = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+wasmfx_baseline = []
+wasmfx_no_baseline = []

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -250,6 +250,8 @@ impl Compiler {
                     || config.gc == Some(true)
                     || config.relaxed_simd == Some(true)
                     || config.gc_types == Some(true)
+                    || config.exceptions == Some(true)
+                    || config.stack_switching == Some(true)
                 {
                     return true;
                 }
@@ -285,6 +287,14 @@ impl WastTest {
     /// Returns whether this test should fail under the specified extra
     /// configuration.
     pub fn should_fail(&self, config: &WastConfig) -> bool {
+        // The stack-switching baseline does not support proper linking of tags yet.
+        if cfg!(feature = "wasmfx_baseline")
+            && cfg!(not(feature = "wasmfx_no_baseline"))
+            && self.path.ends_with("linking_tags2.wast")
+        {
+            return true;
+        }
+
         // Winch only supports x86_64 at this time.
         if config.compiler == Compiler::Winch && !cfg!(target_arch = "x86_64") {
             return true;

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -270,6 +270,8 @@ macro_rules! for_each_host_signature {
             fn(I64, I64) -> I64; // NOTE(dhil): added by me; signature for stack switching baseline libcall
             fn(I64, I32, I64); // NOTE(dhil): added by me; signature for stack switching baseline libcall
             fn(I64, I64, I32, I32) -> I64; // NOTE(dhil): added by me; signature for stack switching libcall
+            fn(I64, I32, I64, I64, I64) -> I64; // NOTE(dhil): added by me; signature for stack switching libcall
+            fn(I64, I32, I64, I64, I64, I64); // NOTE(dhil): added by me; signature for stack switching libcall
         }
     };
 }

--- a/tests/misc_testsuite/stack-switching/cont_args.wast
+++ b/tests/misc_testsuite/stack-switching/cont_args.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; This file tests passing arguments to functions used has continuations and
 ;; returning values from such continuations on ordinary (i.e., non-suspend) exit
 

--- a/tests/misc_testsuite/stack-switching/cont_bind1.wast
+++ b/tests/misc_testsuite/stack-switching/cont_bind1.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Simple test for cont.bind: cont.bind supplies 0 arguments
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_bind2.wast
+++ b/tests/misc_testsuite/stack-switching/cont_bind2.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Simple test for cont.bind: cont.bind turns 2-arg continution into 1-arg one before calling resume
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_bind3.wast
+++ b/tests/misc_testsuite/stack-switching/cont_bind3.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Testing cont.bind on continuations received from suspending rather than cont.new.
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_bind4.wast
+++ b/tests/misc_testsuite/stack-switching/cont_bind4.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Testing that the creation of the necessary payload buffers works as expect,
 ;; even when the same continuation reference is suspended multiple times
 

--- a/tests/misc_testsuite/stack-switching/cont_forwarding1.wast
+++ b/tests/misc_testsuite/stack-switching/cont_forwarding1.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Simple forwarding, no payloads, no param or return values on
 ;; function, immediately resumed by handler
 

--- a/tests/misc_testsuite/stack-switching/cont_forwarding2.wast
+++ b/tests/misc_testsuite/stack-switching/cont_forwarding2.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Like previous test, but with param and return values on functions (but no tag payloads)
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_forwarding3.wast
+++ b/tests/misc_testsuite/stack-switching/cont_forwarding3.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Like previous test, but tag has payloads (param and return values)
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_forwarding4.wast
+++ b/tests/misc_testsuite/stack-switching/cont_forwarding4.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Continuation is not immediately resumed, instead we run a different continuation in the meantime.
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_forwarding5.wast
+++ b/tests/misc_testsuite/stack-switching/cont_forwarding5.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Continuation is not immediately resumed, we pass it to a different one as an
 ;; argument, increasing the length of the chain by adding yet another useless
 ;; handler.

--- a/tests/misc_testsuite/stack-switching/cont_forwarding6.wast
+++ b/tests/misc_testsuite/stack-switching/cont_forwarding6.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; The resumed continuation suspends again (from the same inner function), using the same tag.
 ;; We install a new handler at the outermost level, which should be forwarded to correctly.
 

--- a/tests/misc_testsuite/stack-switching/cont_forwarding7.wast
+++ b/tests/misc_testsuite/stack-switching/cont_forwarding7.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; The resumed continuation suspends again (but not from the same function), using the same tag.
 ;; We use the same outer handler in a loop
 

--- a/tests/misc_testsuite/stack-switching/cont_forwarding8.wast
+++ b/tests/misc_testsuite/stack-switching/cont_forwarding8.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; The resumed continuation suspends again, to the same and different tags.
 ;; We use the same outer handler in a loop
 

--- a/tests/misc_testsuite/stack-switching/cont_nary.wast
+++ b/tests/misc_testsuite/stack-switching/cont_nary.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Tests using support for n-ary continuations
 ;; Uses a function as continuation that has 3 param and 5 return values
 ;; Uses tag that has 4 elements of payloads

--- a/tests/misc_testsuite/stack-switching/cont_nested1.wast
+++ b/tests/misc_testsuite/stack-switching/cont_nested1.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; test using continuations from within a continuation
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_nested2.wast
+++ b/tests/misc_testsuite/stack-switching/cont_nested2.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Similar to cont_nested1, but with payloads
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_nested3.wast
+++ b/tests/misc_testsuite/stack-switching/cont_nested3.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Minimal test for resuming continuation after its original parent is gone
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_nested4.wast
+++ b/tests/misc_testsuite/stack-switching/cont_nested4.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Minimal test for resuming continuation after its original parent is suspended
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_nested5.wast
+++ b/tests/misc_testsuite/stack-switching/cont_nested5.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; test using continuations from within a continuation
 
 

--- a/tests/misc_testsuite/stack-switching/cont_nested6.wast
+++ b/tests/misc_testsuite/stack-switching/cont_nested6.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; test proper handling of TSP pointer after a continuation returns normally
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_new.wast
+++ b/tests/misc_testsuite/stack-switching/cont_new.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 (module
   (type $ft (func))
   (type $ct (cont $ft))

--- a/tests/misc_testsuite/stack-switching/cont_resume.wast
+++ b/tests/misc_testsuite/stack-switching/cont_resume.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 (module
   (type $ft (func))
   (type $ct (cont $ft))

--- a/tests/misc_testsuite/stack-switching/cont_resume1.wast
+++ b/tests/misc_testsuite/stack-switching/cont_resume1.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 (module
   (type $ft_init (func))
   (type $ct_init (cont $ft_init))

--- a/tests/misc_testsuite/stack-switching/cont_resume2.wast
+++ b/tests/misc_testsuite/stack-switching/cont_resume2.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; This test requires the following to work:
 ;; 1. Passing arguments to tags and receiving values back at suspend sites
 ;; 2. Passing values to a continuation obtained from a handler

--- a/tests/misc_testsuite/stack-switching/cont_resume_return.wast
+++ b/tests/misc_testsuite/stack-switching/cont_resume_return.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 (module
   (type $ft (func (result i32)))
   (type $ct (cont $ft))

--- a/tests/misc_testsuite/stack-switching/cont_return.wast
+++ b/tests/misc_testsuite/stack-switching/cont_return.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Test returning value from continuation function without any suspending
 
 (module

--- a/tests/misc_testsuite/stack-switching/cont_suspend.wast
+++ b/tests/misc_testsuite/stack-switching/cont_suspend.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Small continuation resume test
 ;; expected output:
 ;; 1 : i32

--- a/tests/misc_testsuite/stack-switching/cont_table.wast
+++ b/tests/misc_testsuite/stack-switching/cont_table.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 (module
   (type $ft (func (param i32) (result i32)))
   (type $ct (cont $ft))

--- a/tests/misc_testsuite/stack-switching/cont_twice.wast
+++ b/tests/misc_testsuite/stack-switching/cont_twice.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 (module
   (type $ft (func))
   (type $ct (cont $ft))

--- a/tests/misc_testsuite/stack-switching/dup.wast
+++ b/tests/misc_testsuite/stack-switching/dup.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 (module
   (type $ft (func))
   (type $ct (cont $ft))

--- a/tests/misc_testsuite/stack-switching/linking_tags1.wast
+++ b/tests/misc_testsuite/stack-switching/linking_tags1.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 (module $alien
   (tag $alien_tag (export "alien_tag"))
 )

--- a/tests/misc_testsuite/stack-switching/linking_tags2.wast
+++ b/tests/misc_testsuite/stack-switching/linking_tags2.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 (module $foo
   (type $ft (func (result i32)))
   (type $ct (cont $ft))

--- a/tests/misc_testsuite/stack-switching/unhandled.wast
+++ b/tests/misc_testsuite/stack-switching/unhandled.wast
@@ -1,3 +1,4 @@
+;;! stack_switching = true
 ;; Test unhandled suspension
 
 (module

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -238,6 +238,8 @@ fn run_wast(test: &WastTest, config: WastConfig) -> anyhow::Result<()> {
             if result.is_ok() {
                 bail!("this test is flagged as should-fail but it succeeded")
             }
+        } else {
+            result?;
         }
     }
 


### PR DESCRIPTION
* Restores a deleted `result?;`
* Toggles `stack_switching = true` for all stack switching tests.

Resolves #261.
