### PR TITLE
Rename tag_return_values field and payload-related helper functions

### DIFF
--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -272,10 +272,10 @@ pub mod offsets {
         pub const STACK: usize = LAST_ANCESTOR + core::mem::size_of::<usize>();
         /// Offset of `args` field
         pub const ARGS: usize = STACK + super::FIBER_STACK_SIZE;
-        /// Offset of `tag_return_values` field
-        pub const TAG_RETURN_VALUES: usize = ARGS + core::mem::size_of::<Payloads>();
+        /// Offset of `values` field
+        pub const VALUES: usize = ARGS + core::mem::size_of::<Payloads>();
         /// Offset of `revision` field
-        pub const REVISION: usize = TAG_RETURN_VALUES + core::mem::size_of::<Payloads>();
+        pub const REVISION: usize = VALUES + core::mem::size_of::<Payloads>();
     }
 
     pub mod stack_limits {


### PR DESCRIPTION
Currently,  `VMContRef` objects in the optimized implementation have two fields of type `Payloads`:
- `args`, where the arguments and return values stored by the toplevel function running inside the continuation are stored (used by the array call trampoline)
- `tag_return_values`, which is used to store payloads of suspended continuations provided by `resume` or `cont.bind` (thus, their types must correspond to the return type of the tag that we suspended with)

This PR renames the second field, in order to prepare for `switch`: In the presence of `switch`, the name `tag_return_values` does not make sense anymore: We will be storing `switch` arguments in that vector as well.

I've chosen `values` as the new name, inspired by how the baseline implementation calls its counterpart of that vector.

I've also renamed a few helper functions related to payload handling in `optimized.rs`. Mostly to remove the redundant `typed_continuations_` prefixes, but also to reflect better what they do.
- `typed_continuations_load_payloads -> vmctx_load_payloads`
- `typed_continuations_store_payloads ->  vmctx_store_payloads`
-  `typed_continuations_load_tag_return_values -> vmcontref_load_values`
- `typed_continuations_store_resume_args -> vmcontref_store_payloads`


