### PR TITLE
Make backtrace creation more accurate to support GC

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1322,32 +1322,6 @@ pub(crate) fn define(
         .operands_out(vec![Operand::new("addr", iAddr)]),
     );
 
-    // NOTE(frank-emrich)
-    // This is only used as part of a temporary workaround while our
-    // cross-continuation implementation of backtraces is built around the
-    // assumption that we "exit" Wasm on resume.
-    // The returned instruction pointer is never used for actual control flow
-    // (i.e., we never branch to it), but only for the construction of
-    // backtraces.
-    //
-    // We conservatively give it all kinds of side-effects to avoid it being
-    // moved around too much, but all that matters anyway is that during the
-    // Wasm -> CLIF translation, this CLIF instruction is associated with the
-    // current Wasm instruction.
-    ig.push(
-        Inst::new(
-            "get_instruction_pointer",
-            r#"
-        Get the instruction pointer at this instruction.
-        "#,
-            &formats.nullary,
-        )
-        .operands_out(vec![Operand::new("addr", iAddr)])
-        .other_side_effects()
-        .can_load()
-        .can_store(),
-    );
-
     ig.push(
         Inst::new(
             "iconst",

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -811,9 +811,6 @@
        ;; this program point.
        (Unwind (inst UnwindInst))
 
-       ;; Writes the current PC into dst
-       (GetRip (dst WritableGpr))
-
        ;; A pseudoinstruction that just keeps a value alive.
        (DummyUse (reg Reg))))
 

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -4626,15 +4626,6 @@ pub(crate) fn emit(
         Inst::DummyUse { .. } => {
             // Nothing.
         }
-
-        Inst::GetRip { dst } => {
-            let here = sink.get_label();
-            sink.bind_label(here, state.ctrl_plane_mut());
-            let amode = Amode::RipRelative { target: here };
-            let dst = dst.map(|gpr| Reg::from(gpr));
-            let inst = Inst::lea(amode, dst);
-            inst.emit(sink, info, state);
-        }
     }
 
     state.clear_post_insn();

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -139,7 +139,6 @@ impl Inst {
             | Inst::CoffTlsGetAddr { .. }
             | Inst::Unwind { .. }
             | Inst::DummyUse { .. }
-            | Inst::GetRip { .. }
             | Inst::AluConstOp { .. } => smallvec![],
 
             Inst::LockCmpxchg16b { .. }
@@ -1957,10 +1956,6 @@ impl PrettyPrint for Inst {
                 let reg = pretty_print_reg(*reg, 8);
                 format!("dummy_use {reg}")
             }
-
-            Inst::GetRip { .. } => {
-                format!("get_rip")
-            }
         }
     }
 }
@@ -2706,10 +2701,6 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
 
         Inst::DummyUse { reg } => {
             collector.reg_use(reg);
-        }
-
-        Inst::GetRip { dst } => {
-            collector.reg_def(dst);
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3483,11 +3483,6 @@
                 (Amode.ImmReg 8 (x64_rbp) (mem_flags_trusted))
                 (ExtKind.None)))
 
-(rule (lower (get_instruction_pointer))
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.GetRip dst))))
-        (value_reg dst)))
-
 ;; Rules for `jump` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower_branch (jump _) (single_target target))

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -979,8 +979,6 @@ pub(crate) fn check(
         Inst::Unwind { .. } | Inst::DummyUse { .. } => Ok(()),
 
         Inst::StackSwitchBasic { .. } => Err(PccError::UnimplementedInst),
-
-        Inst::GetRip { .. } => Err(PccError::UnimplementedInst),
     }
 }
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -1285,7 +1285,6 @@ where
         Opcode::X86Pmulhrsw => unimplemented!("X86Pmulhrsw"),
         Opcode::X86Pmaddubsw => unimplemented!("X86Pmaddubsw"),
         Opcode::X86Cvtt2dq => unimplemented!("X86Cvtt2dq"),
-        Opcode::GetInstructionPointer => unimplemented!("GetInstructionPointer"),
         Opcode::StackSwitch => unimplemented!("StackSwitch"),
     })
 }

--- a/crates/continuations/src/lib.rs
+++ b/crates/continuations/src/lib.rs
@@ -57,8 +57,6 @@ pub struct WasmFXConfig {
 #[derive(Debug, Default, Clone)]
 pub struct StackLimits {
     pub stack_limit: usize,
-    pub last_wasm_exit_fp: usize,
-    pub last_wasm_exit_pc: usize,
     pub last_wasm_entry_fp: usize,
 }
 
@@ -301,8 +299,6 @@ pub mod offsets {
         use memoffset::offset_of;
 
         pub const STACK_LIMIT: usize = offset_of!(StackLimits, stack_limit);
-        pub const LAST_WASM_EXIT_FP: usize = offset_of!(StackLimits, last_wasm_exit_fp);
-        pub const LAST_WASM_EXIT_PC: usize = offset_of!(StackLimits, last_wasm_exit_pc);
         pub const LAST_WASM_ENTRY_FP: usize = offset_of!(StackLimits, last_wasm_entry_fp);
     }
 

--- a/crates/wasmtime/src/runtime/vm/fibre/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/mod.rs
@@ -82,6 +82,16 @@ cfg_if::cfg_if! {
                 self.0.range()
             }
 
+            /// Returns the instruction pointer stored in the Fiber's ControlContext.
+            pub fn control_context_instruction_pointer(&self) -> usize {
+                self.0.control_context_instruction_pointer()
+            }
+
+            /// Returns the frame pointer stored in the Fiber's ControlContext.
+            pub fn control_context_frame_pointer(&self) -> usize {
+                self.0.control_context_frame_pointer()
+            }
+
             pub fn initialize(
                 &self,
                 func_ref: *const VMFuncRef,

--- a/crates/wasmtime/src/runtime/vm/fibre/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/fibre/unix.rs
@@ -158,6 +158,24 @@ impl FiberStack {
         Some(base..base + self.len)
     }
 
+    pub fn control_context_instruction_pointer(&self) -> usize {
+        // See picture at top of this file:
+        // RIP is stored 8 bytes below top of stack.
+        unsafe {
+            let ptr = self.top.sub(8) as *mut usize;
+            *ptr
+        }
+    }
+
+    pub fn control_context_frame_pointer(&self) -> usize {
+        // See picture at top of this file:
+        // RBP is stored 16 bytes below top of stack.
+        unsafe {
+            let ptr = self.top.sub(16) as *mut usize;
+            *ptr
+        }
+    }
+
     /// This function installs the launchpad for the computation to run on the
     /// fiber, such that executing a `stack_switch` instruction on the stack
     /// actually runs the desired computation.

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -29,7 +29,6 @@ use crate::runtime::vm::{
     Unwind, VMRuntimeLimits,
 };
 use core::ops::ControlFlow;
-use wasmtime_continuations::StackLimits;
 
 /// A WebAssembly stack trace.
 #[derive(Debug)]
@@ -234,6 +233,7 @@ impl Backtrace {
         mut f: impl FnMut(Frame) -> ControlFlow<()>,
     ) -> ControlFlow<()> {
         use crate::runtime::vm::continuation::imp::VMContRef;
+        use wasmtime_continuations::StackLimits;
 
         // Handle the stack that is currently running (which may be a
         // continuation or the main stack).

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -23,7 +23,6 @@
 
 use crate::prelude::*;
 use crate::runtime::store::StoreOpaque;
-use crate::runtime::vm::continuation::imp::VMContRef;
 use crate::runtime::vm::continuation::stack_chain::StackChain;
 use crate::runtime::vm::{
     traphandlers::{tls, CallThreadState},
@@ -234,6 +233,8 @@ impl Backtrace {
         trampoline_sp: usize,
         mut f: impl FnMut(Frame) -> ControlFlow<()>,
     ) -> ControlFlow<()> {
+        use crate::runtime::vm::continuation::imp::VMContRef;
+
         // Handle the stack that is currently running (which may be a
         // continuation or the main stack).
         Self::trace_through_wasm(unwind, pc, fp, trampoline_sp, &mut f)?;

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -213,6 +213,19 @@ impl Backtrace {
         log::trace!("====== Done Capturing Backtrace (reached end of activations) ======");
     }
 
+    #[cfg(all(feature = "wasmfx_baseline", not(feature = "wasmfx_no_baseline")))]
+    unsafe fn trace_through_continuations(
+        _unwind: &dyn Unwind,
+        _chain: Option<&StackChain>,
+        _pc: usize,
+        _fp: usize,
+        _trampoline_sp: usize,
+        _f: impl FnMut(Frame) -> ControlFlow<()>,
+    ) -> ControlFlow<()> {
+        unimplemented!()
+    }
+
+    #[cfg(any(not(feature = "wasmfx_baseline"), feature = "wasmfx_no_baseline"))]
     unsafe fn trace_through_continuations(
         unwind: &dyn Unwind,
         chain: Option<&StackChain>,

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -283,8 +283,6 @@ impl Backtrace {
                     debug_assert!(parent_stack_range.contains(&parent_limits.stack_limit));
                 });
 
-                debug_assert_eq!(resume_fp, parent_limits.last_wasm_exit_fp);
-
                 Self::trace_through_wasm(
                     unwind,
                     resume_pc,

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -23,12 +23,14 @@
 
 use crate::prelude::*;
 use crate::runtime::store::StoreOpaque;
+use crate::runtime::vm::continuation::imp::VMContRef;
 use crate::runtime::vm::continuation::stack_chain::StackChain;
 use crate::runtime::vm::{
     traphandlers::{tls, CallThreadState},
     Unwind, VMRuntimeLimits,
 };
 use core::ops::ControlFlow;
+use wasmtime_continuations::StackLimits;
 
 /// A WebAssembly stack trace.
 #[derive(Debug)]
@@ -226,39 +228,68 @@ impl Backtrace {
         chain.map_or(ControlFlow::Continue(()), |chain| {
             debug_assert_ne!(*chain, StackChain::Absent);
 
-            let stack_limits_iter = chain.clone().into_iter();
+            let stack_limits_vec: Vec<*mut StackLimits> =
+                chain.clone().into_stack_limits_iter().collect();
+            let continuations_vec: Vec<*mut VMContRef> =
+                chain.clone().into_continuation_iter().collect();
 
-            // The very first entry in the stack chain is for what is currently
-            // running (which may be a continuation or main stack). However, for
-            // the currently running stack, the data in its associated
-            // `StackLimits` object is stale (see comment on
-            // `wasmtime_continuations::StackChain` for a description of the
-            // invariants).
-            // That's why we already handled the currently running stack at the
-            // beginning of the function, using data directly from the
-            // VMRuntimeLimits.
-            let remainder = stack_limits_iter.skip(1);
+            // The StackLimits of the currently running stack (whether that's a
+            // continuation or the main stack) contains undefined data, the
+            // information about that stack is saved in the Store's
+            // `VMRuntimeLimits` and handled at the top of this function already.
+            // That's why we ignore `stack_limits_vec[0]`.
+            //
+            // Note that a continuation stack's ControlContext stores
+            // information about how to resume execution *in its parent*. Thus,
+            // we combine the information from continuations_vec[i] with
+            // stack_limits_vec[i + 1] below to get information about a
+            // particular stack.
+            //
+            // There must be exactly one more `StackLimits` object than there
+            // are continuations, due to the main stack having one, too.
+            assert_eq!(stack_limits_vec.len(), continuations_vec.len() + 1);
 
-            for (continuation_opt, limits) in remainder {
-                let limits = limits.as_ref().unwrap();
-                match continuation_opt {
-                    Some(continuation) => unsafe {
-                        let cont = &*continuation;
-                        let stack_range = cont.fiber_stack().range().unwrap();
-                        debug_assert!(stack_range.contains(&limits.last_wasm_exit_fp));
-                        debug_assert!(stack_range.contains(&limits.last_wasm_entry_fp));
-                        debug_assert!(stack_range.contains(&limits.stack_limit));
-                    },
-                    None => {
-                        // reached stack information for main stack
-                    }
-                }
+            for i in 0..continuations_vec.len() {
+                let (continuation, parent_continuation, parent_limits) = unsafe {
+                    // The continuation whose control context we want to
+                    // access, to get information about how to continue
+                    // execution in its parent.
+                    let continuation = &*continuations_vec[i];
+
+                    // The stack limits describing the parent of `continuation`.
+                    let parent_limits = &*stack_limits_vec[i + 1];
+
+                    // The parent of `continuation`, if the parent is itself a
+                    // continuation. Otherwise, if `continuation` is the last
+                    // continuation (i.e., its parent is the main stack), this is
+                    // None.
+                    let parent_continuation = if i + 1 < continuations_vec.len() {
+                        Some(&*continuations_vec[i + 1])
+                    } else {
+                        None
+                    };
+                    (continuation, parent_continuation, parent_limits)
+                };
+                let fiber_stack = continuation.fiber_stack();
+                let resume_pc = fiber_stack.control_context_instruction_pointer();
+                let resume_fp = fiber_stack.control_context_frame_pointer();
+
+                // If the parent is indeed a continuation, we know the
+                // boundaries of its stack and can perform some extra checks.
+                let parent_stack_range = parent_continuation.and_then(|p| p.fiber_stack().range());
+                parent_stack_range.inspect(|parent_stack_range| {
+                    debug_assert!(parent_stack_range.contains(&resume_fp));
+                    debug_assert!(parent_stack_range.contains(&parent_limits.last_wasm_entry_fp));
+                    debug_assert!(parent_stack_range.contains(&parent_limits.stack_limit));
+                });
+
+                debug_assert_eq!(resume_fp, parent_limits.last_wasm_exit_fp);
 
                 Self::trace_through_wasm(
                     unwind,
-                    limits.last_wasm_exit_pc,
-                    limits.last_wasm_exit_fp,
-                    limits.last_wasm_entry_fp,
+                    resume_pc,
+                    resume_fp,
+                    parent_limits.last_wasm_entry_fp,
                     &mut f,
                 )?
             }


### PR DESCRIPTION
When creating a backtrace while running some continuation `c` with parent `p` (another continuation or the main stack), the following happens at the moment:
After traversing the stack frames of `c`, we need to traverse the stack frames of `p`. To this end, we look at the `StackLimits` object of `p`.
The `last_wasm_exit_{fp, pc}` fields therein tell us the frame pointer and program counter at the point where we stopped execution in `p`. This must have been at a `resume` Wasm instruction that resumed `c`. This FP and PC allows us to travese the stack frames of `p`.
Note that the fields in `StackLimits` are updated by the various stack switching instructions. The `last_wasm_exit_{fp,pc}` fields are only ever used for creating backtraces, they do not influence control flow at all.

Since #223, the `last_wasm_exit_pc` field in `StackLimits` is set on `resume` by using the CLIF instruction `get_instruction_pointer`, which I introduced specifically for that use case. This CLIF instruction will give us a PC value that will be associated with the Wasm `resume` instruction under consideration. This ensures that the backtraces we create mention the right Wasm instructions.

That's good enough for our current use case, where backtraces are used mostly to show where things went wrong on a trap. However, in the future, when we want to support GC, we *also* need to use backtraces to obtain stack maps, do identify live objects on continuation stacks. At that point, the current approach becomes too coarse: Currently, the `last_wasm_exit_pc` value we create is associated with the right *Wasm* instruction (namely, a `resume`), but with the wrong *CLIF* instruction: The PC saved in `last_wasm_exit_pc` will be associated with the `get_instruction_pointer` CLIF instruction that created it. However, logically, it must be associated with the `stack_switch` CLIF instruction where execution actually switched from `p` to `c`, and where it would subsequently continue if we were to switch back to the parent `p`. Only the `stack_switch` instruction will have the most recent/correct stack map describing where live values are located in the stack frame that executed `resume`.

This PR rectifies this situation as follows: Instead of maintaining the fields `last_wasm_exit_{fp, pc}` in `StackLimits`, we now load the required PC and FP values directly from the control context of the corresponding Fiber (i.e., the memory area that saves PC, SP, FP used to actually switch stacks). In other words, to create backtraces, we get the necessary information about where execution continues in the parent stack directly from the source of truth (i.e., the control context), rather than duplicating this information in `StackLimits` just for backtrace creation.

Thus, the fields  `last_wasm_exit_{fp, pc}` are removed from `StackLimits` and no longer need to be updated on `resume`. Further, the `get_instruction_pointer` CLIF instruction, and corresponding `GetRip` x64 `MInst`, which I introduced in #223, are removed.